### PR TITLE
On move event, save excursion before calling ledger-reconcile-visit

### DIFF
--- a/lisp/ldg-reconcile.el
+++ b/lisp/ldg-reconcile.el
@@ -262,7 +262,8 @@
 				 'previous-line
 				 'mouse-set-point
 				 'ledger-reconcile-toggle))
-      (ledger-reconcile-visit t)))
+      (save-excursion
+        (ledger-reconcile-visit t))))
 
 (defun ledger-reconcile (account)
   (interactive "sAccount to reconcile: ")


### PR DESCRIPTION
Otherwise, ledger-reconcile-visit might undo last move, making "Down" key ineffective.
