### PR TITLE
provide immediate feedback in test runner

### DIFF
--- a/test/LedgerHarness.py
+++ b/test/LedgerHarness.py
@@ -116,12 +116,14 @@ class LedgerHarness:
 
     def success(self):
         sys.stdout.write(".")
+        sys.stdout.flush()
         self.succeeded += 1
 
     def failure(self, name=None):
         sys.stdout.write("E")
         if name:
             sys.stdout.write("[%s]" % name)
+        sys.stdout.flush()
         self.failed += 1
 
     def exit(self):


### PR DESCRIPTION
stdout is now flushed after every "." or "E". This may help to endure how long test running takes on slow netbooks.
