### PR TITLE
Fix xact-find-slot at end of buffer

### DIFF
--- a/lisp/ledger-xact.el
+++ b/lisp/ledger-xact.el
@@ -89,9 +89,8 @@ MOMENT is an encoded date"
     (when (and (eobp) last-xact-start)
       (let ((end (cadr (ledger-navigate-find-xact-extents last-xact-start))))
         (goto-char end)
-        (if (eobp)
-            (insert "\n")
-          (forward-line))))))
+        (insert "\n")
+        (forward-line)))))
 
 (defun ledger-xact-iterate-transactions (callback)
   "Iterate through each transaction call CALLBACK for each."


### PR DESCRIPTION
Using `ledger-add-transaction` to add a transaction with a date that places it at the end of the buffer will "forget" to insert the newline between it and the previous transaction. This error occurs in `ledger-xact-find-slot` where the `(when (and (eobp) last-xact-start)` is entered, but subsequently the `(if (eobp))` is false because the point has been moved to the end of the prior exact, which is not the end of the buffer.

The `if` expression is superfluous because the `when` expression has already been entered, and it is broken becase the point gets moved. Removing it fixes the behavior for transactions added at the end
of the buffer, and does not break the behavior for transactions added elsewhere.

This was observed with Emacs 24.5.50.1 and Ledger 3.1.0-20141005.

Please verify this issue exists not just on my system, and that there is not a better fix (perhaps the point is meant to be moved elsewhere, I'm not sure). It would also be nice to know where this issue was introduced, so I might `git bisect` it later. My Emacs and Ledger installations are from source, so I'll get them updated and test further.