### PR TITLE
Set shebang line of acprep to python3

### DIFF
--- a/acprep
+++ b/acprep
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # acprep, version 3.1
 #


### PR DESCRIPTION
It uses the print() function and doesn't run on 2.x anyways...