### PR TITLE
Balance at point and target commodity

### DIFF
--- a/lisp/ledger-commodities.el
+++ b/lisp/ledger-commodities.el
@@ -33,6 +33,16 @@
   :type 'string
   :group 'ledger-reconcile)
 
+(defun ledger-read-commodity-with-prompt (prompt)
+  "Read commodity name after PROMPT.
+
+Default value is `ledger-reconcile-default-commodity'."
+  (let* ((buffer (current-buffer))
+         (commodities (with-temp-buffer
+                        (ledger-exec-ledger buffer (current-buffer) "commodities")
+                        (split-string (buffer-string) "\n" t))))
+    (completing-read prompt commodities nil t nil nil ledger-reconcile-default-commodity)))
+
 (defun ledger-split-commodity-string (str)
   "Split a commoditized string, STR, into two parts.
 Returns a list with (value commodity)."

--- a/lisp/ledger-mode.el
+++ b/lisp/ledger-mode.el
@@ -125,14 +125,19 @@
                          ": "))
                nil 'ledger-minibuffer-history default))
 
-(defun ledger-display-balance-at-point ()
+(defun ledger-display-balance-at-point (&optional arg)
   "Display the cleared-or-pending balance.
-And calculate the target-delta of the account being reconciled."
-  (interactive)
+And calculate the target-delta of the account being reconciled.
+
+With prefix argument \\[universal-argument] ask for the target commodity and convert
+the balance into that."
+  (interactive "P")
   (let* ((account (ledger-read-account-with-prompt "Account balance to show"))
+         (target-commodity (when arg (ledger-read-commodity-with-prompt "Target commodity: ")))
          (buffer (current-buffer))
          (balance (with-temp-buffer
-                    (ledger-exec-ledger buffer (current-buffer) "cleared" account)
+                    (apply 'ledger-exec-ledger buffer (current-buffer) "cleared" account
+                            (when target-commodity (list "-X" target-commodity)))
                     (if (> (buffer-size) 0)
                         (buffer-substring-no-properties (point-min) (1- (point-max)))
                       (concat account " is empty.")))))


### PR DESCRIPTION
I often spend to the same account from different currencies (I go back and forth from Euro to non-Euro countries), so the quick balance often gets complex and unreadable.

This patch adds two functions:

1. A general facility to ask user for a commodity name
2. Adds `C-u` to `ledger-display-balance-at-point` which causes it to ask for the target commodity and append `-X` switch to the ledger command produced.