### PR TITLE
Fix strict/pedantic breakage due to non-uncleared transactions

### DIFF
--- a/src/journal.cc
+++ b/src/journal.cc
@@ -152,9 +152,6 @@ account_t * journal_t::register_account(const string& name, post_t * post,
           fixed_accounts = true;
         result->add_flags(ACCOUNT_KNOWN);
       }
-      else if (! fixed_accounts && post->_state != item_t::UNCLEARED) {
-        result->add_flags(ACCOUNT_KNOWN);
-      }
       else if (checking_style == CHECK_WARNING) {
         current_context->warning(_f("Unknown account '%1%'") % result->fullname());
       }
@@ -267,13 +264,6 @@ void journal_t::register_commodity(commodity_t& comm,
       if (context.which() == 0) {
         if (force_checking)
           fixed_commodities = true;
-        comm.add_flags(COMMODITY_KNOWN);
-      }
-      else if (! fixed_commodities &&
-               ((context.which() == 1 &&
-                 boost::get<xact_t *>(context)->_state != item_t::UNCLEARED) ||
-                (context.which() == 2 &&
-                 boost::get<post_t *>(context)->_state != item_t::UNCLEARED))) {
         comm.add_flags(COMMODITY_KNOWN);
       }
       else if (checking_style == CHECK_WARNING) {


### PR DESCRIPTION
Removing these checks will stop ledger from regarding accounts and commodities which are part of pending/cleared transactions as being defined/known.

This fixes the unexpected (and unhelpful?) behaviour of strict/pedantic not working as expected (warn/error if an account has no 'account' directive defining it).

I believe this resolves #838, #844 and #846 on Bugzilla.

Please note that I haven't run the test suite with these changes as following the instructions yielded no output.
