### PR TITLE
doc/ledger3.info should be ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ doc/.dirstamp
 doc/html/
 doc/latex/
 doc/ledger.info
+doc/ledger3.info
 doc/refman.pdf
 doc/report/
 elisp-comp


### PR DESCRIPTION
doc/ledger3.info was probably missing from the .gitignore because
ledger3.info isn't build automatically yet, but might as well add it to
.gitignore for those who are building it by hand at the moment.
