### PR TITLE
Removed call to ledger-reports-patch-reports

### DIFF
--- a/lisp/ldg-mode.el
+++ b/lisp/ldg-mode.el
@@ -117,12 +117,7 @@ customizable to ease retro-entry.")
     (define-key map [menu-bar ldg-menu de] '("Delete Entry" . ledger-delete-current-entry))
     (define-key map [menu-bar ldg-menu ae] '("Add Entry" . ledger-add-entry))
     (define-key map [menu-bar ldg-menu s3] '("--"))
-    (define-key map [menu-bar ldg-menu re] '("Reconcile Account" . ledger-reconcile)))
-
-    
-
- 
-  (ledger-report-patch-reports (current-buffer)))
+    (define-key map [menu-bar ldg-menu re] '("Reconcile Account" . ledger-reconcile))))
 
 (defun ledger-time-less-p (t1 t2)
   "Say whether time value T1 is less than time value T2."


### PR DESCRIPTION
This function was never defined and appeared to nothing.  It caused errors
on some systems by not existing.
