### PR TITLE
Fix crash when accessing the transaction code via post.xact.code using python

### DIFF
--- a/src/py_xact.cc
+++ b/src/py_xact.cc
@@ -119,8 +119,8 @@ void export_xact()
     .def("__str__", py_xact_to_string)
 
     .add_property("code",
-                  make_getter(&xact_t::code),
-                  make_setter(&xact_t::code))
+                  make_getter(&xact_t::code, return_value_policy<return_by_value>()),
+                  make_setter(&xact_t::code, return_value_policy<return_by_value>()))
     .add_property("payee",
                   make_getter(&xact_t::payee),
                   make_setter(&xact_t::payee))
@@ -157,6 +157,8 @@ void export_xact()
                   make_getter(&period_xact_t::period_string),
                   make_setter(&period_xact_t::period_string))
     ;
+
+  register_optional_to_python<std::string>();
 }
 
 } // namespace ledger

--- a/test/regress/xact_code.dat
+++ b/test/regress/xact_code.dat
@@ -1,0 +1,3 @@
+2012-11-10 (C0-d3) Payee
+  Assets:Checking                 € -12,45
+  Expenses:Expenditure

--- a/test/regress/xact_code.py
+++ b/test/regress/xact_code.py
@@ -1,0 +1,4 @@
+import ledger
+
+for post in ledger.read_journal('test/regress/xact_code.dat').query('expenses'):
+  print post.xact.code

--- a/test/regress/xact_code_py.test
+++ b/test/regress/xact_code_py.test
@@ -1,0 +1,3 @@
+test python test/regress/xact_code.py
+C0-d3
+end test


### PR DESCRIPTION
This pull request addresses issue #105.

ledger would abort with the following error message:

```
TypeError: No Python class registered for C++ class boost::optional<std::string>
```

The changes pass a CallPolicy to make_getter when adding the transaction
`code` property for python, so that the correct `to_python` conversion is
made. For details see: [boost faq](http://www.boost.org/doc/libs/1_52_0/libs/python/doc/v2/faq.html#topythonconversionfailed)

I've named the regression test for this issue `test/regress/xact_code_py.test`
but would like the stick to the current naming scheme (8 digit hex number).
How are the names for the test files properly generated?
