### PR TITLE
Fix Bug 1182: Error message for parse failure after '='

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -563,6 +563,9 @@ void instance_t::automated_xact_directive(char * line)
     expr_t::ptr_op_t expr =
       query.parse_args(string_value(skip_ws(line + 1)).to_sequence(),
                        keeper, false, true);
+    if (!expr) {
+      throw parse_error(_("Expected predicate after '='"));
+    }
 
     unique_ptr<auto_xact_t> ae(new auto_xact_t(predicate_t(expr, keeper)));
     ae->pos           = position_t();

--- a/test/regress/1182_1.test
+++ b/test/regress/1182_1.test
@@ -1,0 +1,12 @@
+=
+2000/01/01 Test
+    A  $1.00
+	B
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 1:
+While parsing automated transaction:
+> =
+Error: Expected predicate after '='
+end test

--- a/test/regress/1182_2.test
+++ b/test/regress/1182_2.test
@@ -1,0 +1,17 @@
+2000/01/01 Test
+    A  $1.00
+	B
+
+============
+
+2000/01/02 Test
+    A  $1.00
+	B
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 5:
+While parsing automated transaction:
+> ============
+Error: Expected predicate after '='
+end test


### PR DESCRIPTION
Fixes [Bug 1182](http://bugs.ledger-cli.org/show_bug.cgi?id=1182)
- Handled case where parsing a predicate in an automated transaction fails.
- Before it crashed with SIGABRT on `operator->` in Boost's intrusive_ptr.
- Now it throws an error "Expected predicate after '='".
- Added two regression tests.