### PR TITLE
Fix indent-tabs-mode to nil

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -32,5 +32,5 @@
     (c-special-indent-hook . c-gnu-impose-minimum)
     (c-block-comment-prefix . ""))))
  (emacs-lisp-mode
-  (indent-tabs-mode)))
+  (indent-tabs-mode . nil)))
 


### PR DESCRIPTION
Probably a bug in Emacs:
- This add 't' in .dir-locals.el
`M-x add-dir-local-variable RET emacs-lisp-mode RET indent-tabs-mode RET t   RET`
- This does not add 'nil' in .dir-locals.el
`M-x add-dir-local-variable RET emacs-lisp-mode RET indent-tabs-mode RET nil RET`

Fixing this eases the diff between files (spaces instead of tabs). Even if ledger-mode has been moved to its own repository, there are still Emacs lisp files in this repository.