### PR TITLE
Remove keyword OPTIONAL_COMPONENTS, not present in cmake 2.8.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 find_package(Boost 1.47.0
   REQUIRED date_time filesystem system iostreams regex 
            unit_test_framework test_exec_monitor
-  OPTIONAL_COMPONENTS ${BOOST_PYTHON})
+  ${BOOST_PYTHON})
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 


### PR DESCRIPTION
This doesn't seem to effect whether or not the build happens with the components.
