### PR TITLE
Fix compilation error with boost 1.61

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -92,7 +92,7 @@ public:
 
   typedef std::pair<optional<value_t>, bool> tag_data_t;
   typedef std::map<string, tag_data_t,
-                   function<bool(string, string)> > string_map;
+                   std::function<bool(string, string)> > string_map;
 
   state_t              _state;
   optional<date_t>     _date;


### PR DESCRIPTION
I recently upgraded from boost 1.60 to 1.61 and ledge compilation fails with a relatively long template error message:

```
In file included from /usr/include/boost/utility/enable_if.hpp:15:0,
                 from /usr/include/boost/range/has_range_iterator.hpp:21,
                 from /usr/include/boost/range/difference_type.hpp:21,
                 from /usr/include/boost/range/size_type.hpp:19,
                 from /usr/include/boost/range/size.hpp:21,
                 from /usr/include/boost/range/functions.hpp:20,
                 from /usr/include/boost/range/iterator_range_core.hpp:38,
                 from /usr/include/boost/range/iterator_range.hpp:13,
                 from /usr/include/boost/range/as_literal.hpp:22,
                 from /usr/include/boost/algorithm/string/trim.hpp:19,
                 from /usr/include/boost/algorithm/string.hpp:19,
                 from /home/dkasak/code/ledger/system.hh:174,
                 from /home/dkasak/code/ledger/src/stats.cc:32:
/usr/include/boost/core/enable_if.hpp: In instantiation of ‘struct boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>, void>’:
/usr/include/boost/optional/optional.hpp:696:12:   required by substitution of ‘template<class Expr> boost::optional<T>::optional(Expr&&, typename boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<T, Expr> >::type*) [with Expr = const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&]’
/usr/include/boost/type_traits/is_constructible.hpp:33:65:   required by substitution of ‘template<class T, class Arg, class> static boost::type_traits::yes_type boost::detail::is_constructible_imp::test1(int) [with T = std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >; Arg = const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&; <template-parameter-1-3> = <missing>]’
/usr/include/boost/type_traits/is_constructible.hpp:47:178:   required from ‘struct boost::is_constructible<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)>, std::allocator<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<boost::optional<ledger::value_t>, bool> > > > >&>’
/usr/include/boost/optional/optional.hpp:589:22:   required from ‘struct boost::optional_detail::is_convertible_to_T_or_factory<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>’
/usr/include/boost/optional/optional.hpp:605:56:   required from ‘struct boost::optional_detail::is_optional_val_init_candidate<std::map<std::__cxx11::basic_string<char>, stIn file included from /usr/include/boost/utility/enable_if.hpp:15:0,
                 from /usr/include/boost/range/has_range_iterator.hpp:21,
                 from /usr/include/boost/range/difference_type.hpp:21,
                 from /usr/include/boost/range/size_type.hpp:19,
                 from /usr/include/boost/range/size.hpp:21,
                 from /usr/include/boost/range/functions.hpp:20,
                 from /usr/include/boost/range/iterator_range_core.hpp:38,
                 from /usr/include/boost/range/iterator_range.hpp:13,
                 from /usr/include/boost/range/as_literal.hpp:22,
                 from /usr/include/boost/algorithm/string/trim.hpp:19,
                 from /usr/include/boost/algorithm/string.hpp:19,
                 from /home/dkasak/code/ledger/system.hh:174,
                 from /home/dkasak/code/ledger/src/stats.cc:32:
/usr/include/boost/core/enable_if.hpp: In instantiation of ‘struct boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>, void>’:
/usr/include/boost/optional/optional.hpp:696:12:   required by substitution of ‘template<class Expr> boost::optional<T>::optional(Expr&&, typename boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<T, Expr> >::type*) [with Expr = const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&]’
/usr/include/boost/type_traits/is_constructible.hpp:33:65:   required by substitution of ‘template<class T, class Arg, class> static boost::type_traits::yes_type boost::detail::is_constructible_imp::test1(int) [with T = std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >; Arg = const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&; <template-parameter-1-3> = <missing>]’
/usr/include/boost/type_traits/is_constructible.hpp:47:178:   required from ‘struct boost::is_constructible<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)>, std::allocator<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<boost::optional<ledger::value_t>, bool> > > > >&>’
/usr/include/boost/optional/optional.hpp:589:22:   required from ‘struct boost::optional_detail::is_convertible_to_T_or_factory<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>’
/usr/include/boost/optional/optional.hpp:605:56:   required from ‘struct boost::optional_detail::is_optional_val_init_candidate<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>’
/usr/include/boost/core/enable_if.hpp:41:10:   required from ‘struct boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>, boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>’
/usr/include/boost/optional/optional.hpp:735:5:   required by substitution of ‘template<class Expr> typename boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<T, Expr>, boost::optional<T>&>::type boost::optional<T>::operator=(Expr&&) [with Expr = const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&]’
/home/dkasak/code/ledger/src/item.h:127:22:   required from here
/usr/include/boost/core/enable_if.hpp:41:10: error: incomplete type ‘boost::optional_detail::is_optional_val_init_candidate<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>’ used in nested name specifier
   struct enable_if : public enable_if_c<Cond::value, T> {};
          ^~~~~~~~~
d::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>’
/usr/include/boost/core/enable_if.hpp:41:10:   required from ‘struct boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>, boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>’
/usr/include/boost/optional/optional.hpp:735:5:   required by substitution of ‘template<class Expr> typename boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<T, Expr>, boost::optional<T>&>::type boost::optional<T>::operator=(Expr&&) [with Expr = const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&]’
/home/dkasak/code/ledger/src/item.h:127:22:   required from here
/usr/include/boost/core/enable_if.hpp:41:10: error: incomplete type ‘boost::optional_detail::is_optional_val_init_candidate<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> >, const boost::optional<std::map<std::__cxx11::basic_string<char>, std::pair<boost::optional<ledger::value_t>, bool>, boost::function<bool(std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>)> > >&>’ used in nested name specifier
   struct enable_if : public enable_if_c<Cond::value, T> {};
          ^~~~~~~~~
make[2]: *** [src/CMakeFiles/libledger.dir/build.make:63: src/CMakeFiles/libledger.dir/stats.cc.o] Error 1
make[2]: *** [src/CMakeFiles/libledger.dir/build.make:63: src/CMakeFiles/libledger.dir/stats.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:89: src/CMakeFiles/libledger.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:89: src/CMakeFiles/libledger.dir/all] Error 2
make: *** [Makefile:150: all] Error 2
make: *** [Makefile:150: all] Error 2
```

Prefixing `function` with `std::` fixes the issue and compiles ledger successfully.