### PR TITLE
Feature precision

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -447,6 +447,9 @@ amount_t& amount_t::operator+=(const amount_t& amt)
 
   mpq_add(MP(quantity), MP(quantity), MP(amt.quantity));
 
+ if (has_commodity() && commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION))
+    in_place_roundto(commodity().custom_precision());
+
   if (has_commodity() == amt.has_commodity())
     if (quantity->prec < amt.quantity->prec)
       quantity->prec = amt.quantity->prec;

--- a/src/amount.cc
+++ b/src/amount.cc
@@ -477,9 +477,6 @@ amount_t& amount_t::operator-=(const amount_t& amt)
 
   mpq_sub(MP(quantity), MP(quantity), MP(amt.quantity));
 
-  if (has_commodity() && commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION))
-     in_place_roundto(commodity().custom_precision());
-
   if (has_commodity() == amt.has_commodity())
     if (quantity->prec < amt.quantity->prec)
       quantity->prec = amt.quantity->prec;

--- a/src/amount.cc
+++ b/src/amount.cc
@@ -628,6 +628,12 @@ void amount_t::in_place_round()
   else if (! keep_precision())
     return;
 
+  if (has_commodity()) {
+      commodity_t& comm = commodity();
+      if (comm.has_flags(COMMODITY_SET_CUSTOM_PRECISION))
+          in_place_roundto(comm.custom_precision());
+  }
+
   _dup();
   set_keep_precision(false);
 }

--- a/src/amount.cc
+++ b/src/amount.cc
@@ -447,9 +447,6 @@ amount_t& amount_t::operator+=(const amount_t& amt)
 
   mpq_add(MP(quantity), MP(quantity), MP(amt.quantity));
 
- if (has_commodity() && commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION))
-    in_place_roundto(commodity().custom_precision());
-
   if (has_commodity() == amt.has_commodity())
     if (quantity->prec < amt.quantity->prec)
       quantity->prec = amt.quantity->prec;

--- a/src/amount.cc
+++ b/src/amount.cc
@@ -628,12 +628,6 @@ void amount_t::in_place_round()
   else if (! keep_precision())
     return;
 
-  if (has_commodity()) {
-      commodity_t& comm = commodity();
-      if (comm.has_flags(COMMODITY_SET_CUSTOM_PRECISION))
-          in_place_roundto(comm.custom_precision());
-  }
-
   _dup();
   set_keep_precision(false);
 }

--- a/src/amount.cc
+++ b/src/amount.cc
@@ -480,6 +480,9 @@ amount_t& amount_t::operator-=(const amount_t& amt)
 
   mpq_sub(MP(quantity), MP(quantity), MP(amt.quantity));
 
+  if (has_commodity() && commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION))
+     in_place_roundto(commodity().custom_precision());
+
   if (has_commodity() == amt.has_commodity())
     if (quantity->prec < amt.quantity->prec)
       quantity->prec = amt.quantity->prec;

