### PR TITLE
Add --time-colon option

### DIFF
--- a/src/commodity.cc
+++ b/src/commodity.cc
@@ -39,6 +39,7 @@
 namespace ledger {
 
 bool commodity_t::decimal_comma_by_default = false;
+bool commodity_t::time_colon_by_default = false;
 
 void commodity_t::history_t::add_price(commodity_t&      source,
                                        const datetime_t& date,

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -177,6 +177,7 @@ protected:
 #define COMMODITY_SAW_ANNOTATED          0x200
 #define COMMODITY_SAW_ANN_PRICE_FLOAT    0x400
 #define COMMODITY_SAW_ANN_PRICE_FIXATED  0x800
+#define COMMODITY_STYLE_TIME_COLON       0x1000
 
     string                     symbol;
     amount_t::precision_t      precision;
@@ -251,6 +252,7 @@ protected:
 
 public:
   static bool decimal_comma_by_default;
+  static bool time_colon_by_default;
 
   virtual ~commodity_t() {
     TRACE_DTOR(commodity_t);

--- a/src/session.cc
+++ b/src/session.cc
@@ -262,6 +262,9 @@ option_t<session_t> * session_t::lookup_option(const char * p)
   case 's':
     OPT(strict);
     break;
+  case 't':
+    OPT(time_colon);
+    break;
   }
   return NULL;
 }

--- a/src/session.h
+++ b/src/session.h
@@ -89,6 +89,7 @@ public:
     HANDLER(cache_).report(out);
     HANDLER(download).report(out);
     HANDLER(decimal_comma).report(out);
+    HANDLER(time_colon).report(out);
     HANDLER(file_).report(out);
     HANDLER(input_date_format_).report(out);
     HANDLER(master_account_).report(out);
@@ -111,6 +112,10 @@ public:
 
   OPTION_(session_t, decimal_comma, DO() {
       commodity_t::decimal_comma_by_default = true;
+    });
+
+  OPTION_(session_t, time_colon, DO() {
+      commodity_t::time_colon_by_default = true;
     });
 
   OPTION__


### PR DESCRIPTION
The --time-colon option will display the value for a seconds based commodity as real hours and minutes.

For example 8100 seconds by default will be displayed as 2.25 whereas with the --time-colon option they will be displayed as 2:15.

I'm not sure whether the command line option is named in a way that clearly conveys what is does.
