### PR TITLE
fix bucket directive (bug 765)

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -148,7 +148,7 @@ namespace {
     void account_value_directive(account_t * account, string expr_str);
     void account_default_directive(account_t * account);
 
-    void default_account_directive(char * line);
+    void default_account_directive(char * args);
     void alias_directive(char * line);
 
     void payee_directive(char * line);
@@ -397,7 +397,7 @@ void instance_t::read_next_directive(bool& error_flag)
 #endif // TIMELOG_SUPPORT
 
       case 'A':                 // a default account for unbalanced posts
-        default_account_directive(line);
+        default_account_directive(line + 1);
         break;
       case 'C':                 // a set of conversions
         price_conversion_directive(line);
@@ -490,9 +490,9 @@ void instance_t::default_commodity_directive(char * line)
   amt.commodity().add_flags(COMMODITY_KNOWN);
 }
 
-void instance_t::default_account_directive(char * line)
+void instance_t::default_account_directive(char * args)
 {
-  context.journal->bucket = top_account()->find_account(skip_ws(line + 1));
+  context.journal->bucket = top_account()->find_account(skip_ws(name));
   context.journal->bucket->add_flags(ACCOUNT_KNOWN);
 }
 

--- a/test/regress/0161EB1E.test
+++ b/test/regress/0161EB1E.test
@@ -1,0 +1,15 @@
+bucket Assets:Checking
+2011/04/25 Tom's Used Cars
+  Auto                    $ 5,500.00
+  ; :nobudget:
+
+A Assets:Checking
+2011/04/27 Book Store
+  Books                       $20.00
+
+test reg
+11-Apr-25 Tom's Used Cars       Auto                     $ 5,500.00   $ 5,500.00
+                                Assets:Checking         $ -5,500.00            0
+11-Apr-27 Book Store            Books                       $ 20.00      $ 20.00
+                                Assets:Checking            $ -20.00            0
+end test


### PR DESCRIPTION
This was caused by both `A` and `bucket` using
`default_account_directive`. This function was still stripping the `A`
directive, so the first character of the account name used with `bucket`
was cut off. Maybe the code for the other directives should be changed
accordingly for consistency (put `line + 1` in call instead of function).
