### PR TITLE
Fix clang compile error (FreeBSD 10).

### DIFF
--- a/src/output.cc
+++ b/src/output.cc
@@ -291,7 +291,7 @@ void report_accounts::flush()
 
 void report_accounts::operator()(post_t& post)
 {
-  std::map<account_t *, std::size_t>::iterator i = accounts.find(post.account);
+  accounts_report_map::iterator i = accounts.find(post.account);
   if (i == accounts.end())
     accounts.insert(accounts_pair(post.account, 1));
   else
@@ -362,7 +362,7 @@ void report_commodities::operator()(post_t& post)
   amount_t temp(post.amount.strip_annotations(report.what_to_keep()));
   commodity_t& comm(temp.commodity());
 
-  std::map<commodity_t *, std::size_t>::iterator i = commodities.find(&comm);
+  commodities_report_map::iterator i = commodities.find(&comm);
   if (i == commodities.end())
     commodities.insert(commodities_pair(&comm, 1));
   else
@@ -371,7 +371,7 @@ void report_commodities::operator()(post_t& post)
   if (comm.has_annotation()) {
     annotated_commodity_t& ann_comm(as_annotated_commodity(comm));
     if (ann_comm.details.price) {
-      std::map<commodity_t *, std::size_t>::iterator ii =
+      commodities_report_map::iterator ii =
         commodities.find(&ann_comm.details.price->commodity());
       if (ii == commodities.end())
         commodities.insert

--- a/src/output.h
+++ b/src/output.h
@@ -142,9 +142,10 @@ class report_accounts : public item_handler<post_t>
 protected:
   report_t& report;
 
-  std::map<account_t *, std::size_t, account_compare> accounts;
-
   typedef std::map<account_t *, std::size_t>::value_type accounts_pair;
+  typedef std::map<account_t *, std::size_t, account_compare> accounts_report_map;
+
+  accounts_report_map accounts;
 
 public:
   report_accounts(report_t& _report) : report(_report) {
@@ -221,9 +222,10 @@ class report_commodities : public item_handler<post_t>
 protected:
   report_t& report;
 
-  std::map<commodity_t *, std::size_t, commodity_compare> commodities;
-
   typedef std::map<commodity_t *, std::size_t>::value_type commodities_pair;
+  typedef std::map<commodity_t *, std::size_t, commodity_compare> commodities_report_map;
+
+  commodities_report_map commodities;
 
 public:
   report_commodities(report_t& _report) : report(_report) {


### PR DESCRIPTION
Hi @afh.
I hope this is a last try. :)
Here the compile error output, as you want:
===>>> Port directory: /usr/ports/finance/ledger

===>>> Gathering distinfo list for installed ports

===>>> Launching 'make checksum' for finance/ledger in background
===>>> Gathering dependency list for finance/ledger from ports
===>>> Initial dependency check complete for finance/ledger


===>>> Starting build for finance/ledger <<<===

===>>> All dependencies are up to date

===>  Cleaning for ledger-3.1
===>  License BSD3CLAUSE accepted by the user
===>   ledger-3.1 depends on file: /usr/local/sbin/pkg - found
===> Fetching all distfiles required by ledger-3.1 for building
===>  Extracting for ledger-3.1
=> SHA256 Checksum OK for ledger-3.1.tar.gz.
===>  Patching for ledger-3.1
===>   ledger-3.1 depends on file: /usr/local/include/utf8.h - found
===>   ledger-3.1 depends on file: /usr/local/bin/cmake - found
===>   ledger-3.1 depends on shared library: libgmp.so - found (/usr/local/lib/libgmp.so.10.1.3)
===>   ledger-3.1 depends on shared library: libmpfr.so - found (/usr/local/lib/libmpfr.so.4.1.2)
===>   ledger-3.1 depends on shared library: libedit.so.0 - found (/usr/local/lib/libedit.so.0.0.52)
===>   ledger-3.1 depends on shared library: libboost_system.so - found (/usr/local/lib/libboost_system.so.1.55.0)
===>  Configuring for ledger-3.1
===>  Performing in-source build
/bin/mkdir -p /usr/ports/finance/ledger/work/ledger-ledger-9df7fd4
-- The C compiler identification is Clang 3.3.0
-- The CXX compiler identification is Clang 3.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PythonInterp: /usr/local/bin/python2.7 (found version "2.7.6")
-- Boost version: 1.55.0
-- Found the following Boost libraries:
--   date_time
--   filesystem
--   system
--   iostreams
--   regex
--   unit_test_framework
-- Looking for access
-- Looking for access - found
-- Looking for realpath
-- Looking for realpath - found
-- Looking for getpwuid
-- Looking for getpwuid - found
-- Looking for getpwnam
-- Looking for getpwnam - found
-- Looking for isatty
-- Looking for isatty - found
-- Performing Test UNIX_PIPES_COMPILES
-- Performing Test UNIX_PIPES_COMPILES - Success
-- Performing Test BOOST_REGEX_UNICODE_RUNS
-- Performing Test BOOST_REGEX_UNICODE_RUNS - Failed
-- Looking for readline in edit
-- Looking for readline in edit - found
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_CXX_FLAGS_DEBUG
    CMAKE_C_FLAGS_DEBUG
    CMAKE_C_FLAGS_RELEASE
    CMAKE_MODULE_LINKER_FLAGS
    THREADS_HAVE_PTHREAD_ARG


-- Build files have been written to: /usr/ports/finance/ledger/work/ledger-ledger-9df7fd4
===>  Building for ledger-3.1
Scanning dependencies of target libledger
[  1%] Building CXX object src/CMakeFiles/libledger.dir/stats.cc.o
[  3%] Building CXX object src/CMakeFiles/libledger.dir/generate.cc.o
[  5%] Building CXX object src/CMakeFiles/libledger.dir/csv.cc.o
[  6%] Building CXX object src/CMakeFiles/libledger.dir/convert.cc.o
[  8%] Building CXX object src/CMakeFiles/libledger.dir/draft.cc.o
[ 10%] Building CXX object src/CMakeFiles/libledger.dir/emacs.cc.o
[ 11%] Building CXX object src/CMakeFiles/libledger.dir/org.cc.o
[ 13%] Building CXX object src/CMakeFiles/libledger.dir/ptree.cc.o
[ 15%] Building CXX object src/CMakeFiles/libledger.dir/print.cc.o
[ 16%] Building CXX object src/CMakeFiles/libledger.dir/output.cc.o
```
/usr/ports/finance/ledger/work/ledger-ledger-9df7fd4/src/output.cc:294:48: error: no viable conversion from '__map_iterator<__tree_iterator<union std::__1::map<class ledger::account_t *, unsigned long, struct ledger::account_compare, class std::__1::allocator<struct std::__1::pair<class ledger::account_t *const, unsigned long> > >::__value_type, class std::__1::__tree_node<union std::__1::map<class ledger::account_t *, unsigned long, struct ledger::account_compare, class std::__1::allocator<struct std::__1::pair<class ledger::account_t *const, unsigned long> > >::__value_type, void *> *, [...]>>' to '__map_iterator<__tree_iterator<union std::__1::map<class ledger::account_t *, unsigned long, struct std::__1::less<class ledger::account_t *>, class std::__1::allocator<struct std::__1::pair<class ledger::account_t *const, unsigned long> > >::__value_type, class std::__1::__tree_node<union std::__1::map<class ledger::account_t *, unsigned long, struct std::__1::less<class ledger::account_t *>, class std::__1::allocator<struct std::__1::pair<class ledger::account_t *const, unsigned long> > >::__value_type, void *> *, [...]>>'
  std::map<account_t *, std::size_t>::iterator i = accounts.find(post.account);
                                               ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/map:499:24: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'const std::__1::__map_iterator<std::__1::__tree_iterator<std::__1::map<ledger::account_t *, unsigned long, std::__1::less<ledger::account_t *>, std::__1::allocator<std::__1::pair<ledger::account_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::account_t *, unsigned long, std::__1::less<ledger::account_t *>, std::__1::allocator<std::__1::pair<ledger::account_t *const, unsigned long> > >::__value_type, void *> *, long> > &' for 1st argument
class _LIBCPP_TYPE_VIS __map_iterator
                       ^
/usr/include/c++/v1/map:499:24: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__map_iterator<std::__1::__tree_iterator<std::__1::map<ledger::account_t *, unsigned long, std::__1::less<ledger::account_t *>, std::__1::allocator<std::__1::pair<ledger::account_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::account_t *, unsigned long, std::__1::less<ledger::account_t *>, std::__1::allocator<std::__1::pair<ledger::account_t *const, unsigned long> > >::__value_type, void *> *, long> > &&' for 1st argument
class _LIBCPP_TYPE_VIS __map_iterator
                       ^
/usr/include/c++/v1/map:523:5: note: candidate constructor not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__tree_iterator<std::__1::map<ledger::account_t *, unsigned long, std::__1::less<ledger::account_t *>, std::__1::allocator<std::__1::pair<ledger::account_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::account_t *, unsigned long, std::__1::less<ledger::account_t *>, std::__1::allocator<std::__1::pair<ledger::account_t *const, unsigned long> > >::__value_type, void *> *, long>' for 1st argument
    __map_iterator(_TreeIterator __i) _NOEXCEPT : __i_(__i) {}
    ^
/usr/ports/finance/ledger/work/ledger-ledger-9df7fd4/src/output.cc:365:50: error: no viable conversion from '__map_iterator<__tree_iterator<union std::__1::map<class ledger::commodity_t *, unsigned long, struct ledger::commodity_compare, class std::__1::allocator<struct std::__1::pair<class ledger::commodity_t *const, unsigned long> > >::__value_type, class std::__1::__tree_node<union std::__1::map<class ledger::commodity_t *, unsigned long, struct ledger::commodity_compare, class std::__1::allocator<struct std::__1::pair<class ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, [...]>>' to '__map_iterator<__tree_iterator<union std::__1::map<class ledger::commodity_t *, unsigned long, struct std::__1::less<class ledger::commodity_t *>, class std::__1::allocator<struct std::__1::pair<class ledger::commodity_t *const, unsigned long> > >::__value_type, class std::__1::__tree_node<union std::__1::map<class ledger::commodity_t *, unsigned long, struct std::__1::less<class ledger::commodity_t *>, class std::__1::allocator<struct std::__1::pair<class ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, [...]>>'
  std::map<commodity_t *, std::size_t>::iterator i = commodities.find(&comm);
                                                 ^   ~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/map:499:24: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'const std::__1::__map_iterator<std::__1::__tree_iterator<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, long> > &' for 1st argument
class _LIBCPP_TYPE_VIS __map_iterator
                       ^
/usr/include/c++/v1/map:499:24: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__map_iterator<std::__1::__tree_iterator<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, long> > &&' for 1st argument
class _LIBCPP_TYPE_VIS __map_iterator
                       ^
/usr/include/c++/v1/map:523:5: note: candidate constructor not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__tree_iterator<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, long>' for 1st argument
    __map_iterator(_TreeIterator __i) _NOEXCEPT : __i_(__i) {}
    ^
/usr/ports/finance/ledger/work/ledger-ledger-9df7fd4/src/output.cc:374:54: error: no viable conversion from '__map_iterator<__tree_iterator<union std::__1::map<class ledger::commodity_t *, unsigned long, struct ledger::commodity_compare, class std::__1::allocator<struct std::__1::pair<class ledger::commodity_t *const, unsigned long> > >::__value_type, class std::__1::__tree_node<union std::__1::map<class ledger::commodity_t *, unsigned long, struct ledger::commodity_compare, class std::__1::allocator<struct std::__1::pair<class ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, [...]>>' to '__map_iterator<__tree_iterator<union std::__1::map<class ledger::commodity_t *, unsigned long, struct std::__1::less<class ledger::commodity_t *>, class std::__1::allocator<struct std::__1::pair<class ledger::commodity_t *const, unsigned long> > >::__value_type, class std::__1::__tree_node<union std::__1::map<class ledger::commodity_t *, unsigned long, struct std::__1::less<class ledger::commodity_t *>, class std::__1::allocator<struct std::__1::pair<class ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, [...]>>'
      std::map<commodity_t *, std::size_t>::iterator ii =
                                                     ^
/usr/include/c++/v1/map:499:24: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'const std::__1::__map_iterator<std::__1::__tree_iterator<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, long> > &' for 1st argument
class _LIBCPP_TYPE_VIS __map_iterator
                       ^
/usr/include/c++/v1/map:499:24: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__map_iterator<std::__1::__tree_iterator<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, long> > &&' for 1st argument
class _LIBCPP_TYPE_VIS __map_iterator
                       ^
/usr/include/c++/v1/map:523:5: note: candidate constructor not viable: no known conversion from 'iterator' (aka '__map_iterator<typename __base::iterator>') to 'std::__1::__tree_iterator<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, std::__1::__tree_node<std::__1::map<ledger::commodity_t *, unsigned long, std::__1::less<ledger::commodity_t *>, std::__1::allocator<std::__1::pair<ledger::commodity_t *const, unsigned long> > >::__value_type, void *> *, long>' for 1st argument
    __map_iterator(_TreeIterator __i) _NOEXCEPT : __i_(__i) {}
    ^
```
[ 18%] Building CXX object src/CMakeFiles/libledger.dir/precmd.cc.o
3 errors generated.
--- src/CMakeFiles/libledger.dir/output.cc.o ---
*** [src/CMakeFiles/libledger.dir/output.cc.o] Error code 1

make[3]: stopped in /usr/ports/finance/ledger/work/ledger-ledger-9df7fd4
1 error

make[3]: stopped in /usr/ports/finance/ledger/work/ledger-ledger-9df7fd4
--- src/CMakeFiles/libledger.dir/all ---
*** [src/CMakeFiles/libledger.dir/all] Error code 2

make[2]: stopped in /usr/ports/finance/ledger/work/ledger-ledger-9df7fd4
1 error

make[2]: stopped in /usr/ports/finance/ledger/work/ledger-ledger-9df7fd4
*** [all] Error code 2

make[1]: stopped in /usr/ports/finance/ledger/work/ledger-ledger-9df7fd4
1 error

make[1]: stopped in /usr/ports/finance/ledger/work/ledger-ledger-9df7fd4
===> Compilation failed unexpectedly.
Try to set MAKE_JOBS_UNSAFE=yes and rebuild before reporting the failure to
the maintainer.
*** Error code 1

Stop.
make: stopped in /usr/ports/finance/ledger

===>>> make failed for finance/ledger
===>>> Aborting update

===>>> Killing background jobs
Terminated

===>>> You can restart from the point of failure with this command line:
       portmaster <flags> finance/ledger

===>>> Exiting
