### PR TITLE
Minor reporting fix to contrib/non-profit-audit-reports

### DIFF
--- a/contrib/non-profit-audit-reports/summary-reports.plx
+++ b/contrib/non-profit-audit-reports/summary-reports.plx
@@ -265,7 +265,7 @@ print INCOME "\"INCOME\",",
 my $overallTotal = $ZERO;
 
 $formatStrTotal = "\"%-90s\",\"\$%14s\"\n";
-foreach my $type ('DONATIONS', 'LICENSE ENFORCEMENT',
+foreach my $type ('DONATIONS', 'LICENSE COMPLIANCE',
                   'CONFERENCES, REGISTRATION', 'CONFERENCES, RELATED BUSINESS INCOME',
                   'BOOK ROYALTIES & AFFILIATE PROGRAMS', 'ADVERSITING',
                   'TRADEMARKS', 'INTEREST INCOME', 'OTHER') {
@@ -357,7 +357,7 @@ my %verifyAllGroups;
 foreach my $key (keys %expenseGroups) {
   $verifyAllGroups{$key} = 1;
 }
-foreach my $type ('PAYROLL', 'SOFTWARE DEVELOPMENT', 'LICENSE ENFORCEMENT', 'CONFERENCES',
+foreach my $type ('PAYROLL', 'SOFTWARE DEVELOPMENT', 'LICENSE COMPLIANCE', 'CONFERENCES',
                   'DEVELOPER MENTORING', 'TRAVEL', 'BANKING FEES', 'ADVOCACY AND PROMOTION',
                   'COMPUTING, HOSTING AND EQUIPMENT', 'ACCOUNTING',
                   'OFFICE', 'RENT', 'ADVERSITING', 'OTHER PROGRAM ACTIVITY', 'OTHER') {


### PR DESCRIPTION
This fix is related to Conservancy's specific chart of accounts.  However, there are a number of things in the contrib/non-profit-audit-reports that are somewhat conservancy-specific already, as at least a few of the scripts (summary-reports.plx in particular) are primarily made to just be examples.

Therefore, I'd appreciate if you could merge this in.  Long term, if these scripts were used by others, it would make sense to abstract out the list of regular expressions found in summary-reports.plx into some config file, but since they were already accepted upstream as a hard-coded list, I suggest that we keep the upstream contrib directory matching with what Conservancy is doing -- if for no other reason that I can use this as examples to help answer  ledger questions on IRC, which I do from time to time.
