### PR TITLE
lisp: use more legible colors on dark backgrounds

### DIFF
--- a/lisp/ledger-fonts.el
+++ b/lisp/ledger-fonts.el
@@ -40,7 +40,8 @@
   :group 'ledger-faces)
 
 (defface ledger-font-xact-highlight-face
-    `((t :background "#eee8d5"))
+    `((((background dark)) :background "#1a1a1a" )
+      (t :background "#eee8d5"))
   "Default face for transaction under point"
   :group 'ledger-faces)
 
@@ -80,7 +81,8 @@
   :group 'ledger-faces)
 
 (defface ledger-occur-xact-face
-    `((t :background "#eee8d5" ))
+    `((((background dark)) :background "#1a1a1a" )
+      (t :background "#eee8d5" ))
   "Default face for Ledger occur mode shown transactions"
   :group 'ledger-faces)
 


### PR DESCRIPTION
On dark backgrounds, the color for the current transaction makes the
text quite unreadable. Let's use a darker color in this case. Maybe some
other colors could be adjusted.
