### PR TITLE
[emacs] fix copy

### DIFF
--- a/lisp/ledger-xact.el
+++ b/lisp/ledger-xact.el
@@ -139,6 +139,7 @@ MOMENT is an encoded date"
                            (string-to-number (match-string 2 date)))))
     (ledger-xact-find-slot encoded-date)
     (insert transaction "\n")
+    (beginning-of-line -1)
     (ledger-navigate-beginning-of-xact)
     (re-search-forward ledger-iso-date-regexp)
     (replace-match date)


### PR DESCRIPTION
ledger-xact.el:ledger-copy-transaction-at-point (C-c C-k) led to a confusing change in the ledger file for the case when the target date was smaller than last date in the ledger.