### PR TITLE
T/occur bugs

### DIFF
--- a/lisp/ldg-occur.el
+++ b/lisp/ldg-occur.el
@@ -128,31 +128,32 @@ When REGEX is nil, unhide everything, and remove higlight"
     prompt))
 
 (defun ledger-occur-create-folded-overlays(buffer-matches)
-  (let ((overlays 
-	 (let ((prev-end (point-min))
-	       (temp (point-max)))
-	   (mapcar (lambda (match)
-		     (progn
-		       (setq temp prev-end) ;need a swap so that the
+  (if buffer-matches
+      (let ((overlays
+             (let ((prev-end (point-min))
+                   (temp (point-max)))
+               (mapcar (lambda (match)
+                         (progn
+                           (setq temp prev-end) ;need a swap so that the
 					;last form in the lambda
 					;is the (make-overlay)
-		       (setq prev-end (1+ (cadr match))) ;add 1 so
+                           (setq prev-end (1+ (cadr match))) ;add 1 so
 					;that we skip
 					;the empty
 					;line after
 					;the xact
-		       (make-overlay
-			temp
-			(car match)
-			(current-buffer) t nil)))
-		   buffer-matches))))
-    (mapcar (lambda (ovl) 
-              (overlay-put ovl ledger-occur-overlay-property-name t)
-              (overlay-put ovl 'invisible t)
-              (overlay-put ovl 'intangible t))
-            (push  (make-overlay (cadr (car(last buffer-matches))) 
-				 (point-max) 
-				 (current-buffer) t nil) overlays))))
+                           (make-overlay
+                            temp
+                            (car match)
+                            (current-buffer) t nil)))
+                       buffer-matches))))
+        (mapcar (lambda (ovl)
+                  (overlay-put ovl ledger-occur-overlay-property-name t)
+                  (overlay-put ovl 'invisible t)
+                  (overlay-put ovl 'intangible t))
+                (push  (make-overlay (cadr (car(last buffer-matches)))
+                                     (point-max)
+                                     (current-buffer) t nil) overlays)))))
 
 
 (defun ledger-occur-create-xact-overlays (ovl-bounds)


### PR DESCRIPTION
There is two bug in current ledger-occur
- if ledger-reconcile is called when occur is already there, it
  deactivate it instead of just changing the regex
- if there was no match, it fail with an error, and this is a problem
  when ledge-occur-mode is called by ledge-occur-mode
