### PR TITLE
improve C-c C-a (ledger-xact-insert-transaction) behaviour

### DIFF
--- a/lisp/ledger-xact.el
+++ b/lisp/ledger-xact.el
@@ -89,12 +89,20 @@ within the transaction."
 (defun ledger-xact-find-slot (moment)
   "Find the right place in the buffer for a transaction at MOMENT.
 MOMENT is an encoded date"
-  (catch 'found
-    (ledger-xact-iterate-transactions
-     (function
-      (lambda (start date mark desc)
-       (if (ledger-time-less-p moment date)
-	   (throw 'found t)))))))
+  (let (last-xact-start)
+    (catch 'found
+      (ledger-xact-iterate-transactions
+       (function
+        (lambda (start date mark desc)
+          (setq last-xact-start start)
+          (if (ledger-time-less-p moment date)
+              (throw 'found t))))))
+    (when (and (eobp) last-xact-start)
+      (let ((end (cadr (ledger-find-xact-extents last-xact-start))))
+        (goto-char end)
+        (if (eobp)
+            (insert "\n")
+          (forward-line))))))
 
 (defun ledger-xact-iterate-transactions (callback)
   "Iterate through each transaction call CALLBACK for each."


### PR DESCRIPTION
When the right place to add a transaction is after all existing
transactions, add it just after the last transaction rather than at the
end of the buffer.  (Otherwise the transactions get added after Local
Variables blocks and any other endmatter.)
