### PR TITLE
Fix for BUG 985

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ enable_testing()
 
 add_definitions(-std=c++11)
 
+if (CYGWIN)
+  add_definitions(-U__STRICT_ANSI__)
+endif()
+
 ########################################################################
 
 option(USE_PYTHON "Build support for the Python scripting bridge" OFF)


### PR DESCRIPTION
http://bugs.ledger-cli.org/show_bug.cgi?id=985

Fix compilation issue on Cygwin by adding the '-U__STRICT_ANSI__' flag
to GCC. This avoids GCC disabling some stdlib functions like 'setenv'
and 'popen'.