### PR TITLE
Implemented Bug551  Automatic Transactions are cleared base on parent

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -780,6 +780,14 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context)
         // the automated xact's one.
         post_t * new_post = new post_t(account, amt);
         new_post->copy_details(*post);
+
+	// A Cleared transaction implies all of its automatic posting are cleared
+        // CPR 2012/10/23
+	if(xact.state() == item_t::CLEARED){
+	  DEBUG("xact.extend.cleared", "CLEARED");
+	  new_post->set_state(item_t::CLEARED);
+	}
+
         new_post->add_flags(ITEM_GENERATED);
         new_post->account =
           journal->register_account(account->fullname(), new_post,


### PR DESCRIPTION
Added 6 lines to  auto_xact_t::extend_xact

```
// A Cleared transaction implies all of its automatic posting are cleared
    // CPR 2012/10/23
if(xact.state() == item_t::CLEARED){
  DEBUG("xact.extend.cleared", "CLEARED");
  new_post->set_state(item_t::CLEARED);
}
```
