### PR TITLE
Don't fail cleaning after reconcile when some buffer have been killed

### DIFF
--- a/lisp/ldg-reconcile.el
+++ b/lisp/ldg-reconcile.el
@@ -252,7 +252,7 @@ and exit reconcile mode"
   "Cleanup all hooks established by reconcile mode."
   (interactive)
   (let ((buf ledger-buf))
-    (if buf
+    (if (buffer-live-p buf)
 	(with-current-buffer buf
 	  (remove-hook 'after-save-hook 'ledger-reconcile-refresh-after-save t)
 	  (if ledger-fold-on-reconcile


### PR DESCRIPTION
If buffer in leger-buf has been killed, ledger-reconcile-quit-cleanup
will fail with an error. Better to do nothing.
