### PR TITLE
Use interval start date (period from/since) to initialize first period.

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -982,10 +982,12 @@ void interval_posts::flush()
   std::stable_sort(all_posts.begin(), all_posts.end(),
                    sort_posts_by_date());
 
-  // Determine the beginning interval by using the earliest post
-  if (all_posts.size() > 0 && all_posts.front() &&
-      ! interval.find_period(all_posts.front()->date()))
-    throw_(std::logic_error, _("Failed to find period for interval report"));
+  // only if the interval has no start use the earliest post
+  if (!(interval.begin() && interval.find_period(*interval.begin())))
+    // Determine the beginning interval by using the earliest post
+    if (all_posts.size() > 0 && all_posts.front()
+        && !interval.find_period(all_posts.front()->date()))
+      throw_(std::logic_error, _("Failed to find period for interval report"));
 
   // Walk the interval forward reporting all posts within each one
   // before moving on, until we reach the end of all_posts

--- a/test/regress/1159.test
+++ b/test/regress/1159.test
@@ -1,0 +1,29 @@
+2003/09/13 a payee ; sat
+    A  $100.00
+    B
+
+2003/09/14 a payee ; mon
+    A  $100.00
+    B
+    
+2004/10/15 a payee ; fri
+    A  $50.00
+    B
+
+2004/10/19 a payee ; tue
+    A  $50.00
+    B
+
+;sun first day of month
+test reg -p "every 12 months from 2001/04/01" 
+03-Apr-01 - 04-Mar-31           A                           $200.00      $200.00
+                                B                          $-200.00            0
+04-Apr-01 - 05-Mar-31           A                           $100.00      $100.00
+                                B                          $-100.00            0
+end test
+test reg -p 'every 12 months'
+03-Sep-01 - 04-Aug-31           A                           $200.00      $200.00
+                                B                          $-200.00            0
+04-Sep-01 - 05-Aug-31           A                           $100.00      $100.00
+                                B                          $-100.00            0
+end test


### PR DESCRIPTION
This allows the offset of a period start to be specified

-p 'every 12 months from 2000-04-01'

will have periods

yyyy-04-01 to yyyy-03-31
....

If no from/since is specified for the period the first transaction date reported is used to initialize the period as before.