### PR TITLE
Fix man page typo

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -469,7 +469,7 @@ a
 script, implemented in Perl, is provided in the
 distribution.  Downloaded quote price are then appended to the price
 database, usually specified using the environment variable
-.NmLEDGER_PRICE_DB .
+.Nm LEDGER_PRICE_DB .
 .It Fl \-empty Pq Fl E
 Include empty accounts in report.
 .It Fl \-end Ar DATE Pq Fl e


### PR DESCRIPTION
There is a missing space, which means the variable doesn't get displayed.
