### PR TITLE
Correct cmake variable for install prefix is "CMAKE_INSTALL_PREFIX", not "CMAKE_PREFIX_PATH".

### DIFF
--- a/acprep
+++ b/acprep
@@ -847,7 +847,7 @@ class PrepareBuild(CommandLineApp):
                              self.options.boost_include)
 
         if self.prefix_directory():
-            conf_args.append('-DCMAKE_PREFIX_PATH=%s' % self.prefix_directory())
+            conf_args.append('-DCMAKE_INSTALL_PREFIX=%s' % self.prefix_directory())
 
         return (environ, conf_args + self.configure_args)
 


### PR DESCRIPTION
CMAKE_PREFIX_PATH is for searching for other programs, not for the place
to install this one.  Based on acprep's --help, I think the intention was
to use CMAKE_INSTALL_PREFIX here.

Details from cmake --help-full:

  install
       Specify rules to run at install time.
....
     DESTINATION arguments specify the directory on disk to which a file
       will be installed.  If a full path (with a leading slash or drive
       letter) is given it is used directly.  If a relative path is given it
       is interpreted relative to the value of CMAKE_INSTALL_PREFIX.

meanwhile:

  CMAKE_PREFIX_PATH
       Path used for searching by FIND_XXX(), with appropriate suffixes
       added.

To quote the film, The Princess Bride: "You keep using that word.  I don't think that word means what you think it means." :)
