### PR TITLE
Fix warnings

### DIFF
--- a/lisp/ledger-commodities.el
+++ b/lisp/ledger-commodities.el
@@ -28,6 +28,10 @@
 
 (require 'ledger-regex)
 
+;; These keep the byte-compiler from warning about them, but have no other
+;; effect:
+(defvar ledger-environment-alist)
+
 (defcustom ledger-reconcile-default-commodity "$"
   "The default commodity for use in target calculations in ledger reconcile."
   :type 'string

--- a/lisp/ledger-complete.el
+++ b/lisp/ledger-complete.el
@@ -24,10 +24,13 @@
 
 (require 'pcomplete)
 
-(declare-function ledger-thing-at-point "ledger-context" nil)
 ;; In-place completion support
 
 ;;; Code:
+
+(declare-function ledger-thing-at-point "ledger-context" nil)
+(declare-function ledger-add-transaction "ledger-xact" (transaction-text &optional insert-at-point))
+(declare-function between "ledger-schedule" (val low high))
 
 (defun ledger-parse-arguments ()
   "Parse whitespace separated arguments in the current region."

--- a/lisp/ledger-complete.el
+++ b/lisp/ledger-complete.el
@@ -24,6 +24,7 @@
 
 (require 'pcomplete)
 
+(declare-function ledger-thing-at-point "ledger-context" nil)
 ;; In-place completion support
 
 ;;; Code:

--- a/lisp/ledger-exec.el
+++ b/lisp/ledger-exec.el
@@ -25,6 +25,8 @@
 
 ;;; Code:
 
+(defvar ledger-buf)
+
 (defconst ledger-version-needed "3.0.0"
   "The version of ledger executable needed for interactive features.")
 

--- a/lisp/ledger-occur.el
+++ b/lisp/ledger-occur.el
@@ -29,7 +29,9 @@
 
 ;;; Code:
 
-(require 'cl)
+;; TODO: replace this with (require 'cl-lib)
+(with-no-warnings
+	(require 'cl))
 (require 'ledger-navigate)
 
 (defconst ledger-occur-overlay-property-name 'ledger-occur-custom-buffer-grep)

--- a/lisp/ledger-post.el
+++ b/lisp/ledger-post.el
@@ -27,6 +27,8 @@
 
 ;;; Code:
 
+(declare-function ledger-navigate-find-xact-extents "ledger-navigate" (pos))
+
 (defgroup ledger-post nil
   "Options for controlling how Ledger-mode deals with postings and completion"
   :group 'ledger)

--- a/lisp/ledger-reconcile.el
+++ b/lisp/ledger-reconcile.el
@@ -34,6 +34,7 @@
 (defvar ledger-bufs nil)
 (defvar ledger-acct nil)
 (defvar ledger-target nil)
+(defvar ledger-clear-whole-transactions)
 
 (defgroup ledger-reconcile nil
   "Options for Ledger-mode reconciliation"

--- a/lisp/ledger-reconcile.el
+++ b/lisp/ledger-reconcile.el
@@ -35,7 +35,20 @@
 (defvar ledger-acct nil)
 (defvar ledger-target nil)
 (defvar ledger-clear-whole-transactions)
-
+(declare-function ledger-exec-ledger "ledger-exec" (input-buffer &optional output-buffer &rest args))
+(declare-function ledger-split-commodity-string "ledger-commodities" (str))
+(declare-function ledger-commodity-to-string "ledger-commodities" (c1))
+(declare-function -commodity "ledger-commodities" (c1 c2))
+(declare-function ledger-navigate-to-line "ledger-navigate" (line-number))
+(declare-function ledger-toggle-current "ledger-state" (&optional style))
+(declare-function ledger-insert-effective-date "ledger-mode" (&optional date))
+(declare-function ledger-add-transaction "ledger-xact" (transaction-text &optional insert-at-point))
+(declare-function ledger-delete-current-transaction "ledger-xact" (pos))
+(declare-function ledger-highlight-xact-under-point "ledger-xact" nil)
+(declare-function ledger-occur-mode "ledger-occur")
+(declare-function ledger-read-account-with-prompt "ledger-mode" (prompt))
+(declare-function ledger-occur "ledger-occur" (regex))
+(declare-function ledger-read-commodity-string "ledger-commodities" (prompt))
 (defgroup ledger-reconcile nil
   "Options for Ledger-mode reconciliation"
   :group 'ledger)

--- a/lisp/ledger-report.el
+++ b/lisp/ledger-report.el
@@ -29,6 +29,8 @@
 (eval-when-compile
   (require 'cl))
 
+(defvar ledger-buf)
+
 (defgroup ledger-report nil
   "Customization option for the Report buffer"
   :group 'ledger)

--- a/lisp/ledger-report.el
+++ b/lisp/ledger-report.el
@@ -31,8 +31,6 @@
 (declare-function ledger-navigate-to-line "ledger-navigate" (line-number))
 
 (require 'easymenu)
-(eval-when-compile
-  (require 'cl))
 
 (defvar ledger-buf)
 

--- a/lisp/ledger-report.el
+++ b/lisp/ledger-report.el
@@ -25,6 +25,11 @@
 
 ;;; Code:
 
+(declare-function ledger-read-string-with-default "ledger-mode" (prompt default))
+(declare-function ledger-xact-payee "ledger-xact" nil)
+(declare-function ledger-read-account-with-prompt "ledger-mode" (prompt))
+(declare-function ledger-navigate-to-line "ledger-navigate" (line-number))
+
 (require 'easymenu)
 (eval-when-compile
   (require 'cl))
@@ -151,13 +156,13 @@ text that should replace the format specifier."
   "A mode for viewing ledger reports.")
 
 (defun ledger-report-tagname-format-specifier ()
-  "Return a valid meta-data tag name"
+  "Return a valid meta-data tag name."
   ;; It is intended completion should be available on existing account
   ;; names, but it remains to be implemented.
   (ledger-read-string-with-default "Tag Name: " nil))
 
 (defun ledger-report-tagvalue-format-specifier ()
-  "Return a valid meta-data tag name"
+  "Return a valid meta-data tag name."
   ;; It is intended completion should be available on existing account
   ;; names, but it remains to be implemented.
   (ledger-read-string-with-default "Tag Value: " nil))
@@ -420,8 +425,8 @@ Optional EDIT the command."
   (customize-variable 'ledger-reports))
 
 (defun ledger-report-edit-report ()
+	"Edit the current report command in the mini buffer and re-run the report."
 	(interactive)
-	"Edit the current report command in the mini buffer and re-run the report"
 	(setq ledger-report-cmd (ledger-report-read-command ledger-report-cmd))
 	(ledger-report-redo))
 

--- a/lisp/ledger-schedule.el
+++ b/lisp/ledger-schedule.el
@@ -32,9 +32,8 @@
 
 
 (require 'ledger-init)
-;; TODO: replace this by (require 'cl-lib)
-(with-no-warnings
-	(require 'cl))
+(require 'cl-macs)
+
 (declare-function ledger-mode "ledger-mode")
 ;;; Code:
 
@@ -103,15 +102,15 @@ COUNT 0) means EVERY day-of-week (eg. every Saturday)"
       (cond ((zerop count) ;; Return true if day-of-week matches
              `(eq (nth 6 (decode-time date)) ,day-of-week))
             ((> count 0) ;; Positive count
-             (let ((decoded (gensym)))
+             (let ((decoded (cl-gensym)))
                `(let ((,decoded (decode-time date)))
                   (and (eq (nth 6 ,decoded) ,day-of-week)
                        (between  (nth 3 ,decoded)
                                  ,(* (1- count) 7)
                                  ,(* count 7))))))
             ((< count 0)
-             (let ((days-in-month (gensym))
-                   (decoded (gensym)))
+             (let ((days-in-month (cl-gensym))
+                   (decoded (cl-gensym)))
                `(let* ((,decoded (decode-time date))
                        (,days-in-month (ledger-schedule-days-in-month
                                         (nth 4 ,decoded)
@@ -136,9 +135,9 @@ For example every second Friday, regardless of month."
 
 (defun ledger-schedule-constrain-date-range (month1 day1 month2 day2)
   "Return a form of DATE that is true if DATE falls between MONTH1 DAY1 and MONTH2 DAY2."
-  (let ((decoded (gensym))
-        (target-month (gensym))
-        (target-day (gensym)))
+  (let ((decoded (cl-gensym))
+        (target-month (cl-gensym))
+        (target-day (cl-gensym)))
     `(let* ((,decoded (decode-time date))
             (,target-month (nth 4 decoded))
             (,target-day (nth 3 decoded)))

--- a/lisp/ledger-schedule.el
+++ b/lisp/ledger-schedule.el
@@ -30,9 +30,12 @@
 ;; function slot of the symbol VARNAME.  Then use VARNAME as the
 ;; function without have to use funcall.
 
-(require 'ledger-init)
-(require 'cl)
 
+(require 'ledger-init)
+;; TODO: replace this by (require 'cl-lib)
+(with-no-warnings
+	(require 'cl))
+(declare-function ledger-mode "ledger-mode")
 ;;; Code:
 
 (defgroup ledger-schedule nil

--- a/lisp/ledger-sort.el
+++ b/lisp/ledger-sort.el
@@ -25,20 +25,22 @@
 ;;
 
 ;;; Code:
-
+(defvar ledger-payee-any-status-regex)
+(declare-function ledger-navigate-find-xact-extents "ledger-navigate" (pos))
+(declare-function ledger-navigate-next-xact "ledger-navigate" nil)
 
 (defun ledger-sort-find-start ()
-	"Find the beginning of a sort region"
+	"Find the beginning of a sort region."
   (if (re-search-forward ";.*Ledger-mode:.*Start sort" nil t)
       (match-end 0)))
 
 (defun ledger-sort-find-end ()
-	"Find the end of a sort region"
+	"Find the end of a sort region."
   (if (re-search-forward ";.*Ledger-mode:.*End sort" nil t)
       (match-end 0)))
 
 (defun ledger-sort-insert-start-mark ()
-	"Insert a marker to start a sort region"
+	"Insert a marker to start a sort region."
   (interactive)
   (save-excursion
     (goto-char (point-min))
@@ -48,7 +50,7 @@
   (insert "\n; Ledger-mode: Start sort\n\n"))
 
 (defun ledger-sort-insert-end-mark ()
-	"Insert a marker to end a sort region"
+	"Insert a marker to end a sort region."
   (interactive)
   (save-excursion
     (goto-char (point-min))
@@ -58,7 +60,7 @@
   (insert "\n; Ledger-mode: End sort\n\n"))
 
 (defun ledger-sort-startkey ()
-  "Return the actual date so the sort-subr doesn't sort onthe entire first line."
+  "Return the actual date so the sort subroutine doesn't sort on the entire first line."
   (buffer-substring-no-properties (point) (+ 10 (point))))
 
 (defun ledger-sort-region (beg end)

--- a/lisp/ledger-state.el
+++ b/lisp/ledger-state.el
@@ -24,6 +24,8 @@
 ;; Utilities for dealing with transaction and posting status.
 
 ;;; Code:
+(declare-function ledger-navigate-find-xact-extents "ledger-navigate" (pos))
+(declare-function ledger-thing-at-point "ledger-context" ())
 
 (defcustom ledger-clear-whole-transactions nil
   "If non-nil, clear whole transactions, not individual postings."
@@ -67,7 +69,7 @@
 
 
 (defun ledger-state-from-string (state-string)
-  "Get state from STATE-CHAR."
+  "Get state from STATE-STRING."
   (when state-string
     (cond
      ((string-match "\\!" state-string) 'pending)

--- a/lisp/ledger-texi.el
+++ b/lisp/ledger-texi.el
@@ -18,6 +18,8 @@
 ;; along with GNU Emacs; see the file COPYING.  If not, write to the
 ;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 ;; MA 02110-1301 USA.
+;;; Code:
+(defvar ledger-binary-path)
 
 (defgroup ledger-texi nil
   "Options for working on Ledger texi documentation"

--- a/lisp/ledger-xact.el
+++ b/lisp/ledger-xact.el
@@ -31,6 +31,10 @@
 
 (defvar ledger-year)
 (defvar ledger-month)
+(declare-function ledger-read-date "ledger-mode" (prompt))
+(declare-function ledger-next-amount "ledger-post" (&optional end))
+(declare-function ledger-exec-ledger "ledger-exec" (input-buffer &optional output-buffer &rest args))
+(declare-function ledger-post-align-postings "ledger-post" (&optional beg end))
 
 ;; TODO: This file depends on code in ledger-mode.el, which depends on this.
 

--- a/lisp/ledger-xact.el
+++ b/lisp/ledger-xact.el
@@ -28,6 +28,10 @@
 (require 'eshell)
 (require 'ledger-regex)
 (require 'ledger-navigate)
+
+(defvar ledger-year)
+(defvar ledger-month)
+
 ;; TODO: This file depends on code in ledger-mode.el, which depends on this.
 
 (defcustom ledger-highlight-xact-under-point t

--- a/lisp/ledger-xact.el
+++ b/lisp/ledger-xact.el
@@ -127,6 +127,7 @@ MOMENT is an encoded date"
       (forward-line))))
 
 (defun ledger-year-and-month ()
+	"Return the current year and month, separated by / (or -, depending on LEDGER-USE-ISO-DATES)."
   (let ((sep (if ledger-use-iso-dates
                  "-"
                "/")))


### PR DESCRIPTION
These commits fix all current warnings when byte-compiling on Emacs 24.4.50.2. Mostly they defvar and declare-function various symbols.
[emacs] [ci skip]