### PR TITLE
Fix ledger-reconcile-visit.

### DIFF
--- a/lisp/ledger.el
+++ b/lisp/ledger.el
@@ -545,7 +545,7 @@ dropped."
 (defun ledger-reconcile-visit ()
   (interactive)
   (let ((where (get-text-property (point) 'where)))
-    (when (or (equal (car where) "<stdin>") (equal (car where) "/dev/stdin"))
+    (when (markerp (cdr where))
       (switch-to-buffer-other-window ledger-buf)
       (goto-char (cdr where)))))
 


### PR DESCRIPTION
Removes a (apparently) un-necessary check on the car of the 'where'
text property, and instead checks that the cdr is a valid marker
object. May not be the correct fix for this problem, but _does_ work.
