### PR TITLE
ledger-mode: Fix provided feature to match file/package name

### DIFF
--- a/lisp/ledger-mode.el
+++ b/lisp/ledger-mode.el
@@ -293,6 +293,6 @@ Can indent, complete or align depending on context."
 
 
 
-(provide 'ledger)
+(provide 'ledger-mode)
 
 ;;; ledger-mode.el ends here


### PR DESCRIPTION
For `require` to work correctly, the provided feature name must match the name of the file.
