### PR TITLE
Fix buildability on MSYS2/MinGW32.

### DIFF
--- a/src/global.cc
+++ b/src/global.cc
@@ -451,7 +451,7 @@ expr_t::func_t global_scope_t::look_for_command(scope_t&      scope,
 
 void global_scope_t::visit_man_page() const
 {
-#ifndef WIN32
+#if !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
   int pid = fork();
   if (pid < 0) {
     throw std::logic_error(_("Failed to fork child process"));

--- a/src/main.cc
+++ b/src/main.cc
@@ -74,7 +74,7 @@ int main(int argc, char * argv[], char * envp[])
 #endif
 
   std::signal(SIGINT, sigint_handler);
-#ifndef WIN32
+#if !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
   std::signal(SIGPIPE, sigpipe_handler);
 #endif
 

--- a/src/quotes.cc
+++ b/src/quotes.cc
@@ -62,7 +62,7 @@ commodity_quote_from_script(commodity_t& commodity,
   DEBUG("commodity.download", "invoking command: " << getquote_cmd);
 
   bool success = true;
-#ifndef WIN32
+#if !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
   if (FILE * fp = popen(getquote_cmd.c_str(), "r")) {
     if (std::feof(fp) || ! std::fgets(buf, 255, fp))
       success = false;

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -58,7 +58,7 @@ namespace {
    */
   int do_fork(std::ostream ** os, const path& pager_path)
   {
-#ifndef WIN32
+#if !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
     int pfd[2];
 
     int status = pipe(pfd);
@@ -115,7 +115,7 @@ void output_stream_t::initialize(const optional<path>& output_file,
 
 void output_stream_t::close()
 {
-#ifndef WIN32
+#if !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
   if (os != &std::cout) {
     checked_delete(os);
     os = &std::cout;

--- a/src/strptime.cc
+++ b/src/strptime.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-#ifdef WIN32
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 // Implement strptime under windows
 
 #include "strptime.h"

--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -144,7 +144,7 @@ typedef std::ostream::pos_type ostream_pos_type;
 #endif
 
 #include <sys/stat.h>
-#if defined(WIN32)
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 #include <io.h>
 #else
 #include <unistd.h>

--- a/src/times.cc
+++ b/src/times.cc
@@ -33,7 +33,7 @@
 
 #include "times.h"
 
-#ifdef WIN32
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 #include "strptime.h"
 #endif
 

--- a/test/unit/t_value.cc
+++ b/test/unit/t_value.cc
@@ -6,6 +6,10 @@
 
 #include "value.h"
 
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#include "strptime.h"
+#endif
+
 using namespace ledger;
 
 struct value_fixture {


### PR DESCRIPTION
The build process on MSYS2 is a lot easier than manually installing
Boost and using Visual Studio, in my opinion. However, the source was
not set up to build properly in this environment. When running `make` in
a standard MSYS2/MinGW32 environment, `WIN32` is not set, but `_WIN32`
and (maybe) `__WIN32__` are. Checking these along with the unqualified
version catches all the varieties of Windows builds.

`t_value`'s header was not set up to properly import the `strptime`
replacement on Windows, so it is added.

The process for building on MSYS is similar to the method for Visual
Studio documented in the Wiki. All the work is done from inside
the *32-bit* MinGW shell. The basic development pipeline, CMake, and
Boost all need to be installed (from inside MSYS and for the MinGW32
environment).

Run `cmake -G "MSYS Makefiles"` to create build files.

Edit `system.hh`, replacing all the blank `#define`s in the application
configuration section with `#define VARNAME 0`.

Set `HAVE_ISATTY` in `system.hh` to 0 as well; It's wrong.

Run `make`.

After building, `ledger.exe` should work fine from inside the MSYS
shell, but outside it needs dynamic access to some DLLs. Tracking down
exactly which ones is nasty; I used Dependency Walker for it. Note that
if you have Git for Windows installed on your PATH, libstdc++ will seem
like it exists, but as the wrong architecture. Put the 32 bit libstdc++
in the EXE's directory.

In my case, the necessary DLLs were:

libboost_filesystem-mt.dll
libboost_regex-mt.dll
libboost_system-mt.dll
libgcc_s_dw2-1.dll
libgmp-10.dll
libicudt57.dll
libicuuc57.dll
libledger.dll
libstdc++-6.dll
libwinpthread-1.dll