### PR TITLE
acprep: remove dead code

### DIFF
--- a/acprep
+++ b/acprep
@@ -36,8 +36,6 @@ LEVELS = {'DEBUG':    logging.DEBUG,
           'ERROR':    logging.ERROR,
           'CRITICAL': logging.CRITICAL}
 
-search_prefixes = [ '/usr/local', '/opt/local', '/sw', '/usr' ]
-
 def which(program):
     def is_exe(fpath):
         return os.path.exists(fpath) and os.access(fpath, os.X_OK)


### PR DESCRIPTION
This isn't used anywhere since 4681e58d7f3cda2a2ac6d05b6ec1a106f568e029.
