### PR TITLE
highlight comments as comments in vim

### DIFF
--- a/contrib/vim/syntax/ledger.vim
+++ b/contrib/vim/syntax/ledger.vim
@@ -49,6 +49,7 @@ syn region ledgerApply
     \ contains=ledgerApplyHead,ledgerApply,ledgerTransaction,ledgerComment
 syn match ledgerApplyHead /\%(^apply\s\+\)\@<=\S.*$/ contained
 
+highlight default link ledgerComment Comment
 highlight default link ledgerTransactionDate Constant
 highlight default link ledgerTransactionExpression Statement
 highlight default link ledgerMetadata Tag


### PR DESCRIPTION
there is a matching rule for comments in the vim plugin, let's use it
