### PR TITLE
Ledger's Python API is known to work best against Python 2.7 &/or 2.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ endif()
 find_package(PythonInterp)      # Used for running tests
 
 if(USE_PYTHON)
+  set(Python_ADDITIONAL_VERSIONS 2.7 2.6)
   find_package(PythonLibs)
   if(PYTHONLIBS_FOUND)
     set(BOOST_PYTHON python)


### PR DESCRIPTION
Indeed, at the moment, Ledger's Python API doesn't work against Python 3.x at all, so
ideally, we'd like to tell CMake that no Python versions except 2.7 and
2.6 are acceptable.  However, at least as of CMake 2.8.8, there appears to
be no way to instruct CMake to never consider other versions of Python.

In other words, Python_ADDITIONAL_VERSIONS is prepended to the list of
possible Python versions considered, rather than replacing it wholly.

Theoretically, we could try to diddle withe the internal CMake variables
_PYTHON_FIND_OTHER_VERSIONS or _Python_VERSIONS somehow, but that seems
kludgey and dangerous.  This patch is probably "enough for now" to at
least make sure that if the user has both Python 2.x and Python 3.x
installed, some version of 2.x that is known to work will be preferred.
