### PR TITLE
ledger now runs if default init file is not present

### DIFF
--- a/src/global.cc
+++ b/src/global.cc
@@ -112,6 +112,7 @@ void global_scope_t::read_init()
   if (HANDLED(init_file_)) {
     path init_file(HANDLER(init_file_).str());
     if (exists(init_file)) {
+      
       TRACE_START(init, 1, "Read initialization file");
 
       parse_context_stack_t parsing_context;
@@ -128,7 +129,8 @@ void global_scope_t::read_init()
 
       TRACE_FINISH(init, 1);
     } else {
-      throw_(parse_error, _f("Could not find specified init file %1%") % init_file);
+      if (HANDLER(init_file_).get_source().get().compare("default")!=0)
+      	throw_(parse_error, _f("Could not find specified init file %1%") % init_file);
     }
   }
 }

--- a/src/global.h
+++ b/src/global.h
@@ -155,12 +155,12 @@ See LICENSE file included with the distribution for details and disclaimer.");
    CTOR(global_scope_t, init_file_) {
     if(!_init_file.empty())
       // _init_file is filled during handle_debug_options
-      on(none, _init_file);
+      on("command-line", _init_file);
     else
       if (const char * home_var = std::getenv("HOME"))
-	on(none, (path(home_var) / ".ledgerrc").string());
+	on("default", (path(home_var) / ".ledgerrc").string());
       else
-	on(none, path("./.ledgerrc").string());
+	on("default", path("./.ledgerrc").string());
    });
 
   OPTION(global_scope_t, options);

--- a/src/option.h
+++ b/src/option.h
@@ -120,6 +120,10 @@ public:
     return out.str();
   }
 
+  optional<string> get_source() const {
+    return source;
+  }
+
   operator bool() const {
     return handled;
   }


### PR DESCRIPTION
added public getter for option.source.  This allows read_init to
determine whether the init file was the default ~/.ledgerrc and
keep going if the file doesn't exist, or fail if an init file was
actually specified on the command line and that file doesn't exist.
