### PR TITLE
Fix DocTests running in non-standard width terminal

### DIFF
--- a/test/DocTests.py
+++ b/test/DocTests.py
@@ -114,8 +114,9 @@ class DocTests:
     if command[0] == '$': command.remove('$')
     index = command.index('ledger')
     command[index] = self.ledger
-    command.insert(index+1, '--init-file')
-    command.insert(index+2, '/dev/null')
+    for i,argument in enumerate('--init-file /dev/null --columns 80'.split()):
+      command.insert(index+i+1, argument)
+
     try:
       findex = command.index('-f')
     except ValueError:


### PR DESCRIPTION
The changes introduced with:
  ledger@56976a127c081a6a008c81966360003a8711a319 _make --columns default to terminal width, as returned by ioctl()_
break the DocTests when run in a terminal with a width different
from the standard of 80 columns.
