### PR TITLE
Add dwim align

### DIFF
--- a/lisp/ledger-mode.el
+++ b/lisp/ledger-mode.el
@@ -285,6 +285,7 @@ With a prefix argument, remove the effective date."
 
     (define-key map [(meta ?p)] 'ledger-navigate-prev-xact-or-directive)
     (define-key map [(meta ?n)] 'ledger-navigate-next-xact-or-directive)
+    (define-key map [(meta ?q)] 'ledger-post-align-dwim)
     map)
   "Keymap for `ledger-mode'.")
 

--- a/lisp/ledger-post.el
+++ b/lisp/ledger-post.el
@@ -146,6 +146,13 @@ at beginning of account"
           (setq lines-left (not (eobp)))))
       (setq inhibit-modification-hooks nil))))
 
+(defun ledger-post-align-dwim ()
+  "Align all the posting of the current xact the current region."
+  (interactive)
+  (if (use-region-p)
+      (call-interactively 'ledger-post-align-postings)
+    (call-interactively 'ledger-post-align-xact)))
+
 (defun ledger-post-edit-amount ()
   "Call 'calc-mode' and push the amount in the posting to the top of stack."
   (interactive)


### PR DESCRIPTION
This patch adds two changes:

1. Add a function to dwim (do what I mean) align: if no region is active, align the xact under the point, if a region is active, align that region.
2. Bind this function to `M-q`.  This might be controversial so I put it in a separate patch, but I think it is a very reasonable idea to replace `fill-paragraph` with something that actually makes sense in ledger mode.