### PR TITLE
Take care to not delete some random buffer when exiting reconcile

### DIFF
--- a/lisp/ldg-reconcile.el
+++ b/lisp/ldg-reconcile.el
@@ -172,14 +172,15 @@
 
 (defun ledger-reconcile-quit ()
   (interactive)
-  (let ((buf ledger-buf))
+  (let ((buf ledger-buf)
+        (reconcile-buf (current-buffer)))
     (with-current-buffer ledger-buf
       (remove-hook 'after-save-hook 'ledger-reconcile-refresh-after-save t))
 
     ;Make sure you delete the window before you delete the buffer,
     ;otherwise, madness ensues
-    (delete-window (get-buffer-window (current-buffer)))
-    (kill-buffer (current-buffer))
+    (delete-window (get-buffer-window reconcile-buf))
+    (kill-buffer (reconcile-buf))
     (if ledger-fold-on-reconcile
 	(ledger-occur-quit-buffer buf))))
 


### PR DESCRIPTION
It seem that from time to time, when I quit the reconcile mode some random buffer is deleted instead, this take care to delete the buffer where the function has been called.
