### PR TITLE
Fix off by one error in textual.cc

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1816,7 +1816,7 @@ xact_t * instance_t::parse_xact(char *          line,
         char *q = p - 1;
         while (q > next && std::isspace(*q))
           --q;
-        if (q > next)
+        if (q >= next)
           *(q + 1) = '\0';
         break;
       }


### PR DESCRIPTION
This fixes parsing of transactions with single-character payees and inline comment. Try

```
2014-01-01 x  ; x
  a  1
  b
```
