### PR TITLE
Add warning to docs about whitespace in ledger format.

### DIFF
--- a/doc/ledger.texi
+++ b/doc/ledger.texi
@@ -1305,8 +1305,9 @@ The format of each following posting is:
   ACCOUNT  AMOUNT  [; NOTE]
 @end example
 
-The @samp{ACCOUNT} may be surrounded by parentheses if it is a virtual
-postings, or square brackets if it is a virtual postings that
+Note that there must be at least two spaces between @samp{ACCOUNT} and
+@samp{AMOUNT}.  The @samp{ACCOUNT} may be surrounded by parentheses if it
+is a virtual posting or square brackets if it is a virtual posting that
 must balance.  The @samp{AMOUNT} can be followed by a per-unit
 posting cost, by specifying @samp{@@ AMOUNT}, or a complete
 posting cost with @samp{@@@@ AMOUNT}.  Lastly, the @samp{NOTE} may


### PR DESCRIPTION
ledger won't accept a ledger without at least two spaces between the account name and value.  This adds a warning about it in the File format section of the docs.

When you edit or view the docs in your editor the monospace display makes it easy to see the two space requirement.  I was viewing the HTML version of the docs in my browser and missed the subtle distinction.  This gave me quite a bit of pain trying to hunt down the source of the problem.  This patch was entirely motivated by the problems I had trying to get my ledger up and off the ground.
