### PR TITLE
Fixing two GCC warnings

### DIFF
--- a/src/pstream.h
+++ b/src/pstream.h
@@ -83,7 +83,10 @@ class ptristream : public std::istream
     virtual pos_type seekoff(off_type off, ios_base::seekdir way,
                              ios_base::openmode)
     {
-      switch (way) {
+      // cast to avoid gcc '-Wswitch' warning
+      // as ios_base::beg/cur/end are not necesssarily values of 'way' enum type ios_base::seekdir
+      // based on https://svn.boost.org/trac/boost/ticket/7644
+      switch (static_cast<int>(way)) {
       case std::ios::cur:
         setg(ptr, gptr()+off, ptr+len);
         break;

--- a/src/wcwidth.cc
+++ b/src/wcwidth.cc
@@ -69,8 +69,8 @@ namespace ledger {
 
 namespace {
   struct interval {
-    int first;
-    int last;
+    boost::uint32_t first;
+    boost::uint32_t last;
   };
 }
 


### PR DESCRIPTION
This commit fixes two warnings. I'm not exactly sure about the first "solution", but boost also uses it, so it might be ok.
