### PR TITLE
[emacs] Fix bug 1060.

### DIFF
--- a/doc/ledger-mode.texi
+++ b/doc/ledger-mode.texi
@@ -596,10 +596,16 @@ mark the transaction if appropriate.
 @node Finalize Reconciliation, Adding and Deleting Transactions during Reconciliation, Edit Transactions During Reconciliation, The Reconcile Buffer
 @section Finalize Reconciliation
 @cindex reconciliation, finalizing
+@kindex C-c C-c
+@kindex q
 
 Once you have marked all transactions as pending and the cleared balance
 is correct.  Finish the reconciliation by typing @kbd{C-c C-c}.  This
 marks all pending transactions as cleared and saves the ledger buffer.
+
+Type @kbd{q} to close out the reconciliation buffer. If variable
+@var{ledger-reconcile-finish-force-quit} is set, the reconciliation
+buffer will be killed automatically after @kbd{C-c C-c}.
 
 @node Adding and Deleting Transactions during Reconciliation, Changing Reconciliation Account, Finalize Reconciliation, The Reconcile Buffer
 @section Adding and Deleting Transactions during Reconciliation
@@ -985,6 +991,9 @@ ledger file order. Defaults to '(0)'.
 @item ledger-reconcile-insert-effective-date nil
 If t, prompt for effective date when clearing transactions during
 reconciliation.
+
+@item ledger-reconcile-finish-force-quit nil
+If t, will force closing reconcile window after @kbd{C-c C-c}.
 
 @end ftable
 

--- a/lisp/ledger-reconcile.el
+++ b/lisp/ledger-reconcile.el
@@ -118,6 +118,11 @@ Possible values are '(date)', '(amount)', '(payee)' or '(0)' for no sorting, i.e
   :type 'boolean
   :group 'ledger-reconcile)
 
+(defcustom ledger-reconcile-finish-force-quit nil
+  "If t, will force closing reconcile window after \\[ledger-reconcile-finish]."
+  :type 'boolean
+  :group 'ledger-reconcile)
+
 ;; s-functions below are copied from Magnars' s.el
 ;; prefix ledger-reconcile- is added to not conflict with s.el
 (defun ledger-reconcile-s-pad-left (len padding s)
@@ -314,7 +319,7 @@ Return the number of uncleared xacts found."
 (defun ledger-reconcile-finish ()
   "Mark all pending posting or transactions as cleared.
 Depends on ledger-reconcile-clear-whole-transactions, save the buffers
-and exit reconcile mode"
+and exit reconcile mode if `ledger-reconcile-finish-force-quit'"
   (interactive)
   (save-excursion
     (goto-char (point-min))
@@ -327,7 +332,8 @@ and exit reconcile mode"
               (ledger-toggle-current 'cleared))))
       (forward-line 1)))
   (ledger-reconcile-save)
-  (ledger-reconcile-quit))
+  (when ledger-reconcile-finish-force-quit
+    (ledger-reconcile-quit)))
 
 
 (defun ledger-reconcile-quit ()


### PR DESCRIPTION
Set as an option to kill (or not) the reconcile buffer after
ledger-reconcile-finish.  The default is set to *not* kill the
buffer. This is justified as the facts that:

1. In old ledger mode (the one from Ledger 2.6), the default is to *not*
kill the buffer. Also for the ones who will migrate from 2.6 to 3 when
package will be available in their linux distribution, this will be the
path of least surprise.
2. The current documentation does state that the buffer is to be killed
with 'q' after 'C-c C-c'.

This has been made configurable, as killing buffer may already be part
of the workflow of some persons.

[ci skip]