### PR TITLE
Reload init when calling ledger-init-load-init-file again.

### DIFF
--- a/lisp/ledger-init.el
+++ b/lisp/ledger-init.el
@@ -54,7 +54,8 @@
   (interactive)
   (let ((init-base-name (file-name-nondirectory ledger-init-file-name)))
     (if (get-buffer init-base-name) ;; init file already loaded, parse it and leave it
-				(ledger-init-parse-initialization init-base-name)
+				(setq ledger-environment-alist
+              (ledger-init-parse-initialization init-base-name))
 			(when (and ledger-init-file-name
 								 (file-exists-p ledger-init-file-name)
 								 (file-readable-p ledger-init-file-name))


### PR DESCRIPTION
When the ledger-init-load-init-file was called again, it used to parse ledger
init file, and to throw away the result. No you can use it to load this file
again when you have change something in it.

I'm not completely convinced this is what should happen, but I need it
once, and so wrote the code, and push it here to let you decide of it
usefulness.
