### PR TITLE
Prevent overwriting s.el functions

### DIFF
--- a/lisp/ledger-fontify.el
+++ b/lisp/ledger-fontify.el
@@ -192,19 +192,19 @@ Fontify the first line of an xact"
 	(put-text-property (car extents) (cadr extents) 'face face))
 
 
-(defun s-trim-left (s)
+(defun ledger-s-trim-left (s)
   "Remove whitespace at the beginning of S."
   (if (string-match "\\`[ \t\n\r]+" s)
       (replace-match "" t t s)
     s))
 
-(defun s-trim-right (s)
+(defun ledger-s-trim-right (s)
   "Remove whitespace at the end of S."
   (if (string-match "[ \t\n\r]+\\'" s)
       (replace-match "" t t s)
     s))
 
-(defun s-trim (s)
+(defun ledger-s-trim (s)
   "Remove whitespace at the beginning and end of S."
   (s-trim-left (s-trim-right s)))
 ;;; ledger-fontify.el ends here


### PR DESCRIPTION
DO NOT overwrite other package functions. Use prefix or require.
