### PR TITLE
Align amounts on the decimal separator.

### DIFF
--- a/lisp/ledger-post.el
+++ b/lisp/ledger-post.el
@@ -79,8 +79,7 @@ point at beginning of the commodity."
     (when (re-search-forward ledger-amount-regex end t)
       (goto-char (match-beginning 0))
       (skip-syntax-forward " ")
-      (- (or (match-end 4)
-             (match-end 3)) (point)))))
+      (- (match-end 3) (point)))))
 
 (defun ledger-next-account (&optional end)
   "Move to the beginning of the posting, or status marker, limit to END.

--- a/lisp/ledger-regex.el
+++ b/lisp/ledger-regex.el
@@ -27,8 +27,14 @@
 (defconst ledger-amount-regex
   (concat "\\(  \\|\t\\| \t\\)[ \t]*-?"
           "\\([A-Z$€£₹_(]+ *\\)?"
-          "\\(-?[0-9,]+\\)"
-          "\\(\\.[0-9)]+\\)?"
+          ;; We either match just a number after the commodity with no
+          ;; decimal or thousand separators or a number with thousand
+          ;; separators.  If we have a decimal part starting with `,'
+          ;; or `.', because the match is non-greedy, it must leave at
+          ;; least one of those symbols for the following capture
+          ;; group, which then finishes the decimal part.
+          "\\(-?\\(?:[0-9]+\\|[0-9,.]+?\\)\\)"
+          "\\([,.][0-9)]+\\)?"
           "\\( *[[:word:]€£₹_\"]+\\)?"
           "\\([ \t]*[@={]@?[^\n;]+?\\)?"
           "\\([ \t]+;.+?\\|[ \t]*\\)?$"))


### PR DESCRIPTION
That is:

    A   $10.00
    B    $5
    C  -$15.00

Before the numbers aligned at the end of the last digit.

@thdox reported this issue to me.  My last align patch broke `,` as decimal separator, that is also fixed.  The bejaviour I "benchmarked" my patch against was master which aligned numbers on the last digit:

    A   $10.00
    B       $5
    C  -$15.00

We both found that undersirable.

If anyone has some edge-cases they feel like we should check, please share :)