### PR TITLE
Added "draft" and "lisp" command synonyms

### DIFF
--- a/src/report.cc
+++ b/src/report.cc
@@ -1596,6 +1596,7 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind,
       if (is_eq(p, "draft")) {
         return WRAP_FUNCTOR(xact_command);
       }
+      break;
     case 'e':
       if (is_eq(p, "equity")) {
         HANDLER(generated).on("#equity");


### PR DESCRIPTION
Added "draft" as a synonym for "xact", and "lisp" as a synonym for "emacs"
