### PR TITLE
inhibit read only when inserting in *Ledger Error*

### DIFF
--- a/lisp/ledger-exec.el
+++ b/lisp/ledger-exec.el
@@ -48,7 +48,8 @@
 (defun ledger-exec-handle-error (ledger-output)
   "Deal with ledger errors contained in LEDGER-OUTPUT."
   (with-current-buffer (get-buffer-create "*Ledger Error*")
-    (insert-buffer-substring ledger-output)
+    (let ((inhibit-read-only t))
+      (insert-buffer-substring ledger-output))
     (view-mode)
     (setq buffer-read-only t)))
 


### PR DESCRIPTION
When ledger-exec-handle-error is called a second time, it try to insert
the error in a buffer that is already read-only. inhibit-read-only
allow the insertion.
