### PR TITLE
link ledger executable to Python on OS X

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -273,6 +273,9 @@ if (BUILD_LIBRARY)
 
   add_executable(ledger main.cc global.cc)
   target_link_libraries(ledger libledger)
+  if (APPLE AND HAVE_BOOST_PYTHON)
+    target_link_libraries(ledger ${PYTHON_LIBRARIES})
+  endif()
 
   install(TARGETS libledger DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(FILES ${LEDGER_INCLUDES}


### PR DESCRIPTION
#415 was slightly incorrect; I didn't appreciate that the `ledger` executable embeds a Python interpreter (for `ledger python`, I guess).

Since the ledger executable embeds a Python interpreter, it does need an explicit link to a Python framework on OS X after all.

The dynamic library (which is simply copied into the Python site-packages as the importable module) does not need this link.

This change adds the library linkage back to the `ledger` executable but not the shared library.

It's a little ungainly that the Python stuff is spread out between a couple of different CMakeLists now, I think; I'd be happy to apply some refactoring if there are suggestions.