### PR TITLE
ledger-copy-transaction-at-point: leave point in better place for editing

### DIFF
--- a/lisp/ledger-xact.el
+++ b/lisp/ledger-xact.el
@@ -151,7 +151,8 @@ MOMENT is an encoded date"
     (re-search-forward ledger-iso-date-regexp)
     (replace-match date)
     (ledger-next-amount)
-    (forward-char 2)))
+    (if (re-search-forward "[-0-9]")
+        (goto-char (match-beginning 0)))))
 
 (defun ledger-delete-current-transaction (pos)
   "Delete the transaction surrounging point."


### PR DESCRIPTION
I love `ledger-copy-transaction-at-point`, but at the end of the function, it leaves the point right on top of the dollar-sign ($), so I always have to move forward 2 characters to edit the actual amount. This change saves me two keystrokes :-) But, I completely understand if you'd prefer to keep the original behavior... just wanted to share. Thanks!
