### PR TITLE
Fix regress test 383 on Windows

### DIFF
--- a/test/regress/383.test
+++ b/test/regress/383.test
@@ -23,7 +23,7 @@ test bal Assets:Investments --lots --date-format %Y-%m-%d
 100 AA {2.00 GBP} [2014-01-01]  Assets:Investments
 end test
 
-test bal Assets:Investments --lots --date-format %g-%b-%d
+test bal Assets:Investments --lots --date-format %y-%b-%d
 100 AA {2.00 GBP} [14-Jan-01]  Assets:Investments
 end test
 


### PR DESCRIPTION
%g is not available in Windows strftime. See documentation at https://msdn.microsoft.com/en-us/library/fe06s4ak.aspx

If this test is meant specifically to test %g as opposed to %y, I will have to come up with another way of fixing this.