### PR TITLE
Adds a "binary" format specifier to ledger-report.

### DIFF
--- a/lisp/ledger-report.el
+++ b/lisp/ledger-report.el
@@ -39,10 +39,10 @@
   :group 'ledger)
 
 (defcustom ledger-reports
-  '(("bal" "ledger -f %(ledger-file) bal")
-    ("reg" "ledger -f %(ledger-file) reg")
-    ("payee" "ledger -f %(ledger-file) reg @%(payee)")
-    ("account" "ledger -f %(ledger-file) reg %(account)"))
+  '(("bal" "%(binary) -f %(ledger-file) bal")
+    ("reg" "%(binary) -f %(ledger-file) reg")
+    ("payee" "%(binary) -f %(ledger-file) reg @%(payee)")
+    ("account" "%(binary) -f %(ledger-file) reg %(account)"))
   "Definition of reports to run.
 
 Each element has the form (NAME CMDLINE).  The command line can
@@ -60,6 +60,7 @@ specifier."
 
 (defcustom ledger-report-format-specifiers
   '(("ledger-file" . ledger-report-ledger-file-format-specifier)
+    ("binary" . (lambda () ledger-binary-path))
     ("payee" . ledger-report-payee-format-specifier)
     ("account" . ledger-report-account-format-specifier)
     ("tagname" . ledger-report-tagname-format-specifier)


### PR DESCRIPTION
This makes the current `ledger-binary-path` accessible to ledger reports by using the `%(binary)` format specifier.

It is intended to aid users who may have different `ledger-binary-path` values on different machines. It also means that the default `ledger-reports` will work out of the box even if their ledger executable is not named "ledger" --- for example, if they are using `hledger`, and have otherwise set their binary path appropriately.

This patch would also address [Bug 1172](http://bugs.ledger-cli.org/show_bug.cgi?id=1172).