### PR TITLE
Set CMake policy CMP0042

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 2.8.5)
+if(POLICY CMP0042)
+  # CMP0042 is only known to CMake 3.0 and above
+  cmake_policy(SET CMP0042 OLD)
+endif(POLICY CMP0042)
 
 PROJECT(ledger)
 


### PR DESCRIPTION
to remove the warning below when running cmake.
In the long run changing the CMake rules to set MACOSX_RPATH
might be the better option.

  CMake Warning (dev):
    Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
    --help-policy CMP0042" for policy details.  Use the cmake_policy
    command to set the policy and suppress this warning.
    MACOSX_RPATH is not specified for the following targets:

```
 libledger
```

  This warning is for project developers.  Use -Wno-dev to suppress it.
