### PR TITLE
Fixed the new ledger mod so that loading leg-new.el is sufficient

### DIFF
--- a/lisp/ldg-new.el
+++ b/lisp/ldg-new.el
@@ -32,12 +32,17 @@
 
 ;;; Commentary:
 
-(require 'ldg-post)
-(require 'ldg-mode)
 (require 'ldg-complete)
-(require 'ldg-state)
+(require 'ldg-exec)
+(require 'ldg-mode)
+(require 'ldg-post)
+(require 'ldg-reconcile)
+(require 'ldg-register)
 (require 'ldg-report)
-
+(require 'ldg-state)
+(require 'ldg-test)
+(require 'ldg-texi)
+(require 'ldg-xact)
 ;(autoload #'ledger-mode "ldg-mode" nil t)
 ;(autoload #'ledger-fully-complete-entry "ldg-complete" nil t)
 ;(autoload #'ledger-toggle-current "ldg-state" nil t)

--- a/lisp/ldg-reconcile.el
+++ b/lisp/ldg-reconcile.el
@@ -203,3 +203,5 @@
     (define-key map [menu-bar ldg-recon-menu sav] '("Save" . ledger-reconcile-save))
 
     (use-local-map map)))
+
+(provide 'ldg-reconcile)

--- a/lisp/ldg-xact.el
+++ b/lisp/ldg-xact.el
@@ -18,3 +18,4 @@
       (lambda ()
         (forward-paragraph))))))
 
+(provide 'ldg-xact)


### PR DESCRIPTION
The reconcile package and the xact package didn't provide themselves, and the leg-new
module didn't load up everything it needed.

Now you only need to (load "ldg-new") to get teh entire package up and running