--- a/src/balance.cc
+++ b/src/balance.cc
@@ -190,6 +190,14 @@ balance_t::value(const datetime_t&   moment,
 {
   balance_t temp;
   bool      resolved = false;
+  std::multimap<commodity_t*, amount_t, ledger::commodity_compare> tmp_amounts ;
+  tmp_amounts.insert(amounts.begin(), amounts.end());
+  commodity_t* tmp_comm = NULL;
+  amount_t* tmp_amount = NULL;
+  bool round_amt = false;
+  std::multimap<commodity_t*, amount_t, ledger::commodity_compare>::iterator
+                                  i,j,k;
+
 
   foreach (const amounts_map::value_type& pair, amounts) {
     if (optional<amount_t> val = pair.second.value(moment, in_terms_of)) {

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -108,10 +108,13 @@ protected:
 #define COMMODITY_SAW_ANN_PRICE_FLOAT    0x400
 #define COMMODITY_SAW_ANN_PRICE_FIXATED  0x800
 #define COMMODITY_STYLE_TIME_COLON       0x1000
+#define COMMODITY_SET_CUSTOM_PRECISION   0X2000
+
 
     string                symbol;
     optional<std::size_t> graph_index;
     amount_t::precision_t precision;
+    int_least16_t         custom_precision;
     optional<string>      name;
     optional<string>      note;
     optional<amount_t>    smaller;
@@ -132,7 +135,7 @@ protected:
         (commodity_t::decimal_comma_by_default ?
          static_cast<uint_least16_t>(COMMODITY_STYLE_DECIMAL_COMMA) :
          static_cast<uint_least16_t>(COMMODITY_STYLE_DEFAULTS)),
-        symbol(_symbol), precision(0) {
+        symbol(_symbol), precision(0), custom_precision(0) {
       TRACE_CTOR(commodity_t::base_t, "const string&");
     }
     virtual ~base_t() {
@@ -247,8 +250,14 @@ public:
   amount_t::precision_t precision() const {
     return base->precision;
   }
+  int_least16_t custom_precision() const {
+    return base->custom_precision;
+  }
   void set_precision(amount_t::precision_t arg) {
     base->precision = arg;
+  }
+  void set_custom_precision(int_least16_t arg) {
+    base->custom_precision = arg;
   }
 
   optional<amount_t> smaller() const {

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -163,6 +163,7 @@ namespace {
     void commodity_format_directive(commodity_t& comm, string format);
     void commodity_nomarket_directive(commodity_t& comm);
     void commodity_default_directive(commodity_t& comm);
+    void commodity_precision_directive(commodity_t& comm, string precise);
 
     void default_commodity_directive(char * line);
 
@@ -1096,6 +1097,8 @@ void instance_t::commodity_directive(char * line)
         commodity_default_directive(*commodity);
       else if (keyword == "note")
         commodity->set_note(string(b));
+      else if (keyword == "precision")
+        commodity_precision_directive(*commodity, b);
     }
   }
 }
@@ -1129,6 +1132,14 @@ void instance_t::commodity_nomarket_directive(commodity_t& comm)
 void instance_t::commodity_default_directive(commodity_t& comm)
 {
   commodity_pool_t::current_pool->default_commodity = &comm;
+}
+
+void instance_t::commodity_precision_directive(commodity_t& comm, string precise)
+{
+  trim(precise);
+  int_least16_t  _precision_level = boost::lexical_cast<int_least16_t>(precise);
+  comm.set_custom_precision(_precision_level);
+  comm.add_flags(COMMODITY_SET_CUSTOM_PRECISION);
 }
 
 void instance_t::tag_directive(char * line)

--- a/src/value.cc
+++ b/src/value.cc
@@ -408,9 +408,11 @@ value_t& value_t::operator+=(const value_t& val)
         in_place_cast(BALANCE);
         return *this += val;
       } else {
-        if (as_amount().has_commodity() && as_amount().commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION)) {
-            amount_t temp(as_amount());
-            temp.in_place_roundto(as_amount().commodity().custom_precision());
+        const amount_t& t_amt = as_amount();
+
+        if (t_amt.has_commodity() && t_amt.commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION)) {
+            amount_t temp(t_amt);
+            temp.in_place_roundto(t_amt.commodity().custom_precision());
         }
 
         as_amount_lval() += val.as_amount();

--- a/src/value.cc
+++ b/src/value.cc
@@ -1431,8 +1431,15 @@ value_t value_t::value(const datetime_t&   moment,
     return NULL_VALUE;
 
   case AMOUNT:
-    if (optional<amount_t> val = as_amount().value(moment, in_terms_of))
+    if (optional<amount_t> val = as_amount().value(moment, in_terms_of)) {
+      amount_t& amt = *val;
+
+      if (amt.has_commodity() && amt.commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION))
+        amt.in_place_roundto(amt.commodity().custom_precision());
+
       return *val;
+    }
+
     return NULL_VALUE;
 
   case BALANCE:

--- a/src/value.cc
+++ b/src/value.cc
@@ -408,6 +408,11 @@ value_t& value_t::operator+=(const value_t& val)
         in_place_cast(BALANCE);
         return *this += val;
       } else {
+        if (as_amount().has_commodity() && as_amount().commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION)) {
+            amount_t temp(as_amount());
+            temp.in_place_roundto(as_amount().commodity().custom_precision());
+        }
+
         as_amount_lval() += val.as_amount();
         return *this;
       }

--- a/src/value.cc
+++ b/src/value.cc
@@ -414,6 +414,13 @@ value_t& value_t::operator+=(const value_t& val)
         }
 
         as_amount_lval() += val.as_amount();
+        amount_t& t_lval = as_amount_lval();
+
+        if (t_lval.has_commodity() && t_lval.commodity().has_flags(COMMODITY_SET_CUSTOM_PRECISION)) {
+            amount_t temp(t_lval);
+            temp.in_place_roundto(t_lval.commodity().custom_precision());
+        }
+
         return *this;
       }
 

