### PR TITLE
Fix crash when using --trace 10 or above

### DIFF
--- a/src/global.cc
+++ b/src/global.cc
@@ -514,7 +514,7 @@ void handle_debug_options(int argc, char * argv[])
 #if TRACING_ON
         _log_level   = LOG_TRACE;
         try {
-          _trace_level = boost::lexical_cast<uint8_t>(argv[i + 1]);
+          _trace_level = boost::lexical_cast<uint16_t>(argv[i + 1]);
         }
         catch (const boost::bad_lexical_cast&) {
           throw std::logic_error(_("Argument to --trace must be an integer"));

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -574,7 +574,7 @@ std::ostream *     _log_stream = &std::cerr;
 std::ostringstream _log_buffer;
 
 #if TRACING_ON
-uint8_t            _trace_level;
+uint16_t            _trace_level;
 #endif
 
 static bool  logger_has_run = false;

--- a/src/utils.h
+++ b/src/utils.h
@@ -251,7 +251,7 @@ void logger_func(log_level_t level);
 
 #if TRACING_ON
 
-extern uint8_t _trace_level;
+extern uint16_t _trace_level;
 
 #define SHOW_TRACE(lvl) \
   (ledger::_log_level >= ledger::LOG_TRACE && lvl <= ledger::_trace_level)

--- a/test/baseline/opt-trace.test
+++ b/test/baseline/opt-trace.test
@@ -1,0 +1,15 @@
+2007/02/02 RD VMMXX
+    Assets:Investments:Vanguard:VMMXX  0.350 VMMXX @ $1.00
+    Income:Dividends:Vanguard:VMMXX        $-0.35
+
+; Using values with two or more digits as the argument to the --trace option
+; resulted in a segmentation fault.
+; Since ledger prints debugging information to stderr when the --trace option
+; was given and that debugging information contains timing information, e.g. [1ms]
+; which is likely to differ on each test run, this test only checks that ledger
+; does not crash when the --trace options was specified.
+test reg --trace 10 2>/dev/null
+07-Feb-02 RD VMMXX              As:Inves:Vanguar:VMMXX  0.350 VMMXX  0.350 VMMXX
+                                In:Divid:Vanguar:VMMXX       $-0.35       $-0.35
+                                                                     0.350 VMMXX
+end test


### PR DESCRIPTION
`uint8_t` is typedef'd to char, thus `boost::lexical_cast` treats it
as such instead of a number.

I've had an insightful chat in the #boost channel and this seems to me the best solution.
Another approach could be to use [stoul](http://en.cppreference.com/w/cpp/string/basic_string/stoul) from C++11, which is generally more efficient, but doesn't explicitly support `uint8_t` either.
(Kudos to VeXocide in #boost)

I chose `boost:lexical_cast<uint16_t>` over `stoul` to keep the changes as small as possible,
but would be willing to change this pull request to use `stoul` if that's preferred.
