### PR TITLE
[doc] Add "Dependency" anchor link to quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ and easy to use.
 
 ## For the Impatient
 
-I know, you just want to build and play.  If you have all the dependencies
-installed (see below), then simply do this:
+I know, you just want to build and play.  If you have all the [dependencies](#dependencies)
+installed, then simply do this:
 
     $ git clone git://github.com/ledger/ledger.git
     $ cd ledger && ./acprep update  # Update to the latest, configure, make


### PR DESCRIPTION
The quick start section is already called "For the Impatient", and this
minor doc tweak should decrease the time and effort demanded of a
new user before their first run by a very tiny amount, and it makes the
README a touch more cohesive.

[ci skip]