### PR TITLE
Fixed emacs lisp compilation

### DIFF
--- a/lisp/CMakeLists.txt
+++ b/lisp/CMakeLists.txt
@@ -56,7 +56,7 @@ if(EMACS_EXECUTABLE)
 
   # install the byte-compiled emacs-lisp sources
   install(FILES ${EMACS_LISP_SOURCES} ${EMACS_LISP_BINARIES} ${EMACS_LISP_UNCOMPILABLE}
-    DESTINATION share/emacs/site-lisp)
+    DESTINATION share/emacs/site-lisp/ledger-mode)
 endif()
 
 ### CMakeLists.txt ends here


### PR DESCRIPTION
Fixed a compile error, caused by `lisp/ledger-context.el` not being present in the `CMAKE_CURRENT_BINARY_DIR` during compile time. Bug presumably introduced with 3105f13a7be56ea7b6e210b98742b4e1f9694e3f
Additionally, moved installation destination of emacs lisp files into subdirectory of site-lisp.
