### PR TITLE
Commodity column in default CSV format should match the displayed amount

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -5833,7 +5833,7 @@ Strings}).  The default is:
 "%(quoted(code)),"
 "%(quoted(payee)),"
 "%(quoted(display_account)),"
-"%(quoted(commodity)),"
+"%(quoted(commodity(scrub(display_amount)))),"
 "%(quoted(quantity(scrub(display_amount)))),"
 "%(quoted(cleared ? \"*\" : (pending ? \"!\" : \"\"))),"
 "%(quoted(join(note | xact.note)))\n"
@@ -6780,7 +6780,7 @@ Set the format for @command{csv} reports.  The default is:
  %(quoted(code)),
  %(quoted(payee)),
  %(quoted(display_account)),
- %(quoted(commodity)),
+ %(quoted(commodity(scrub(display_amount)))),
  %(quoted(quantity(scrub(display_amount)))),
  %(quoted(cleared ? \"*\" : (pending ? \"!\" : \"\"))),
  %(quoted(join(note | xact.note)))\n"

--- a/src/report.h
+++ b/src/report.h
@@ -521,7 +521,7 @@ public:
        "%(quoted(code)),"
        "%(quoted(payee)),"
        "%(quoted(display_account)),"
-       "%(quoted(commodity)),"
+       "%(quoted(commodity(scrub(display_amount)))),"
        "%(quoted(quantity(scrub(display_amount)))),"
        "%(quoted(cleared ? \"*\" : (pending ? \"!\" : \"\"))),"
        "%(quoted(join(note | xact.note)))\n");


### PR DESCRIPTION
If one uses --exchange to force CSV display amounts into a particular currency, then the commodity output column should match that currency.

Without this patch, the commodity column contains the original commodity, not the commodity for the exported amount.

I'll refrain from committing this directly, in case this isn't obviously a good idea. :-)
