### PR TITLE
don't add a space when completing

### DIFF
--- a/lisp/ledger-complete.el
+++ b/lisp/ledger-complete.el
@@ -254,7 +254,8 @@ ledger-magic-tab would cycle properly"
                (pcomplete-autolist pcomplete-autolist)
                (pcomplete-suffix-list pcomplete-suffix-list)
                (completions (pcomplete-completions))
-               (result (pcomplete-do-complete pcomplete-stub completions)))
+               (result (pcomplete-do-complete pcomplete-stub completions))
+               (pcomplete-termination-string ""))
           (and result
                (not (eq (car result) 'listed))
                (cdr result)


### PR DESCRIPTION
completing payees with ledger-magic-tab would add a space when
there was only one possible completion.  That space, in ledger's
file format, would always need to be deleted again

it might be helpful when completing accounts to add two spaces, but
the current completion code organization can't (easily) distinguish
between payee and account completion.  Adding one space is harmful
to account completion too, in that `ledger-account.*regex' parse
accounts by looking for two spaces, and treat an account name ending
with a single space before the newline as having the space as part
of the account name.
