### PR TITLE
Consider ISO dates in `ledger-read-date'.

### DIFF
--- a/lisp/ledger-init.el
+++ b/lisp/ledger-init.el
@@ -34,6 +34,8 @@
 
 (defvar ledger-default-date-format "%Y/%m/%d")
 
+(defvar ledger-iso-date-format "%Y-%m-%d")
+
 (defun ledger-init-parse-initialization (buffer)
   "Parse the .ledgerrc file in BUFFER."
   (with-current-buffer buffer

--- a/lisp/ledger-mode.el
+++ b/lisp/ledger-mode.el
@@ -115,7 +115,9 @@
             (string= "" date))
         (format-time-string
          (or (cdr (assoc "date-format" ledger-environment-alist))
-             ledger-default-date-format))
+             (if ledger-use-iso-dates
+                 ledger-iso-date-format
+               ledger-default-date-format)))
       date)))
 
 (defun ledger-read-string-with-default (prompt default)


### PR DESCRIPTION
I've set `ledger-use-iso-dates` to `t`, but when I add a new entry (with <kbd>C-C C-a</kbd>) followed by a press of <kbd>RET</kbd> to use today's date the format changes to the default format (in my case, because I have no `ledger-environment`). 

This PR extends `ledger-read-date` to use the `ledger-iso-date-format` variable (introduced by this very PR) if `ledger-use-iso-dates` is non-nil.

-Sebastian