### PR TITLE
Fix ledger iterate regex

### DIFF
--- a/lisp/ledger-regex.el
+++ b/lisp/ledger-regex.el
@@ -178,8 +178,8 @@
 (ledger-define-regexp iso-date
   ( let ((sep '(or ?-  ?/)))
     (rx (group
-         (and (group (? (= 4 num)))
-	      (eval sep)
+         (and (? (and (group (= 4 num)))
+                 (eval sep))
               (group (and num (? num)))
               (eval sep)
               (group (and num (? num)))))))


### PR DESCRIPTION
the iterate regex insisted on having a year in the date (through ledger-iso-date-regex), despite attempting to handle "Y" directives.
