### PR TITLE
doc: ledger-mode: load lazily

### DIFF
--- a/doc/ledger-mode.texi
+++ b/doc/ledger-mode.texi
@@ -119,9 +119,9 @@ initialization file (@file{~/.emacs}, @file{~/.emacs.d/init.el}, or
 @file{~/.Aquamacs/Preferences.el}).
 
 @lisp
+(autoload 'ledger-mode "ledger-mode" "A major mode for Ledger" t)
 (add-to-list 'load-path
              (expand-file-name "/path/to/ledger/source/lisp/"))
-(load "ledger-mode")
 (add-to-list 'auto-mode-alist '("\\.ledger$" . ledger-mode))
 @end lisp
 


### PR DESCRIPTION
This was a quick documentation fix, but I've only tested it by myself on Arch. It speeds up my emacs initialization significantly (as I do not use emacs-daemon).

Also, I am not an emacs expert, so this might not actually be even correct --- please critique.
