### PR TITLE
Accept sum like 1,789.34 € in ledger-split-commodity-string

### DIFF
--- a/lisp/ldg-commodities.el
+++ b/lisp/ldg-commodities.el
@@ -39,7 +39,7 @@
 	(with-temp-buffer
 	  (insert str)
 	  (goto-char (point-min))
-	  (cond ((re-search-forward "-?[1-9][0-9]*[.,][0-9]*" nil t)
+	  (cond ((re-search-forward "-?[1-9][0-9,]*[.,][0-9]*" nil t)
 		 ;; found a decimal number
 		 (setq val 
 		       (string-to-number


### PR DESCRIPTION
With some locale, ledger will produce amount that use `,` to separate thousand and such. Those amount that make the regexp in ledger-split-commodity-string to fail.
