### PR TITLE
Create default scope from python session only if needed

### DIFF
--- a/src/pyinterp.cc
+++ b/src/pyinterp.cc
@@ -78,9 +78,11 @@ void initialize_for_python()
   export_session();
   export_journal();
 
-  python_session.reset(new ledger::python_interpreter_t);
-  shared_ptr<session_t> session_ptr = python_session;
-  scope_t::default_scope = new report_t(*session_ptr);
+  if (! scope_t::default_scope) {
+    python_session.reset(new ledger::python_interpreter_t);
+    shared_ptr<session_t> session_ptr = python_session;
+    scope_t::default_scope = new report_t(*session_ptr);
+  }
 }
 
 struct python_run


### PR DESCRIPTION
Fixes test failures introduced with the commit
"Create default scope to read journal"
a9078767b8224a223f8942a1cb80d4544024387b
