### PR TITLE
Do not fail in ledger-reconcile-refresh-after-save.

### DIFF
--- a/lisp/ldg-reconcile.el
+++ b/lisp/ldg-reconcile.el
@@ -121,11 +121,13 @@
     (forward-line line)))
 
 (defun ledger-reconcile-refresh-after-save ()
-  (let ((buf (get-buffer ledger-recon-buffer-name)))
-    (if buf
-        (with-current-buffer buf
-          (ledger-reconcile-refresh)
-          (set-buffer-modified-p nil)))))
+  (condition-case er
+      (let ((buf (get-buffer ledger-recon-buffer-name)))
+        (if buf
+            (with-current-buffer buf
+              (ledger-reconcile-refresh)
+              (set-buffer-modified-p nil))))
+    (error nil)))
 
 (defun ledger-reconcile-add ()
   (interactive)


### PR DESCRIPTION
As this function is put into a system hook, it should not fail, ever,
otherwise, things like exiting Emacs could fail, for exemple when some buffer have been killed by the user.
