### PR TITLE
Adding option --no-aliases to completely disable alias expansion

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -381,6 +381,8 @@ See
 .It Fl \-meta Ar EXPR
 .It Fl \-meta-width Ar INT
 .It Fl \-monthly Pq Fl M
+.It Fl \-no-aliases
+Aliases are completely ignored.
 .It Fl \-no-color
 .It Fl \-no-pager
 .It Fl \-no-rounding

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -2175,6 +2175,8 @@ alias Checking=Assets:Credit Union:Joint Checking Account
   Checking
 @end smallexample
 
+The option @option{--no-aliases} completely disables alias expansion.
+
 @item assert
 @c instance_t::assert_directive
 An assertion can throw an error if a condition is not met during
@@ -5787,6 +5789,9 @@ $ ledger -f drewr3.dat bal --no-total --master-account HUMBUG
             $ -20.00      MasterCard
             $ 200.00      Mortgage:Principal
 @end smallexample
+
+@item --no-aliases
+Ledger does not expand any aliases if this option is specified.
 
 @item --pedantic
 FIX THIS ENTRY @c FIXME thdox

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -173,6 +173,9 @@ account_t * journal_t::expand_aliases(string name) {
   // prevent infinite excursion. Each alias may only be expanded at most once.
   account_t * result = NULL;
 
+  if(no_aliases)
+    return result;
+
   bool keep_expanding = true;
   std::list<string> already_seen;
   // loop until no expansion can be found

--- a/src/journal.h
+++ b/src/journal.h
@@ -132,6 +132,7 @@ public:
   bool                  check_payees;
   bool                  day_break;
   bool                  recursive_aliases;
+  bool                  no_aliases;
   payee_mappings_t      payee_mappings;
   account_mappings_t    account_mappings;
   accounts_map          account_aliases;

--- a/src/session.cc
+++ b/src/session.cc
@@ -115,6 +115,8 @@ std::size_t session_t::read_data(const string& master_account)
 
   if (HANDLED(recursive_aliases))
     journal->recursive_aliases = true;
+  if (HANDLED(no_aliases))
+    journal->no_aliases = true;
   
   if (HANDLED(permissive))
     journal->checking_style = journal_t::CHECK_PERMISSIVE;
@@ -346,6 +348,9 @@ option_t<session_t> * session_t::lookup_option(const char * p)
     break;
   case 'm':
     OPT(master_account_);
+    break;
+  case 'n':
+    OPT(no_aliases);
     break;
   case 'p':
     OPT(price_db_);

--- a/src/session.h
+++ b/src/session.h
@@ -110,6 +110,7 @@ public:
     HANDLER(price_db_).report(out);
     HANDLER(price_exp_).report(out);
     HANDLER(recursive_aliases).report(out);
+    HANDLER(no_aliases).report(out);
     HANDLER(strict).report(out);
     HANDLER(value_expr_).report(out);
   }
@@ -166,6 +167,7 @@ public:
   OPTION(session_t, strict);
   OPTION(session_t, value_expr_);
   OPTION(session_t, recursive_aliases);
+  OPTION(session_t, no_aliases);
 };
 
 /**


### PR DESCRIPTION
This is useful for obtaining a list of accounts as used verbatim in the ledger file (for example for auto-completion inside an IDE). ledger parses the file much faster than most other programs/languages.
