### PR TITLE
[emacs] Fontification should work independentily on where the point currently is

### DIFF
--- a/lisp/ledger-fontify.el
+++ b/lisp/ledger-fontify.el
@@ -42,6 +42,7 @@
 	(save-excursion
 		(unless beg (setq beg (point-min)))
 		(unless end (setq end (point-max)))
+		(goto-char beg)
 		(beginning-of-line)
 		(while (< (point) end)
 			(cond ((or (looking-at ledger-xact-start-regex)


### PR DESCRIPTION
This is a subtle bug that happens only when org-src-fontify-natively is
enabled:

```emacs-lisp
(setq org-src-fontify-natively t)
```

If then you create a Babel block with ledger text, it won't be
fontified.

This happens because the 'ledger-fontify-buffer-part' starts
fontification from the current 'point', which in case of
org-src-font-lock-fontify-block happens to _not_ point to the beginning
of buffer. Instead it points to the original org-mode buffer.
This doesn't happen when one opens regular files, because the
'point' is almost always at the beginning of the file.

To reproduce the bug, you can do the following:

```emacs-lisp
(defun fontify-test()
  (let ((lang-mode 'ledger-mode) pos next)

  (with-current-buffer
      (get-buffer-create
       "ledger-fontification-bug")
    (unless (eq major-mode lang-mode) (funcall lang-mode))
    (erase-buffer)
    (insert "2015/01/09 asdf\n  foo\n  bar\n" " ")
    (font-lock-fontify-buffer)
    (switch-to-buffer "ledger-fontification-bug")
    )))
```

Call 'fontify-test' and see that the buffer is not fontified.

[ci skip]