### PR TITLE
Use boost parent_path() method instead of manual computation

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -721,15 +721,12 @@ void instance_t::include_directive(char * line)
   if (line[0] != '/' && line[0] != '\\' && line[0] != '~') {
     DEBUG("textual.include", "received a relative path");
     DEBUG("textual.include", "parent file path: " << context.pathname);
-    string pathstr(context.pathname.string());
-    string::size_type pos = pathstr.rfind('/');
-    if (pos == string::npos)
-      pos = pathstr.rfind('\\');
-    if (pos != string::npos) {
-      filename = path(string(pathstr, 0, pos + 1)) / line;
-      DEBUG("textual.include", "normalized path: " << filename.string());
-    } else {
+    path parent_path = context.pathname.parent_path();
+    if (parent_path.empty()) {
       filename = path(string(".")) / line;
+    } else {
+      filename = parent_path / line;
+      DEBUG("textual.include", "normalized path: " << filename.string());
     }
   } else {
     filename = line;


### PR DESCRIPTION
This fixes error-in-include.test, dir-apply.test, 6188B0EC.test, and 89233B6D.test when running under msys2 on Windows. The manual computation is incorrect when there are both forward slash and backward slash characters in the path.