--- a/test/baseline/dir-commodity-precision.test
+++ b/test/baseline/dir-commodity-precision.test
@@ -1,0 +1,20 @@
+D 1000.000 EUR
+commodity EUR
+  precision 2
+  default
+
+2012-01-01 *
+   A                        1 AAA @@ 10.00 EUR
+   A                        1 BBB @@ 20.00 EUR
+   C
+
+P 2012-07-01 AAA 10.123 EUR
+P 2012-07-01 BBB 20.123 EUR 
+
+test -V bal
+          30.240 EUR  A
+         -30.000 EUR  C
+--------------------
+           0.240 EUR
+end test
+

--- a/test/regress/781_a.test
+++ b/test/regress/781_a.test
@@ -1,0 +1,18 @@
+D 10.00 EUR
+commodity EUR
+  precision 2
+  default
+
+2014-01-01 Opening balance
+ Assets:Investments     10 AAA @ 10.1234 EUR
+ Assets:Investments     10 BBB @ 10.5692 EUR
+ Equity:Opening balance
+
+
+test -V bal
+          206.92 EUR  Assets:Investments
+         -206.92 EUR  Equity:Opening balance
+--------------------
+                   0
+end test
+

--- a/test/regress/781_b.test
+++ b/test/regress/781_b.test
@@ -1,0 +1,21 @@
+D $1000.00
+commodity $
+ precision 2
+ default
+ 
+2014-06-15 Test 1
+    Liabilities:Payable           GBP -19.86 @ $1.3869
+    Expenses
+
+2014-06-16 Test 2
+    Liabilities:Payable           GBP -19.86 @ $1.3869
+    Expenses
+
+
+test -V bal
+              $55.08  Expenses
+             $-55.08  Liabilities:Payable
+--------------------
+                   0
+end test
+

--- a/test/regress/781_b.test
+++ b/test/regress/781_b.test
@@ -14,8 +14,8 @@ commodity $
 
 test -V bal
               $55.08  Expenses
-             $-55.08  Liabilities:Payable
+             $-55.09  Liabilities:Payable
 --------------------
-                   0
+              $-0.01
 end test
 

--- a/test/regress/781_c.test
+++ b/test/regress/781_c.test
@@ -1,0 +1,18 @@
+D 1000.000 EUR
+commodity EUR
+  precision 2
+  default
+
+
+2012-01-02 * 
+   A                      3.692 EUR
+   C			    -269 boots @@ 3.691 EUR
+ 
+
+test -V bal
+           3.690 EUR  A
+          -3.690 EUR  C
+--------------------
+                   0
+end test
+

--- a/test/regress/781_d.test
+++ b/test/regress/781_d.test
@@ -1,0 +1,17 @@
+D 100.000 GBP
+commodity GBP
+  precision 2
+  default
+
+2014-01-01 *  
+ A		 3.6911 GBP
+ B 		-100 boots @@ 3.6921 GBP 
+ 
+
+ test -V bal
+          3.6900 GBP  A
+         -3.6900 GBP  B
+--------------------
+                   0
+end test
+

