### PR TITLE
Fix build under msys32; add Appveyor continuous build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+version: build-{build}
+
+image: Visual Studio 2013
+
+shallow_clone: true  # don't download repo history
+
+install:
+- time /t
+- tzutil /s "Eastern Standard Time_dstoff"
+- time /t
+
+build_script:
+- C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy pacman"
+- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
+- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Syu"
+- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -S mingw-w64-i686-boost"
+- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -S mingw-w64-i686-mpfr"
+- C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -S mingw-w64-i686-cmake"
+- C:\msys64\usr\bin\bash -lc "export PATH=/mingw32/bin:$PATH && cd $APPVEYOR_BUILD_FOLDER && cmake -G 'MSYS Makefiles'"
+- C:\msys64\usr\bin\bash -lc "export PATH=/mingw32/bin:$PATH && cd $APPVEYOR_BUILD_FOLDER && make -j2"
+
+after_build:
+- set LIB_DIR=C:\msys64\mingw32\bin
+- 7z a ledger-win.zip %APPVEYOR_BUILD_FOLDER%\ledger.exe %LIB_DIR%\libboost_filesystem-mt.dll %LIB_DIR%\libboost_regex-mt.dll %LIB_DIR%\libboost_system-mt.dll %LIB_DIR%\libgcc_s_dw2-1.dll %LIB_DIR%\libgmp-10.dll %LIB_DIR%\libicudt57.dll %LIB_DIR%\libicuuc57.dll %APPVEYOR_BUILD_FOLDER%\libledger.dll %LIB_DIR%\libstdc++-6.dll %LIB_DIR%\libwinpthread-1.dll
+
+artifacts:
+  - path: ledger-win.zip
+    name: Ledger Win32 binaries

