### PR TITLE
Fix bug 1038; Improve error handling when parsing year directives

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -285,6 +285,11 @@ void instance_t::parse()
     }
   }
 
+  if (apply_stack.front().value.type() == typeid(optional<datetime_t>))
+    epoch = boost::get<optional<datetime_t> >(apply_stack.front().value);
+
+  apply_stack.pop_front();
+
 #if defined(TIMELOG_SUPPORT)
   timelog.close();
 #endif // TIMELOG_SUPPORT

--- a/test/regress/1038_1.test
+++ b/test/regress/1038_1.test
@@ -1,0 +1,18 @@
+Y2014
+
+04/13 Bank
+    Expenses:Loan          $400
+    Assets:Cash
+
+05/13 Bug 1038 Test
+    Expenses:Some:Account  $500
+    Assets:Cash
+
+06/13 Landlord
+    Expenses:Rent          $600
+    Assets:Cash
+
+test reg --now 2014-05-14 -p 'this month'
+14-May-13 Bug 1038 Test         Expenses:Some:Account          $500         $500
+                                Assets:Cash                   $-500            0
+end test

--- a/test/regress/1038_2.test
+++ b/test/regress/1038_2.test
@@ -1,0 +1,18 @@
+year 2014
+
+04/13 Bank
+    Expenses:Loan          $400
+    Assets:Cash
+
+05/13 Bug 1038 Test
+    Expenses:Some:Account  $500
+    Assets:Cash
+
+06/13 Landlord
+    Expenses:Rent          $600
+    Assets:Cash
+
+test reg --now 2014-05-14 -p 'this month'
+14-May-13 Bug 1038 Test         Expenses:Some:Account          $500         $500
+                                Assets:Cash                   $-500            0
+end test

--- a/test/regress/1038_3.test
+++ b/test/regress/1038_3.test
@@ -1,0 +1,20 @@
+apply year 2014
+
+04/13 Bank
+    Expenses:Loan          $400
+    Assets:Cash
+
+05/13 Bug 1038 Test
+    Expenses:Some:Account  $500
+    Assets:Cash
+
+06/13 Landlord
+    Expenses:Rent          $600
+    Assets:Cash
+
+end apply
+
+test reg --now 2014-05-14 -p 'this month'
+14-May-13 Bug 1038 Test         Expenses:Some:Account          $500         $500
+                                Assets:Cash                   $-500            0
+end test


### PR DESCRIPTION
These changes fix the [1038](http://bugs.ledger-cli.org/show_bug.cgi?id=1038) issue.

Since my understanding about leader's code architecture is still rather limited, the proposed changes may not be the optimal solution or they may have side effects. Please review scrutinizingly, thanks :christmas_tree: 