--- a/test/regress/781_e.test
+++ b/test/regress/781_e.test
@@ -1,0 +1,22 @@
+D 100.000 EUR
+commodity EUR
+  precision 2
+  default
+
+D 100.000 GBP  
+commodity GBP
+  precision 2
+
+2014-01-01 *
+ A		-38.24 EUR
+ B 		 30.00 GBP
+ C		 2.09 EUR
+
+test -V bal
+         -31.730 GBP  A
+          30.000 GBP  B
+           1.730 GBP  C
+--------------------
+                   0
+end test
+

--- a/test/regress/781_f.test
+++ b/test/regress/781_f.test
@@ -1,0 +1,19 @@
+D 100.000 GBP 
+commodity GBP
+  precision 2
+  default
+
+2014-02-01 *interest
+ Asset:Savings				 0.34 GBP
+ Income:Interest			-0.43 GBP
+ Expenditure:Tax:Interest		 0.09 GBP
+ 
+
+ test -V bal
+           0.340 GBP  Asset:Savings
+           0.090 GBP  Expenditure:Tax:Interest
+          -0.430 GBP  Income:Interest
+--------------------
+                   0
+end test
+

--- a/test/regress/781_g.test
+++ b/test/regress/781_g.test
@@ -1,0 +1,34 @@
+commodity GBP
+   precision 2
+   format 1000.000 GBP
+
+2010-01-10 * Buy XXX
+    Assets:Pension                 342.2904 XXX @@  820.72 GBP
+    Assets:Cash
+
+2010-02-10 * Buy XXX
+    Assets:Pension                 108.0939 XXX @@  259.18 GBP
+    Assets:Cash
+
+2010-03-10 * Buy XXX
+    Assets:Pension                 108.0939 XXX @@  259.18 GBP
+    Assets:Cash
+
+2010-04-02 * Buy XXX
+    Assets:Pension                 476.4930 XXX @@ 1079.90 GBP
+    Assets:Cash
+
+2010-05-02 * Buy XXX
+    Assets:Pension                 114.3601 XXX @@  259.18 GBP
+    Assets:Cash
+
+P 2011/01/01 XXX 2.7316 GBP
+
+test -V bal
+         461.350 GBP  Assets
+       -2678.160 GBP    Cash
+        3139.510 GBP    Pension
+--------------------
+         461.350 GBP
+end test
+

--- a/test/regress/781_h.test
+++ b/test/regress/781_h.test
@@ -1,0 +1,25 @@
+D 1000.000 EUR
+commodity EUR
+  precision 2
+  default
+  
+
+
+2014-06-01 * Opening balance
+    Assets:Investments            123 XXX {1.23456 EUR} @ 1.23456 EUR
+    Equity:Opening balances          -151.85 EUR
+
+2014-06-22 * Sell some shares
+    Assets:Investments            -123 XXX {1.23456 EUR} @ 2.345 EUR
+    Assets:Cash                        288.44 EUR
+    Income:Capital gains              -136.59 EUR 
+    
+
+test -V bal
+         288.440 EUR  Assets:Cash
+        -151.850 EUR  Equity:Opening balances
+        -136.590 EUR  Income:Capital gains
+--------------------
+                   0
+end test 
+


### PR DESCRIPTION
implemented precision commodity sub directive.

Use case: 
Monetary test cases only .

Performance: 
 It does not affect ledger performance significantly .Sorting is only done just when required and a flag can be added so that sorting is not done for those who do not require this feature. 

Comment:
Sorting by commodity is already being done for functions like printing.  fn: :map_sorted_amounts

Tests:
All tests which do not use this feature passed at the time of writing this feature. Tests using this feature passed but have been written to check specific requirements. More tests should be added with combination of options using this feature. 

Challenge faced: 
Account with single amount does not use balance_t object, The balance is maintained as amount_t object. Therefore, rounding implemented for balance valuation does not work and so rounding has been done after the amount is valued. 

Future work: 
Extend this feature to non-monetary use cases.
