### PR TITLE
Fix Bug 1147: Check balance assertions against the amount AFTER

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1671,24 +1671,26 @@ post_t * instance_t::parse_post(char *          line,
         break;
       }
 
-      amount_t tot = amt - diff;
-
       DEBUG("post.assign",
             "line " << context.linenum << ": " << "diff = " << diff);
       DEBUG("textual.parse", "line " << context.linenum << ": "
             << "POST assign: diff = " << diff);
 
-      if (! diff.is_zero()) {
-        if (! post->amount.is_null()) {
-          diff -= post->amount;
-          if (! no_assertions && ! diff.is_zero())
-            throw_(parse_error,
-                   _f("Balance assertion off by %1% (expected to see %2%)")
-                   % diff % tot);
-        } else {
+      if (post->amount.is_null()) {
+        // balance assignment
+        if (! diff.is_zero()) {
           post->amount = diff;
           DEBUG("textual.parse", "line " << context.linenum << ": "
                 << "Overwrite null posting");
+        }
+      } else {
+        // balance assertion
+        diff -= post->amount;
+        if (! no_assertions && ! diff.is_zero()) {
+          amount_t tot = amt - diff;
+          throw_(parse_error,
+                  _f("Balance assertion off by %1% (expected to see %2%)")
+                  % diff % tot);
         }
       }
 

--- a/test/baseline/feat-balance_assert-off.test
+++ b/test/baseline/feat-balance_assert-off.test
@@ -13,6 +13,6 @@ While parsing file "$FILE", line 8:
 While parsing posting:
   Assets:Cash          -$10 = $80
                               ^^^
-Error: Balance assertion off by $-10 (expected to see $100)
+Error: Balance assertion off by $-10 (expected to see $90)
 end test
 

--- a/test/baseline/feat-balance_assert_split.test
+++ b/test/baseline/feat-balance_assert_split.test
@@ -14,7 +14,7 @@
 
 2012-01-04 Test
     ; UUID: foo
-    Liabilities:MasterCard  $150.00 = $-300
+    Liabilities:MasterCard  $150.00 = $-150
     <Assets:Checking>
 
 2012-01-04 Test
@@ -24,7 +24,7 @@
 
 2012-01-04 Test
     ; UUID: baz
-    Liabilities:MasterCard  $150.00 = $0
+    Liabilities:MasterCard  $150.00 = $150
     <Assets:Checking>
 
 ;; b.dat

--- a/test/regress/1147-a.test
+++ b/test/regress/1147-a.test
@@ -1,0 +1,12 @@
+2000/01/01 Pre-transaction balance
+    A  $5.00 = $0.00
+    B
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 2:
+While parsing posting:
+  A  $5.00 = $0.00
+             ^^^^^
+Error: Balance assertion off by $-5.00 (expected to see $5.00)
+end test

--- a/test/regress/1147-b.test
+++ b/test/regress/1147-b.test
@@ -1,0 +1,10 @@
+2000/01/01 Post-transaction balance
+	A  $5.00 = $5.00
+	B
+
+test bal
+               $5.00  A
+              $-5.00  B
+--------------------
+                   0
+end test


### PR DESCRIPTION
Fixes [Bug 1147](http://bugs.ledger-cli.org/show_bug.cgi?id=1147)

- Made balance assertions succeed only against the amount _after_ the posting, not before.
- Changed the error message to reflect this (the expected value is the amount _after_).
- Added a regression test.