### PR TITLE
Fix ledger-magic-tab: Wrong number of arguments

### DIFF
--- a/lisp/ledger-mode.el
+++ b/lisp/ledger-mode.el
@@ -159,7 +159,7 @@ Can indent, complete or align depending on context."
     (if (and (> (point) 1)
              (looking-back "\\([^ \t]\\)" 1))
         (ledger-pcomplete interactively)
-      (ledger-post-align-postings))))
+      (ledger-post-align-postings (line-beginning-position) (line-end-position)))))
 
 (defvar ledger-mode-abbrev-table)
 


### PR DESCRIPTION
ledger-post-align-postings expects (beg end) not to be optional