### PR TITLE
Ensure that parse errors produce useful RuntimeErrors for Python code.

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -70,6 +70,7 @@ public:
   std::size_t      errors;
   std::size_t      count;
   std::size_t      sequence;
+  std::string      last;
 
   explicit parse_context_t(const path& cwd)
     : current_directory(cwd), master(NULL), scope(NULL),

--- a/src/error.h
+++ b/src/error.h
@@ -95,8 +95,9 @@ string source_context(const path&            file,
 
 struct error_count {
   std::size_t count;
-  explicit error_count(std::size_t _count) : count(_count) {}
-  const char * what() const { return ""; }
+  std::string message;
+  explicit error_count(std::size_t _count, std::string _msg) : count(_count), message(_msg) {}
+  const char * what() const { return message.c_str(); }
 };
 
 } // namespace ledger

--- a/src/global.h
+++ b/src/global.h
@@ -166,7 +166,7 @@ See LICENSE file included with the distribution for details and disclaimer.");
 
   OPTION_(global_scope_t, version, DO() { // -v
       parent->show_version_info(std::cout);
-      throw error_count(0);     // exit immediately
+      throw error_count(0, "");     // exit immediately
     });
 };
 

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -282,6 +282,10 @@ void instance_t::parse()
 
       std::cerr << _("Error: ") << err.what() << std::endl;
       context.errors++;
+      if (! current_context.empty())
+          context.last = current_context + "\n" + err.what();
+      else
+          context.last = err.what();
     }
   }
 
@@ -1998,7 +2002,8 @@ std::size_t journal_t::read_textual(parse_context_stack_t& context_stack)
   TRACE_FINISH(parsing_total, 1);
 
   if (context_stack.get_current().errors > 0)
-    throw error_count(context_stack.get_current().errors);
+    throw error_count(context_stack.get_current().errors,
+                      context_stack.get_current().last);
 
   return context_stack.get_current().count;
 }

--- a/test/python/JournalTest.py
+++ b/test/python/JournalTest.py
@@ -22,6 +22,24 @@ class JournalTestCase(unittest.TestCase):
         for post in journal.query("food"):
             self.assertEqual(str(post.account), "Expenses:Food")
             self.assertEqual(post.amount, Amount("$21.34"))
+
+    def testParseError(self):
+        # TODO: ledger spits out parse errors to standard out.
+        # This should not happen, especially when the error
+        # has already been captured by a Python exception.
+        def fun():
+            read_journal_from_string("""
+2012-03-01 KFC
+    Expenses:Food  rsnetnirsnti
+    Assets:Cash
+""")
+        self.assertRaises(RuntimeError, fun)
+        try:
+            fun()
+        except RuntimeError as e:
+            self.assertEquals(str(e).splitlines()[-1],
+                              "No quantity specified for amount")
+
  
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(JournalTestCase)


### PR DESCRIPTION
Parse errors from Python produce RuntimeErrors that str() eval to "".

That is obviously wrong.

This pull request adds the latest context error message to the exception.