### PR TITLE
Restore C-x C-s keyboard shortcut in reconcile buffer

### DIFF
--- a/lisp/ledger-reconcile.el
+++ b/lisp/ledger-reconcile.el
@@ -448,6 +448,7 @@ moved and recentered.  If they aren't strange things happen."
   (let ((map (make-sparse-keymap)))
     (define-key map [(control ?m)] 'ledger-reconcile-visit)
     (define-key map [return] 'ledger-reconcile-visit)
+    (define-key map [(control ?x) (control ?s)] 'ledger-reconcile-save)
     (define-key map [(control ?l)] 'ledger-reconcile-refresh)
     (define-key map [(control ?c) (control ?c)] 'ledger-reconcile-finish)
     (define-key map [? ] 'ledger-reconcile-toggle)


### PR DESCRIPTION
Was introduced with commit 73f336a, which removed a functionality from
ledger.el old ledger mode.  I maintain a branch locally to always
restore C-x C-s keyboard shortcut that is so deeply inside my Emacs
muscle memory. I propose to restore this definitely.
