### PR TITLE
Add face definition for `ledger-font-payee-pending-face'.

### DIFF
--- a/lisp/ledger-fonts.el
+++ b/lisp/ledger-fonts.el
@@ -65,11 +65,15 @@
   "Default face for cleared (*) payees"
   :group 'ledger-faces)
 
+(defface ledger-font-payee-pending-face
+  `((t :foreground "#F24B61" :weight normal))
+  "Default face for pending (!) payees"
+  :group 'ledger-faces)
+
 (defface ledger-font-xact-highlight-face
   `((t :inherit ledger-occur-xact-face))
   "Default face for transaction under point"
   :group 'ledger-faces)
-
 
 (defface ledger-font-pending-face
   `((t :foreground "#cb4b16" :weight normal ))


### PR DESCRIPTION
Ledger fontifies payees on pending transactions using the aptly named
`ledger-font-payee-pending-face' face, despite that face not actually
being defined. This patch fixes that.
