### PR TITLE
T/schedule with args

### DIFF
--- a/lisp/ledger-schedule.el
+++ b/lisp/ledger-schedule.el
@@ -297,12 +297,26 @@ returns true if the date meets the requirements"
      (ledger-mode))
     (length candidates)))
 
-(defun ledger-schedule-upcoming ()
-  (interactive)
+(defun ledger-schedule-upcoming (file look-backward look-forward)
+  "Generate upcoming transaction
+
+FILE is the file containing the scheduled transaction,
+default to `ledger-schedule-file'.
+LOOK-BACKWARD is the number of day in the past to look at
+default to `ledger-schedule-look-backward'
+LOOK-FORWARD is the number of day in the futur to look at
+default to `ledger-schedule-look-forward'
+
+Use a prefix arg to change the default value"
+  (interactive (if current-prefix-arg
+                   (list (read-file-name "Schedule File: " () ledger-schedule-file t)
+                         (read-number "Look backward: " ledger-schedule-look-backward)
+                         (read-number "Look forward: " ledger-schedule-look-forward))
+                   (list ledger-schedule-file ledger-schedule-look-backward ledger-schedule-look-forward)))
   (ledger-schedule-create-auto-buffer
-   (ledger-schedule-scan-transactions ledger-schedule-file)
-   ledger-schedule-look-backward
-   ledger-schedule-look-forward
+   (ledger-schedule-scan-transactions file)
+   look-backward
+   look-forward
    (current-buffer))
   (pop-to-buffer ledger-schedule-buffer-name))
 


### PR DESCRIPTION
This let ledger-schedule-upcoming
- pop the "_Ledger Schedule_" buffer, otherwise it look like the function has silently failed
- let ledger-schedule-upcoming take argument, for running it with non default value for file-name, look-backward and look-forward.
