### PR TITLE
Fix compiling with GCC 4.9

### DIFF
--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -156,6 +156,7 @@ typedef std::ostream::pos_type ostream_pos_type;
 #include <sys/wait.h>
 #endif
 
+#include <cstddef> /* needed for gcc 4.9 */
 #include <gmp.h>
 #include <mpfr.h>
 #include "utf8.h"


### PR DESCRIPTION
Library GMP is not yet ready for GCC 4.9, as described at bottom of page
http://gcc.gnu.org/gcc-4.9/porting_to.html

See extract below:

The <cstddef> header was updated for C++11 support and this breaks some
libraries which misuse macros meant for internal use by GCC only. For
instance with GMP versions up to 5.1.3, you may see:

/usr/include/c++/4.9.0/cstddef:51:11: error: ‘::max_align_t’ has not been declared
   using ::max_align_t;
           ^

Another possible error is:

someheader.h:99:13: error: ‘ptrdiff_t’ does not name a type

A workaround until libraries get updated is to include <cstddef> or
<stddef.h> before any headers from that library.