--- a/src/global.cc
+++ b/src/global.cc
@@ -451,7 +451,7 @@ expr_t::func_t global_scope_t::look_for_command(scope_t&      scope,
 
 void global_scope_t::visit_man_page() const
 {
-#ifndef WIN32
+#ifndef _WIN32
   int pid = fork();
   if (pid < 0) {
     throw std::logic_error(_("Failed to fork child process"));

--- a/src/main.cc
+++ b/src/main.cc
@@ -74,7 +74,7 @@ int main(int argc, char * argv[], char * envp[])
 #endif
 
   std::signal(SIGINT, sigint_handler);
-#ifndef WIN32
+#ifndef _WIN32
   std::signal(SIGPIPE, sigpipe_handler);
 #endif
 

--- a/src/quotes.cc
+++ b/src/quotes.cc
@@ -62,7 +62,7 @@ commodity_quote_from_script(commodity_t& commodity,
   DEBUG("commodity.download", "invoking command: " << getquote_cmd);
 
   bool success = true;
-#ifndef WIN32
+#ifndef _WIN32
   if (FILE * fp = popen(getquote_cmd.c_str(), "r")) {
     if (std::feof(fp) || ! std::fgets(buf, 255, fp))
       success = false;

--- a/src/report.cc
+++ b/src/report.cc
@@ -57,7 +57,7 @@ void report_t::normalize_options(const string& verb)
   // Patch up some of the reporting options based on what kind of
   // command it was.
 
-#if HAVE_ISATTY
+#ifdef HAVE_ISATTY
   if (! HANDLED(force_color)) {
     if (! HANDLED(no_color) && isatty(STDOUT_FILENO))
       HANDLER(color).on("?normalize");
@@ -181,14 +181,14 @@ void report_t::normalize_options(const string& verb)
   }
 
   long cols = 0;
-#if HAVE_IOCTL
+#ifdef HAVE_IOCTL
   struct winsize ws;
 #endif
   if (HANDLED(columns_))
     cols = lexical_cast<long>(HANDLER(columns_).value);
   else if (const char * columns = std::getenv("COLUMNS"))
     cols = lexical_cast<long>(columns);
-#if HAVE_IOCTL
+#ifdef HAVE_IOCTL
   else if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) != -1)
       cols = ws.ws_col;
 #endif

--- a/src/report.h
+++ b/src/report.h
@@ -793,7 +793,8 @@ public:
 
   OPTION(report_t, output_); // -o
 
-#if HAVE_ISATTY
+// setenv() is not available on WIN32
+#if defined(HAVE_ISATTY) and !defined(_WIN32)
   OPTION__
   (report_t, pager_,
    CTOR(report_t, pager_) {

--- a/src/select.cc
+++ b/src/select.cc
@@ -145,14 +145,14 @@ value_t select_command(call_scope_t& args)
       string  thus_far = "";
 
       std::size_t cols = 0;
-#if HAVE_IOCTL
+#ifdef HAVE_IOCTL
       struct winsize ws;
 #endif
       if (report.HANDLED(columns_))
         cols = lexical_cast<std::size_t>(report.HANDLER(columns_).value);
       else if (const char * columns_env = std::getenv("COLUMNS"))
         cols = lexical_cast<std::size_t>(columns_env);
-#if HAVE_IOCTL
+#ifdef HAVE_IOCTL
       else if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) != -1)
           cols = ws.ws_col;
 #endif

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -58,7 +58,7 @@ namespace {
    */
   int do_fork(std::ostream ** os, const path& pager_path)
   {
-#ifndef WIN32
+#ifndef _WIN32
     int pfd[2];
 
     int status = pipe(pfd);
@@ -115,7 +115,7 @@ void output_stream_t::initialize(const optional<path>& output_file,
 
 void output_stream_t::close()
 {
-#ifndef WIN32
+#ifndef _WIN32
   if (os != &std::cout) {
     checked_delete(os);
     os = &std::cout;

--- a/src/strptime.cc
+++ b/src/strptime.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-#ifdef WIN32
+#ifdef _WIN32
 // Implement strptime under windows
 
 #include "strptime.h"
@@ -186,4 +186,4 @@ char* strptime(const char *buf, const char *fmt, struct tm *tm) {
   return _strptime(buf, fmt, tm);
 }
 
-#endif  // WIN32
+#endif  // _WIN32

--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -60,12 +60,12 @@
 #define HAVE_EDIT                @HAVE_EDIT@
 #define HAVE_GETTEXT             @HAVE_GETTEXT@
 
-#define HAVE_ACCESS              @HAVE_ACCESS@
-#define HAVE_REALPATH            @HAVE_REALPATH@
-#define HAVE_GETPWUID            @HAVE_GETPWUID@
-#define HAVE_GETPWNAM            @HAVE_GETPWNAM@
-#define HAVE_IOCTL               @HAVE_IOCTL@
-#define HAVE_ISATTY              @HAVE_ISATTY@
+#cmakedefine HAVE_ACCESS
+#cmakedefine HAVE_REALPATH
+#cmakedefine HAVE_GETPWUID
+#cmakedefine HAVE_GETPWNAM
+#cmakedefine HAVE_IOCTL
+#cmakedefine HAVE_ISATTY
 
 #define HAVE_UNIX_PIPES          @HAVE_UNIX_PIPES@
 
@@ -144,16 +144,16 @@ typedef std::ostream::pos_type ostream_pos_type;
 #endif
 
 #include <sys/stat.h>
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <io.h>
 #else
 #include <unistd.h>
 #endif
-#if HAVE_GETPWUID || HAVE_GETPWNAM
+#if defined(HAVE_GETPWUID) || defined(HAVE_GETPWNAM)
 #include <pwd.h>
 #endif
 
-#if HAVE_IOCTL
+#ifdef HAVE_IOCTL
 #include <sys/ioctl.h>
 #endif
 

--- a/src/times.cc
+++ b/src/times.cc
@@ -33,7 +33,7 @@
 
 #include "times.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "strptime.h"
 #endif
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -807,7 +807,7 @@ path expand_path(const path& pathname)
 
   if (path_string.length() == 1 || pos == 1) {
     pfx = std::getenv("HOME");
-#if HAVE_GETPWUID
+#ifdef HAVE_GETPWUID
     if (! pfx) {
       // Punt. We're trying to expand ~/, but HOME isn't set
       struct passwd * pw = getpwuid(getuid());
@@ -816,7 +816,7 @@ path expand_path(const path& pathname)
     }
 #endif
   }
-#if HAVE_GETPWNAM
+#ifdef HAVE_GETPWNAM
   else {
     string user(path_string, 1, pos == string::npos ?
                 string::npos : pos - 1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -496,7 +496,7 @@ inline T& downcast(U& object) {
 
 path resolve_path(const path& pathname);
 
-#if HAVE_REALPATH
+#ifdef HAVE_REALPATH
 extern "C" char * realpath(const char *, char resolved_path[]);
 #endif
 

--- a/test/unit/t_value.cc
+++ b/test/unit/t_value.cc
@@ -6,6 +6,10 @@
 
 #include "value.h"
 
+#ifdef _WIN32
+#include "strptime.h"
+#endif
+
 using namespace ledger;
 
 struct value_fixture {


### PR DESCRIPTION
* Appveyor is a continuous integration platform for Windows that is free for open source projects. See latest test build here: https://ci.appveyor.com/project/Evan/ledger/build/artifacts

* Changed WIN32 to _WIN32 because this article [http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system] claims that it is defined by the greatest number of compilers.

* Modified HAVE_ISATTY and other system defines so that system.hh compiles when cmake fails to find the relevant function.

* Add missing include in test/unit/t_value.cc

Almost all tests fail when you run them on msys32. I will address that in a future PR.