### PR TITLE
Manual install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,9 @@ footwork for you:
     # $HOME/local and build with 2 processes in parallel
     ./acprep update --boost-suffix=-mt --prefix=$HOME/local -j2
 
-Please read the contents of `config.log` if the configure step fails.  Also,
-see the `help` subcommand to `acprep`, which explains some of its many
-options.  It's pretty much the only command I run for configuring, building
-and testing Ledger.
+See the `help` subcommand to `acprep`, which explains some of its many options.
+It's pretty much the only command I run for configuring, building and testing
+Ledger.
 
 You can run `make check` to confirm the result, and `make install` to install.
 

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -367,17 +367,24 @@ data, not for altering it.
 @node Building the program, Getting help, Fat-free Accounting, Introduction to Ledger
 @section Building the program
 
-Ledger is written in ANSI C++, and should compile on any platform.  It
-depends on the GNU multiple precision arithmetic library (libgmp), and
-the Perl regular expression library (libpcre).  It was developed using
-GNU make and gcc 3.3, on a PowerBook running OS/X.
-
-To build and install once you have these libraries on your system,
-enter these commands:
+Ledger is written in ANSI C++, and should compile on any unix platform.
+The easiest way to build and install ledger is to use the prepared
+acprep script, that does a lot of the footwork:
 
 @smallexample
-$ ./configure && make install
+    # to install missing dependencies
+    ./acprep dependencies
+    # building ledger
+    ./acprep update
+    # to run the actual installation
+    make install
 @end smallexample
+
+Please read the contents of `config.log` if the configure step fails.
+Also, see the `help` subcommand to `acprep`, which explains some of its
+many options.  It's pretty much the only command I run for configuring,
+building and testing Ledger.  You can run `make check` to confirm the
+result, and `make install` to install.
 
 @node Getting help,  , Building the program, Introduction to Ledger
 @section Getting help

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -380,11 +380,10 @@ acprep script, that does a lot of the footwork:
     make install
 @end smallexample
 
-Please read the contents of `config.log` if the configure step fails.
-Also, see the `help` subcommand to `acprep`, which explains some of its
-many options.  It's pretty much the only command I run for configuring,
-building and testing Ledger.  You can run `make check` to confirm the
-result, and `make install` to install.
+See the `help` subcommand to `acprep`, which explains some of its many
+options. You can run `make check` to confirm the result, and `make
+install` to install. If these intructions do not work for you can check the
+`README.md` in the source directory for more up do date build instructions.
 
 @node Getting help,  , Building the program, Introduction to Ledger
 @section Getting help


### PR DESCRIPTION
The install instruction in the manual still used an old `configure` setup. I copied and adjusted the instructions from `README.md`. It would be nice if a native speaker could look over it. Thanks