### PR TITLE
Add --time-colon option

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -195,7 +195,10 @@ namespace {
 
         for (const char * p = buf; *p; p++) {
           if (*p == '.') {
-            if (commodity_t::decimal_comma_by_default ||
+            if (commodity_t::time_colon_by_default ||
+                (comm && comm->has_flags(COMMODITY_STYLE_TIME_COLON)))
+              out << ':';
+            else if (commodity_t::decimal_comma_by_default ||
                 (comm && comm->has_flags(COMMODITY_STYLE_DECIMAL_COMMA)))
               out << ',';
             else
@@ -209,7 +212,10 @@ namespace {
             out << *p;
 
             if (integer_digits > 3 && --integer_digits % 3 == 0) {
-              if (commodity_t::decimal_comma_by_default ||
+              if (commodity_t::time_colon_by_default ||
+                  (comm && comm->has_flags(COMMODITY_STYLE_TIME_COLON)))
+                out << ':';
+              else if (commodity_t::decimal_comma_by_default ||
                   (comm && comm->has_flags(COMMODITY_STYLE_DECIMAL_COMMA)))
                 out << '.';
               else
@@ -737,6 +743,16 @@ void amount_t::in_place_unreduce()
   }
 
   if (shifted) {
+    if ("h" == comm->symbol() && commodity_t::time_colon_by_default) {
+      amount_t floored = tmp.floored();
+      amount_t precision = tmp - floored;
+      if (precision < 0.0) {
+        precision += 1.0;
+        floored -= 1.0;
+      }
+      tmp = floored + (precision * (comm->smaller()->number() / 100.0));
+    }
+
     *this      = tmp;
     commodity_ = comm;
   }
@@ -1090,6 +1106,9 @@ bool amount_t::parse(std::istream& in, const parse_flags_t& flags)
   bool decimal_comma_style
     = (commodity_t::decimal_comma_by_default ||
        commodity().has_flags(COMMODITY_STYLE_DECIMAL_COMMA));
+  bool time_colon_style
+    = (commodity_t::time_colon_by_default ||
+       commodity().has_flags(COMMODITY_STYLE_TIME_COLON));
 
   new_quantity->prec = 0;
 

--- a/src/commodity.cc
+++ b/src/commodity.cc
@@ -40,6 +40,7 @@
 namespace ledger {
 
 bool commodity_t::decimal_comma_by_default = false;
+bool commodity_t::time_colon_by_default = false;
 
 void commodity_t::add_price(const datetime_t& date, const amount_t& price,
                             const bool reflexive)

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -107,6 +107,7 @@ protected:
 #define COMMODITY_SAW_ANNOTATED          0x200
 #define COMMODITY_SAW_ANN_PRICE_FLOAT    0x400
 #define COMMODITY_SAW_ANN_PRICE_FIXATED  0x800
+#define COMMODITY_STYLE_TIME_COLON       0x1000
 
     string                symbol;
     optional<std::size_t> graph_index;
@@ -176,6 +177,7 @@ protected:
 
 public:
   static bool decimal_comma_by_default;
+  static bool time_colon_by_default;
 
   virtual ~commodity_t() {
     TRACE_DTOR(commodity_t);

--- a/src/session.cc
+++ b/src/session.cc
@@ -348,9 +348,11 @@ option_t<session_t> * session_t::lookup_option(const char * p)
   case 's':
     OPT(strict);
     break;
+  case 't':
+    OPT(time_colon);
+    break;
   case 'v':
     OPT(value_expr_);
-    break;
   }
   return NULL;
 }

--- a/src/session.h
+++ b/src/session.h
@@ -100,6 +100,7 @@ public:
     HANDLER(day_break).report(out);
     HANDLER(download).report(out);
     HANDLER(decimal_comma).report(out);
+    HANDLER(time_colon).report(out);
     HANDLER(file_).report(out);
     HANDLER(input_date_format_).report(out);
     HANDLER(explicit).report(out);
@@ -128,6 +129,10 @@ public:
 
   OPTION_(session_t, decimal_comma, DO() {
       commodity_t::decimal_comma_by_default = true;
+    });
+
+  OPTION_(session_t, time_colon, DO() {
+      commodity_t::time_colon_by_default = true;
     });
 
   OPTION__


### PR DESCRIPTION
The --time-colon option will display the value for a seconds
based commodity as real hours and minutes.

For example 8100 seconds by default will be displayed as 2.25
whereas with the --time-colon option they will be displayed
as 2:15.

I've made much use of the feature, much to my customers' delight,
for 7:45 hours makes much more sense than 7.75 in a billed timesheet.

I'm sure the introduced changes can be improved and I look forward
to your feedback
