### PR TITLE
Fill comment paragraph with ledger-post-align-dwim

### DIFF
--- a/lisp/ledger-post.el
+++ b/lisp/ledger-post.el
@@ -147,11 +147,17 @@ at beginning of account"
       (setq inhibit-modification-hooks nil))))
 
 (defun ledger-post-align-dwim ()
-  "Align all the posting of the current xact the current region."
+  "Align all the posting of the current xact or the current region.
+
+If the point is in a comment, fill the comment paragraph as
+regular text."
   (interactive)
-  (if (use-region-p)
-      (call-interactively 'ledger-post-align-postings)
-    (call-interactively 'ledger-post-align-xact)))
+  (cond
+   ((nth 4 (syntax-ppss))
+    (call-interactively 'ledger-post-align-postings)
+    (fill-paragraph))
+   ((use-region-p) (call-interactively 'ledger-post-align-postings))
+   (t (call-interactively 'ledger-post-align-xact))))
 
 (defun ledger-post-edit-amount ()
   "Call 'calc-mode' and push the amount in the posting to the top of stack."


### PR DESCRIPTION
In addition to re-aligning postings, if the point is in a comment, just
fill that comment as regular plaintext.

(cf. #431)