### PR TITLE
fix bug 788: behaviour of source_context for '-f -'

### DIFF
--- a/src/error.cc
+++ b/src/error.cc
@@ -84,7 +84,7 @@ string source_context(const path&            file,
                       const string&          prefix)
 {
   const std::streamoff len = end_pos - pos;
-  if (! len || file == path("/dev/stdin"))
+  if (! len || file == path("/dev/stdin") || file.empty())
     return _("<no source context>");
 
   assert(len > 0);

--- a/src/session.cc
+++ b/src/session.cc
@@ -159,6 +159,7 @@ std::size_t session_t::read_data(const string& master_account)
 
         shared_ptr<std::istream> stream(new std::istringstream(buffer.str()));
         parsing_context.push(stream);
+        parsing_context.get_current().pathname = "/dev/stdin";
       } else {
         parsing_context.push(pathname);
       }


### PR DESCRIPTION
`session_t::read_data` did not set context.pathname to `/dev/stdin`
for the special case `-f -`. I chose to adjust `source_context` too
as there is no sensible context if no file name is provided.
