### PR TITLE
Fixes xact having higher priority than region

### DIFF
--- a/lisp/ledger-xact.el
+++ b/lisp/ledger-xact.el
@@ -52,7 +52,7 @@
                                       (current-buffer) t nil)))
           (move-overlay ovl (car exts) (cadr exts)))
         (overlay-put ovl 'face 'ledger-font-xact-highlight-face)
-        (overlay-put ovl 'priority 100))))
+        (overlay-put ovl 'priority '(nil . 99)))))
 
 (defun ledger-xact-payee ()
   "Return the payee of the transaction containing point or nil."


### PR DESCRIPTION
The xact face is given priority 100 while region has priority `(nil. 100)`. This changes xact priority to `(nil . 99)`
