### PR TITLE
Changed drewr.dat to drewr3.dat in docs

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -10152,7 +10152,7 @@ is now @env{LEDGER_PRICE_EXP}.
 @appendix Example Journal File
 
 The following journal file is included with the source distribution of
-ledger.  It is called @file{drewr.dat} and exhibits many ledger
+ledger.  It is called @file{drewr3.dat} and exhibits many ledger
 features, include automatic and virtual transactions,
 
 @smallexample @c input:validate
@@ -10161,64 +10161,71 @@ features, include automatic and virtual transactions,
 = /^Income/
   (Liabilities:Tithe)                    0.12
 
-~ Monthly
-  Assets:Checking                     $500.00
-  Income:Salary
+;~ Monthly
+;  Assets:Checking                     $500.00
+;  Income:Salary
 
-2003/12/01 * Checking balance
+;~ Monthly
+;   Expenses:Food  $100
+;   Assets
+
+2010/12/01 * Checking balance
   Assets:Checking                   $1,000.00
   Equity:Opening Balances
 
-2003/12/20 Organic Co-op
-  Expenses:Food:Groceries             $ 37.50  ; [=2004/01/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2004/02/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2004/03/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2004/04/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2004/05/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2004/06/01]
+2010/12/20 * Organic Co-op
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/01/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/02/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/03/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/04/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/05/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/06/01]
   Assets:Checking                   $ -225.00
 
-2003/12/28=2004/01/01 Acme Mortgage
+2010/12/28=2011/01/01 Acme Mortgage
   Liabilities:Mortgage:Principal    $  200.00
   Expenses:Interest:Mortgage        $  500.00
   Expenses:Escrow                   $  300.00
   Assets:Checking                  $ -1000.00
 
-2004/01/02 Grocery Store
+2011/01/02 Grocery Store
   Expenses:Food:Groceries             $ 65.00
   Assets:Checking
 
-2004/01/05 Employer
+2011/01/05 Employer
   Assets:Checking                   $ 2000.00
   Income:Salary
 
-2004/01/14 Bank
+2011/01/14 Bank
   ; Regular monthly savings transfer
   Assets:Savings                     $ 300.00
   Assets:Checking
 
-2004/01/19 Grocery Store
-  Expenses:Food:Groceries             $ 44.00
+2011/01/19 Grocery Store
+  Expenses:Food:Groceries             $ 44.00 ; hastag: not block
   Assets:Checking
 
-2004/01/25 Bank
+2011/01/25 Bank
   ; Transfer to cover car purchase
   Assets:Checking                  $ 5,500.00
   Assets:Savings
   ; :nobudget:
 
-2004/01/25 Tom's Used Cars
+apply tag hastag: true
+apply tag nestedtag: true
+2011/01/25 Tom's Used Cars
   Expenses:Auto                    $ 5,500.00
   ; :nobudget:
   Assets:Checking
 
-2004/01/27 Book Store
+2011/01/27 Book Store
   Expenses:Books                       $20.00
   Liabilities:MasterCard
-
-2004/02/01 Sale
+end tag
+2011/12/01 Sale
   Assets:Checking:Business            $ 30.00
   Income:Sales
+end tag
 @end smallexample
 
 @node Miscellaneous Notes, Concepts Index, Example Journal File, Top


### PR DESCRIPTION
I had a problem when going through the tutorial portion of the ledger manual. It was easier for me to cut and paste from the manual to generate the tutorial journal file (drewr3.dat) instead of using the file from the repo itself. However, when I did so, I encountered a run-time error during the 2.2.3 Cleared Report section. After trying to track down what was going on, I realized that the example journal in the manual was actually drewr.dat and not drewr3.dat. So this pull request is to fix the docs so that the example journal is actually drewr3.dat. However, I actually think you should disregard this pull request and fix this problem in a more elegant fashion. Because drewr3.dat has commented out sections and tags that may or may not aid comprehension for the new ledger user (and I just cut and paste drewr3.dat into the docs). 