### PR TITLE
Fix apply_year_directive

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -416,7 +416,7 @@ void instance_t::read_next_directive(bool& error_flag)
         price_xact_directive(line);
         break;
       case 'Y':                 // set the current year
-        apply_year_directive(line);
+        apply_year_directive(line + 1);
         break;
       }
     }
@@ -865,7 +865,7 @@ void instance_t::apply_year_directive(char * line)
   // This must be set to the last day of the year, otherwise partial
   // dates like "11/01" will refer to last year's november, not the
   // current year.
-  unsigned short year(lexical_cast<unsigned short>(skip_ws(line + 1)));
+  unsigned short year(lexical_cast<unsigned short>(skip_ws(line)));
   DEBUG("times.epoch", "Setting current year to " << year);
   epoch = datetime_t(date_t(year, 12, 31));
 }

--- a/test/regress/6E7C2DF9.test
+++ b/test/regress/6E7C2DF9.test
@@ -1,0 +1,24 @@
+Y 2010 
+10/10 * TwentyTen
+    Account:Ten                         $ 10.10
+    Assets:Cash
+
+apply year 2011
+11/11 * TwentyEleven
+    Account:Eleven                      $ 11.11
+    Assets:Cash
+
+2012/12/12 * TwentyTwelve
+    Account:Twelve                      $ 12.12
+    Assets:Cash
+
+11/11 * TwentyEleven Again
+    Account:Eleven                      $ 11.11
+    Assets:Cash
+
+test reg --sort date account
+10-Oct-10 TwentyTen             Account:Ten                 $ 10.10      $ 10.10
+11-Nov-11 TwentyEleven          Account:Eleven              $ 11.11      $ 21.21
+11-Nov-11 TwentyEleven Again    Account:Eleven              $ 11.11      $ 32.32
+12-Dec-12 TwentyTwelve          Account:Twelve              $ 12.12      $ 44.44
+end test


### PR DESCRIPTION
Using the `Y 2014` syntax worked fine, but using
`apply year 2014` resulted in the following error:
`Error: Year is out of valid range: 1400..10000`
since part of the given year string was chopped off.
