### PR TITLE
 	Change ledger-next-amount to be case-sensitive

### DIFF
--- a/lisp/ledger-post.el
+++ b/lisp/ledger-post.el
@@ -117,11 +117,12 @@ to choose from."
 Return the width of the amount field as an integer and leave
 point at beginning of the commodity."
   ;;(beginning-of-line)
-  (when (re-search-forward ledger-amount-regex end t)
-    (goto-char (match-beginning 0))
-    (skip-syntax-forward " ")
-    (- (or (match-end 4)
-           (match-end 3)) (point))))
+  (let ((case-fold-search nil))
+    (when (re-search-forward ledger-amount-regex end t)
+      (goto-char (match-beginning 0))
+      (skip-syntax-forward " ")
+      (- (or (match-end 4)
+             (match-end 3)) (point)))))
 
 
 (defun ledger-next-account (&optional end)


### PR DESCRIPTION
Otherwise if there is an account that's name only has one part, the
regex can match it as a currency and as the beginning of an amount.
E.g. if we have the line "Expenses 45 USD", then the old
ledger-next-amount will jump to Expenses instead of to 45.
