### PR TITLE
Use "ledger accounts" command rather than the '-F "%150A\n" reg' report solution

### DIFF
--- a/contrib/non-profit-audit-reports/cash-receipts-and-disbursments-journals.plx
+++ b/contrib/non-profit-audit-reports/cash-receipts-and-disbursments-journals.plx
@@ -67,8 +67,7 @@ if (@ARGV < 2) {
 
 my($beginDate, $endDate, @otherLedgerOpts) = @ARGV;
 
-my(@chartOfAccountsOpts) = ('-V', '-F', "%150A\n",  '-w', '-s',
-                            '-b', $beginDate, '-e', $endDate, @otherLedgerOpts, 'reg');
+my(@chartOfAccountsOpts) = ('-b', $beginDate, '-e', $endDate, @otherLedgerOpts, 'accounts');
 
 open(CHART_DATA, "-|", $LEDGER_CMD, @chartOfAccountsOpts)
   or die "Unable to run $LEDGER_CMD @chartOfAccountsOpts: $!";

--- a/contrib/non-profit-audit-reports/general-ledger-report.plx
+++ b/contrib/non-profit-audit-reports/general-ledger-report.plx
@@ -62,8 +62,7 @@ die "badly formatted end date, $beginDate" if $formattedBeginDate->parse($beginD
 $formattedBeginDate = $formattedBeginDate->printf("%Y/%m/%d");
 
 
-my(@chartOfAccountsOpts) = ('-V', '-F', "%150A\n",  '-w', '-s',
-                            '-b', $beginDate, '-e', $endDate, @otherLedgerOpts, 'reg');
+my(@chartOfAccountsOpts) = ('-b', $beginDate, '-e', $endDate, @otherLedgerOpts, 'accounts');
 
 open(CHART_DATA, "-|", $LEDGER_CMD, @chartOfAccountsOpts)
   or die "Unable to run $LEDGER_CMD @chartOfAccountsOpts: $!";


### PR DESCRIPTION
This is a small bugfix to the non-profit-audit-reports contrib area.

Ledger has had (probably for some time) an "accounts" command that will list
all the accounts from all transactions meeting the other criteria set on the
command line.  That's really what we're looking for here when we build this
chart of accounts, and thus that should be used.

Note that this corrects a subtle bug that wasn't apparent with the old
solution.  With the '-F "%150A\n" reg' solution, accounts that balanced out
to zero for period (e.g., accrual accounts that were emptied during in the
month) did not show up on the reports.  This bug that I didn't know I had
here is thus now fixed by switching to the "accounts" report.
