### PR TITLE
Status (cleared/pending/uncleared) processing behavior

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1434,8 +1434,7 @@ post_t * instance_t::parse_post(char *          line,
   }
 
   if (xact &&
-      ((xact->_state == item_t::CLEARED && post->_state != item_t::CLEARED) ||
-       (xact->_state == item_t::PENDING && post->_state == item_t::UNCLEARED)))
+      (xact->_state != item_t::UNCLEARED && post->_state == item_t::UNCLEARED))
     post->set_state(xact->_state);
 
   // Parse the account name


### PR DESCRIPTION
When a status flag (! or *) is explicitly specified for an individual posting, it always must have a priority over entire transaction status.
New behavior is the same as an old one when:
1) Either transaction or posting status is UNCLEARED, or both
2) Transaction and posting are specified (CLEARED or PENDING) and are the same
3) Transaction is marked PENDING, posting is marked CLEARED, then the posting considered as CLEARED

New behavior DIFFERS from the old one when:
1) Transaction is marked CLEARED, posting is marked PENDING, then the posting considered as PENDING, despite pending is a "lower" status than cleared, but "local" flag overrides "global" flag here.
