### PR TITLE
Makes links in ledger-report "register" commands optional.

### DIFF
--- a/lisp/ledger-report.el
+++ b/lisp/ledger-report.el
@@ -82,6 +82,12 @@ text that should replace the format specifier."
   :type 'boolean
   :group 'ledger-report)
 
+(defcustom ledger-report-links-in-register t
+  "When non-nil, attempt to link transactions in \"register\"
+reports to their location in the currrent ledger file buffer."
+  :type 'boolean
+  :group 'ledger-report)
+
 (defvar ledger-report-buffer-name "*Ledger Report*")
 
 (defvar ledger-report-name nil)
@@ -337,11 +343,12 @@ Optional EDIT the command."
      ;; --subtotal does not produce identifiable transactions, so don't
      ;; prepend location information for them
      (if (and register-report
+              ledger-report-links-in-register
               (not (string-match "--subtotal" cmd)))
          (concat cmd " --prepend-format='%(filename):%(beg_line):'")
        cmd)
      t nil)
-    (when register-report
+    (when (and register-report ledger-report-links-in-register)
       (goto-char data-pos)
       (while (re-search-forward "^\\(/[^:]+\\)?:\\([0-9]+\\)?:" nil t)
         (let ((file (match-string 1))


### PR DESCRIPTION
This commit adds a new custom `ledger-report-links-in-register` flag that controls whether `ledger-report` will attempt to link transactions in the report buffer to the entries in the original file. Essentially, it controls whether `ledger-report` will silently pass the `--prepend-format` flag to the binary.

The primary motivation for this is that not all implementations of ledger support the `--prepend-format` flag, and thus all "register" commands run by `ledger-report` (and usually *only* "register" commands)
will always fail, because they are treated as a special case in `ledger-do-report`.

At present, the user has no ability to prevent the `--prepend-format` flag from being silently passed to the binary. This PR provides that feature.