### PR TITLE
Improve documentation about differences between ledger 2.6 and ledger 3.0

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -9086,14 +9086,39 @@ for example, issue @samp{ctest -V -R "5FB"}.
 @node Major Changes from version 2.6, Example Journal File, Ledger for Developers, Top
 @chapter Major Changes from version 2.6
 
+The following have been removed from Ledger 3.0:
+
 @itemize
 
 @item
-OFX support has been removed from Ledger 3.0
+OFX support
 
 @item
+GnuCash file import
+
+@end itemize
+
+@noindent
+The following are deprecated in Ledger 3.0:
+
+@itemize
+
+@item 
 Single character value expressions are deprecated and should be changed
 to the new value expressions available in 3.0
+
+@item
+The following environment variables have been renamed in Ledger 3.0:
+@table @env
+@item LEDGER
+is now @env{LEDGER_FILE},
+@item LEDGER_INIT
+is now @env{LEDGER_INIT_FILE},
+@item PRICE_HIST
+is now @env{LEDGER_PRICE_DB},
+@item PRICE_EXP
+is now @env{LEDGER_PRICE_EXP}.
+@end table
 
 @end itemize
 

--- a/src/global.cc
+++ b/src/global.cc
@@ -399,11 +399,13 @@ void global_scope_t::read_environment_settings(char * envp[])
       process_option("environ", "init-file", report(), p, "LEDGER_INIT");
   }
   if (const char * p = std::getenv("PRICE_HIST")) {
-    if (! std::getenv("LEDGER_PRICEDB"))
+    if (! std::getenv("LEDGER_PRICE_DB"))
       process_option("environ", "price-db", report(), p, "PRICE_HIST");
   }
-  if (const char * p = std::getenv("PRICE_EXP"))
-    process_option("environ", "price-exp", report(), p, "PRICE_EXP");
+  if (const char * p = std::getenv("PRICE_EXP")) {
+    if (! std::getenv("LEDGER_PRICE_EXP"))
+			process_option("environ", "price-exp", report(), p, "PRICE_EXP");
+	}
 #endif
 
   TRACE_FINISH(environment, 1);


### PR DESCRIPTION
GnuCash support removed, environment variables deprecated.

For the modification in global.cc, I have checked in 2.6 documentation and 2.6 code to make it consistent (particularly the underscore '_' between PRICE and DB, and the PRICE_EXP.
