### PR TITLE
Fix and re-enable DocTests

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -2388,7 +2388,7 @@ fixed CAD $0.90
 2012-04-11 Second day Dinner in Canada
     Assets:Wallet            -25.75 CAD
     Expenses:Food            25.75 CAD
-endfixed
+endfixed CAD
 @end smallexample
 
 is equivalent to this:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,17 +36,16 @@ add_subdirectory(manual)
 add_subdirectory(baseline)
 add_subdirectory(regress)
 
-# jww (2014-04-17): This is temporary until we find a fix.
-#if (PYTHONINTERP_FOUND)
-#  set(_class DocTests)
-#  file(GLOB ${_class}_TESTS ${PROJECT_SOURCE_DIR}/doc/*.texi)
-#  foreach(TestFile ${${_class}_TESTS})
-#    get_filename_component(TestFile_Name ${TestFile} NAME_WE)
-#    add_test(NAME ${_class}Test_${TestFile_Name}
-#      COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/DocTests.py
-#      --ledger $<TARGET_FILE:ledger> --file ${TestFile})
-#    set_target_properties(check PROPERTIES DEPENDS ${_class}Test_${TestFile_Name})
-#  endforeach()
-#endif()
+if (PYTHONINTERP_FOUND)
+  set(_class DocTests)
+  file(GLOB ${_class}_TESTS ${PROJECT_SOURCE_DIR}/doc/*.texi)
+  foreach(TestFile ${${_class}_TESTS})
+    get_filename_component(TestFile_Name ${TestFile} NAME_WE)
+    add_test(NAME ${_class}Test_${TestFile_Name}
+      COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/DocTests.py
+      --ledger $<TARGET_FILE:ledger> --file ${TestFile})
+    set_target_properties(check PROPERTIES DEPENDS ${_class}Test_${TestFile_Name})
+  endforeach()
+endif()
 
 ### CMakeLists.txt ends here


### PR DESCRIPTION
I'm quite surprised that the DocTests have been disabled since April.

@jwiegley what was the motivation to disable the tests instead of addressing the issue(s)?

Next time please ask the ledger community to help (if you have, I must have missed it).
I'm more than willing to contribute as much as I can, so feel free to also ask me personally.
