### PR TITLE
Fix crash when using -M with empty result

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -983,7 +983,7 @@ void interval_posts::flush()
                    sort_posts_by_date());
 
   // Determine the beginning interval by using the earliest post
-  if (all_posts.front() &&
+  if (all_posts.size() > 0 && all_posts.front() &&
       ! interval.find_period(all_posts.front()->date()))
     throw_(std::logic_error, _("Failed to find period for interval report"));
 

--- a/test/regress/730.test
+++ b/test/regress/730.test
@@ -1,0 +1,37 @@
+; Using -M in combination with an empty result causes a segmentation fault
+; therefore this test case does not have or need any test data
+
+test -f /dev/null -M reg
+end test
+
+; Tests mentioned in #730
+test reg -M
+end test
+
+test reg -M .foo
+end test
+
+test reg -M -e 2012/01
+end test
+
+
+; Tests mentioned in #1080
+test reg '^Expenses' and expr 'any(account =~ /^Assets:Cash/)' --period 'every week this month'
+end test
+
+test bal '^Expenses' and expr 'any(account =~ /^Assets:Cash/)' --period 'every week this month'
+end test
+
+test bal reg foo and  expr 'any(account =~ /bar/)' --period 'every week'
+end test
+
+
+; Tests mentioned in #1084
+test b abc -M
+end test
+
+test reg foo -M 
+end test
+
+test bal foo -M 
+end test


### PR DESCRIPTION
`ledger -f /dev/null reg -M test` causes a segmentation fault,
see [bug 730](http://bugs.ledger-cli.org/show_bug.cgi?id=730) and duplicates [1080](http://bugs.ledger-cli.org/show_bug.cgi?id=1080) and [1084](http://bugs.ledger-cli.org/show_bug.cgi?id=1084) for details.
