### PR TITLE
@itemx shoud be after an @item

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -6305,7 +6305,7 @@ Allow the user to specify what account name should be used for
 unrealized gains. Defaults to @samp{"Equity:Unrealized Gains"}.
 Often set in one's @file{~/.ledgerrc} file to change default.
 
-@itemx --unrealized-losses @var{STR}
+@item --unrealized-losses @var{STR}
 Allow the user to specify what account name should be used for
 unrealized gains. Defaults to @samp{"Equity:Unrealized Losses"}.
 Often set in one's @file{~/.ledgerrc} file to change default.


### PR DESCRIPTION
When trying to make an info file from leder3.texi using makeinfo it fail because there was an @itemx where there should be an @item.
