### PR TITLE
Add Ubuntu 16.04 (Xenial) to acprep.

### DIFF
--- a/acprep
+++ b/acprep
@@ -66,6 +66,16 @@ class BoostInfo(object):
         if system == 'centos':
             return [ 'boost-devel' ]
 
+        elif system == 'ubuntu-xenial':
+            return [ 'libboost-dev',
+                     'libboost-date-time-dev',
+                     'libboost-filesystem-dev',
+                     'libboost-iostreams-dev',
+                     'libboost-python-dev',
+                     'libboost-regex-dev',
+                     'libboost-system-dev',
+                     'libboost-test-dev' ]
+
         elif system == 'ubuntu-trusty':
             return [ 'libboost-dev',
                      'libboost-date-time-dev',
@@ -565,6 +575,26 @@ class PrepareBuild(CommandLineApp):
                             'libutfcpp-dev',
                             'sloccount'
                         ] + BoostInfo().dependencies('ubuntu-trusty')
+                    elif re.search('xenial', info):
+                        self.log.info('Looks like you are using APT on Ubuntu Xenial')
+                        packages = [
+                            'sudo', 'apt-get', 'install',
+                            'build-essential',
+                            'doxygen',
+                            'cmake',
+                            'ninja-build',
+                            'zlib1g-dev',
+                            'libbz2-dev',
+                            'python-dev',
+                            'libgmp3-dev',
+                            'libmpfr-dev',
+                            'gettext',
+                            'libedit-dev',
+                            'texinfo',
+                            'lcov',
+                            'libutfcpp-dev',
+                            'sloccount'
+                        ] + BoostInfo().dependencies('ubuntu-xenial')
                     elif re.search('saucy', info):
                         self.log.info('Looks like you are using APT on Ubuntu Saucy')
                         packages = [


### PR DESCRIPTION
The `acprep dependencies` command did not work on Unbtun 16.04 LTS. I just copy-pasted the blocks from Trusty (14.04) and it seems to build and run ok.

Two tests failed:
* BaselineTest_opt-datetime-format
* BaselineTest_opt-time-report

But the output looks ok when I run them, so I'm not sure what the problem is.