### PR TITLE
Emacs: Only reconcile real balances

### DIFF
--- a/lisp/ledger-reconcile.el
+++ b/lisp/ledger-reconcile.el
@@ -171,7 +171,7 @@ Possible values are '(date)', '(amount)', '(payee)' or '(0)' for no sorting, i.e
     ;; split arguments like the shell does, so you need to
     ;; specify the individual fields in the command line.
     (if (ledger-exec-ledger buffer (current-buffer)
-                            "balance" "--limit" "cleared or pending" "--empty" "--collapse"
+                            "balance" "--limit" "cleared or pending" "--empty" "--collapse" "--real"
                             "--format" "%(scrub(display_total))" account)
         (ledger-split-commodity-string
          (buffer-substring-no-properties (point-min) (point-max))))))


### PR DESCRIPTION
Use only real transactions when calculating the cleared or pending balance.

With this, the cleared/pending amount will reach 0 once all real transactions are correctly reconciled,
whereas it would previously be off by the total of all virtual transactions.