### PR TITLE
Fix spell check language.

### DIFF
--- a/tools/spellcheck.sh
+++ b/tools/spellcheck.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-aspell check --mode=texinfo $(dirname $0)/../doc/ledger3.texi
+aspell --lang=en_US.UTF-8 check --mode=texinfo $(dirname $0)/../doc/ledger3.texi


### PR DESCRIPTION
I am on a non English based system, and when spell check starts it uses
by default my language that is not English.
This fix should work on Linux and Mac OS. I doubt it will work on
Windows, but anyway spellcheck.sh is a development tool and the base of
our developers are on Unix based systems.
