### PR TITLE
[fix] Make trim function trim trailing whitespace

### DIFF
--- a/src/report.cc
+++ b/src/report.cc
@@ -631,7 +631,7 @@ value_t report_t::fn_trim(call_scope_t& args)
   while (*p && std::isspace(*p))
     p++;
 
-  const char * e = buf.get() + temp.length();
+  const char * e = buf.get() + temp.length() - 1;
   while (e > p && std::isspace(*e))
     e--;
 
@@ -643,7 +643,7 @@ value_t report_t::fn_trim(call_scope_t& args)
     return string_value(empty_string);
   }
   else {
-    return string_value(string(p, static_cast<std::string::size_type>(e - p)));
+    return string_value(string(p, static_cast<std::string::size_type>(e - p + 1)));
   }
 }
 

--- a/test/regress/1106.test
+++ b/test/regress/1106.test
@@ -1,0 +1,11 @@
+2015/01/20 Payee
+  Assets:Cash      ¤ 12,34
+  Expenses:Food
+
+test -F "»%(trim(' 	Trimmed 	 '))«\n" reg expenses
+»Trimmed«
+end test
+
+test -F "»%(trim('Trimmed'))«\n" reg expenses
+»Trimmed«
+end test


### PR DESCRIPTION
std::isspace(*e) returns false for the end of c-string null-byte.

Bugzilla: 1106