### PR TITLE
Remove reference to `ncursesw` MacPort.

### DIFF
--- a/acprep
+++ b/acprep
@@ -516,7 +516,7 @@ class PrepareBuild(CommandLineApp):
                     'libiconv', '+universal',
                     'zlib', '+universal',
                     'gmp' ,'+universal', 'mpfr', '+universal',
-                    'ncurses', '+universal', 'ncursesw', '+universal',
+                    'ncurses', '+universal',
                     'gettext' ,'+universal',
                     'libedit' ,'+universal',
                     'texlive-xetex', 'doxygen', 'graphviz', 'texinfo',


### PR DESCRIPTION
The `ncursesw` port doesn't exist anymore, its functionality is included in the `ncurses` port.