### PR TITLE
Fixes regression error introduced by tags command patch

### DIFF
--- a/src/report.cc
+++ b/src/report.cc
@@ -1089,6 +1089,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT(anon);
     else OPT_ALT(color, ansi);
     else OPT(auto_match);
+    else OPT(aux_date);
     else OPT(average);
     else OPT(account_width_);
     else OPT(amount_width_);
@@ -1096,7 +1097,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
   case 'b':
     OPT(balance_format_);
     else OPT(base);
-    else OPT_ALT(basis, cost);
+    else OPT(basis);
     else OPT_(begin_);
     else OPT(bold_if_);
     else OPT(budget);
@@ -1105,6 +1106,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     break;
   case 'c':
     OPT(csv_format_);
+    else OPT_ALT(gain, change);
     else OPT(cleared);
     else OPT(collapse);
     else OPT(collapse_if_zero);
@@ -1122,6 +1124,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT(dc);
     else OPT(depth_);
     else OPT(deviation);
+    else OPT_ALT(rich_data, detail);
     else OPT_(display_);
     else OPT(display_amount_);
     else OPT(display_total_);
@@ -1146,7 +1149,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT_ALT(head_, first_);
     break;
   case 'g':
-    OPT_ALT(gain, change);
+    OPT(gain);
     else OPT(group_by_);
     else OPT(group_title_format_);
     else OPT(generated);
@@ -1173,7 +1176,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT_ALT(tail_, last_);
     break;
   case 'm':
-    OPT_ALT(market, value);
+    OPT(market);
     else OPT(monthly);
     else OPT(meta_);
     else OPT(meta_width_);
@@ -1203,6 +1206,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT(price);
     else OPT(prices_format_);
     else OPT(pricedb_format_);
+    else OPT(primary_date);
     else OPT(payee_width_);
     else OPT(prepend_format_);
     else OPT(prepend_width_);
@@ -1220,7 +1224,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT(revalued);
     else OPT(revalued_only);
     else OPT(revalued_total_);
-    else OPT_ALT(rich_data, detail);
+    else OPT(rich_data);
     break;
   case 's':
     OPT(sort_);
@@ -1248,7 +1252,8 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT(unround);
     break;
   case 'v':
-    OPT(values);
+    OPT_ALT(market, value);
+    else OPT(values);
     break;
   case 'w':
     OPT(weekly);


### PR DESCRIPTION
Not sure how the changes to the options got into the report.cc file, but this takes the changes out. All tests pass (save the two regression that I have no clue how to fix)
