### PR TITLE
[python] Remove double quotes from unicode values

### DIFF
--- a/src/py_value.cc
+++ b/src/py_value.cc
@@ -325,7 +325,6 @@ void export_value()
     .def("to_mask", &value_t::to_mask)
     .def("to_sequence", &value_t::to_sequence)
 
-    .def("__unicode__", py_dump_relaxed)
     .def("__repr__", py_dump)
 
     .def("casted", &value_t::casted)

--- a/test/regress/B21BF389.py
+++ b/test/regress/B21BF389.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, unicode_literals
+
+import ledger
+
+for post in ledger.read_journal(__file__.replace(".py", "_py.test")).query("income"):
+  print(unicode(post.tag("Reference")))

--- a/test/regress/B21BF389_py.test
+++ b/test/regress/B21BF389_py.test
@@ -1,0 +1,8 @@
+2016/01/11 * Employer
+  Assets:Checking
+  Income:Salary                 € 1.500,00
+    ; Reference: Christmas bonus
+
+test python test/regress/B21BF389.py
+Christmas bonus
+end test


### PR DESCRIPTION
When converting a `ledger.Value` to unicode the Python API added
double quotes around it.

It looks like a bug that was introduced in d5e95720, @jwiegley would you mind having a look please.

To me it does not make sense to have a second `.def("__unicode__", py_dump_relaxed)` in `src/py_value.cc:323` that overwrites the previous `.def("__unicode__", py_value_unicode)` in `src/py_value.cc:317` (see [`src/py_value.cc:317ff`](https://github.com/ledger/ledger/commit/d5e95720#diff-20451a5ff4ce15ef3adc1ad28121d16aR317) or `git show d5e95720:src/py_value.cc | nl -ba | sed -ne '315,325p'`).