### PR TITLE
ledger-reconcile.el: don't use flatten

### DIFF
--- a/lisp/ledger-reconcile.el
+++ b/lisp/ledger-reconcile.el
@@ -323,9 +323,9 @@ POSTING is used in `ledger-clear-whole-transactions' is nil."
 	(let (fields
 				(start 0))
 		(while (string-match "(\\(.*?\\))" fstr start)
-			(setq fields (list fields (intern (substring fstr (match-beginning 1) (match-end 1)))))
+			(setq fields (cons (intern (match-string 1 fstr)) fields))
 			(setq start (match-end 0)))
-		(setq fields (flatten (list 'format (replace-regexp-in-string "(.*?)" "" fstr) (cdr (flatten fields)))))
+		(setq fields (list* 'format (replace-regexp-in-string "(.*?)" "" fstr) (nreverse fields)))
 		`(lambda (date code status payee account amount)
 			 ,fields)))
 


### PR DESCRIPTION
The new version of reconcile in Emacs use the flatten function, but this function is not part of Emacs 24.3.1, so I rewrote it somewhat to not use it.
