### PR TITLE
remove version name for boost in aptitude command

### DIFF
--- a/README-1ST
+++ b/README-1ST
@@ -54,19 +54,12 @@ it's usually fairly obvious where things have gone astray.
       GNU/Linux system (or Debian-based system such as Ubuntu), something
       like this should work (as root):
 
-      # aptitude update
-      # for name in                                                   \
-            cmake libboost-dev libboost-date-time-dev libboost-doc    \
-            libboost-dbg libboost-filesystem-dev libboost-graph-dev   \
-            libboost-iostreams-dev libboost-program-options-dev       \
-            libboost-python-dev libboost-regex-dev                    \
-            libboost-serialization-dev libboost-signals-dev           \
-            libboost-test-dev libboost-thread-dev libboost-wave-dev   \
-            libmpfr-dev libmpfr-dbg libmpfr-doc;                      \
-        do                                                            \
-            aptitude install ${name};                                 \
-        done
-    
+        sudo apt-get install build-essential cmake autopoint texinfo python-dev \
+            zlib1g-dev libbz2-dev libgmp3-dev gettext libmpfr-dev \
+            libboost-date-time-dev libboost-filesystem-dev \
+            libboost-graph-dev libboost-iostreams-dev \
+            libboost-python-dev libboost-regex-dev libboost-test-dev
+
    ----------------------------------------------------------------------
 
  - Q: Configure fails saying it can't find boost_regex

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ following packages (current as of Ubuntu 12.04):
 Or, for Ubuntu Karmic:
 
     sudo apt-get install build-essential cmake texinfo python-dev zlib1g-dev
-         libbz2-dev libgmp3-dev bjam gettext cvs libboost1.40-dev
-         libboost-regex1.40-dev libboost-date-time1.40-dev
-         libboost-filesystem1.40-dev libmpfr-dev
+         libbz2-dev libgmp3-dev bjam gettext cvs libboost-dev
+         libboost-regex-dev libboost-date-time-dev
+         libboost-filesystem-dev libmpfr-dev
 
 ### Debian
 
@@ -125,11 +125,11 @@ Debian wheezy (7.0) contains all components needed to build ledger.
 You can install all required build dependencies using the following
 command:
 
-    sudo apt-get install build-essential cmake autopoint texinfo python-dev
-         zlib1g-dev libbz2-dev libgmp3-dev gettext libmpfr-dev
-         libboost-date-time1.49-dev libboost-filesystem1.49-dev
-         libboost-graph1.49-dev libboost-iostreams1.49-dev
-         libboost-python1.49-dev libboost-regex1.49-dev libboost-test1.49-dev
+    sudo apt-get install build-essential cmake autopoint texinfo python-dev \
+         zlib1g-dev libbz2-dev libgmp3-dev gettext libmpfr-dev \
+         libboost-date-time-dev libboost-filesystem-dev \
+         libboost-graph-dev libboost-iostreams-dev \
+         libboost-python-dev libboost-regex-dev libboost-test-dev
 
 ## Building
 


### PR DESCRIPTION
Always point to the most current boost libraries available for debian
and it's derivatives

I don't have a ubuntu to check the dependencies but they should be the same for debian. If you don't have any special reasons to keep the ubuntu paragraphs I will make a more generic 'ubuntu/debian' one.
