### PR TITLE
Remove some obsolete material from the build instructions.

### DIFF
--- a/README-1ST
+++ b/README-1ST
@@ -11,21 +11,9 @@ almost certainly going to run into problems.  In future, you can run
 'acprep update' again and again, and it will keep you updated to the
 very latest version.
 
-I further recommend building both debug and optimized versions of Ledger, in a
-subdirectory of your source tree named 'build' (which acprep will manage for
-you, you simply need to create it):
+Now install it:
 
-    $ mkdir build
-    $ ./acprep opt make
-    $ ./acprep debug make
-
-Now install the optimized version:
-
-    $ cd build/ledger/opt
     $ sudo make install
-
-but know that you have 'build/ledger/debug' available for testing and
-for more useful bug reports.
 
 ===============================================================================
                        COMMON CONFIGURE/BUILD PROBLEMS


### PR DESCRIPTION
It no longer works to create the "build" directory and then build
separate optimized and debug versions.  As confirmed in IRC with sm
and egh, the former instructions resulted in an error:

  $ mkdir build
  $ ./acprep opt make
  make: **\* No targets specified and no makefile found.  Stop.
  acprep: ERROR: Execution failed: make
  $ ./acprep debug make
  make: **\* No targets specified and no makefile found.  Stop.
  acprep: ERROR: Execution failed: make

Maybe there's a fix for this, but I don't know what it is, so this
commit just makes the build instructions work for the common case.
