### PR TITLE
Add value expression function debug

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -2400,6 +2400,23 @@ should never be auto-downloaded.
 
 The @code{default} sub-directive marks this as the ``default'' commodity.
 
+@item debug
+@findex debug
+@c instance_t::debug_directive in textual.cc
+Prints to stderr the value of a value expression.  For example:
+
+@smallexample @c input:validate
+2011/12/01 Test
+    Assets:Savings  $100
+    Assets:Current Account
+
+debug account("Assets:Savings").total
+@end smallexample
+
+When ledger is run, this will output:
+
+debug: account("Assets:Savings").total $100.00
+
 @item define
 @findex define
 @c instance_t::define_directive in textual.cc

--- a/src/expr.h
+++ b/src/expr.h
@@ -61,7 +61,8 @@ public:
   enum check_expr_kind_t {
     EXPR_GENERAL,
     EXPR_ASSERTION,
-    EXPR_CHECK
+    EXPR_CHECK,
+    EXPR_DEBUG
   };
 
   typedef std::pair<expr_t, check_expr_kind_t> check_expr_pair;

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -188,6 +188,7 @@ namespace {
 
     void eval_directive(char * line);
     void assert_directive(char * line);
+    void debug_directive(char * line);
     void check_directive(char * line);
     void value_directive(char * line);
 
@@ -598,11 +599,13 @@ void instance_t::automated_xact_directive(char * line)
                 std::strncmp(p, "assert", 6) == 0 && std::isspace(p[6])) ||
                (remlen > 6 && *p == 'c' &&
                 std::strncmp(p, "check", 5) == 0 && std::isspace(p[5])) ||
+               (remlen > 6 && *p == 'd' &&
+                std::strncmp(p, "debug", 5) == 0 && std::isspace(p[5])) ||
                (remlen > 5 && *p == 'e' &&
                 ((std::strncmp(p, "expr", 4) == 0 && std::isspace(p[4])) ||
                  (std::strncmp(p, "eval", 4) == 0 && std::isspace(p[4]))))) {
         const char c = *p;
-        p = skip_ws(&p[*p == 'a' ? 6 : (*p == 'c' ? 5 : 4)]);
+        p = skip_ws(&p[*p == 'a' ? 6 : ((*p == 'c' || *p == 'd') ? 5 : 4)]);
         if (! ae->check_exprs)
           ae->check_exprs = expr_t::check_expr_list();
         ae->check_exprs->push_back
@@ -611,7 +614,9 @@ void instance_t::automated_xact_directive(char * line)
                                    expr_t::EXPR_ASSERTION :
                                    (c == 'c' ?
                                     expr_t::EXPR_CHECK :
-                                    expr_t::EXPR_GENERAL)));
+                                    (c == 'd' ?
+                                     expr_t::EXPR_DEBUG :
+                                     expr_t::EXPR_GENERAL))));
       }
       else {
         reveal_context = false;
@@ -941,7 +946,7 @@ void instance_t::account_directive(char * line)
     else if (keyword == "default") {
       account_default_directive(account);
     }
-    else if (keyword == "assert" || keyword == "check") {
+    else if (keyword == "assert" || keyword == "check" || keyword == "debug") {
       keep_details_t keeper(true, true, true);
       expr_t         expr(string("account == \"") + account->fullname() + "\"");
       predicate_t    pred(expr.get_op(), keeper);
@@ -961,7 +966,9 @@ void instance_t::account_directive(char * line)
         (expr_t::check_expr_pair(expr_t(b),
                                  keyword == "assert" ?
                                  expr_t::EXPR_ASSERTION :
-                                 expr_t::EXPR_CHECK));
+                                 (keyword == "debug" ?
+                                  expr_t::EXPR_DEBUG :
+                                  expr_t::EXPR_CHECK)));
     }
     else if (keyword == "eval" || keyword == "expr") {
       // jww (2012-02-27): Make account into symbol scopes so that this
@@ -1151,13 +1158,15 @@ void instance_t::tag_directive(char * line)
 
     char * b = next_element(q);
     string keyword(q);
-    if (keyword == "assert" || keyword == "check") {
+    if (keyword == "assert" || keyword == "check" || keyword == "debug") {
       context.journal->tag_check_exprs.insert
         (tag_check_exprs_map::value_type
          (string(p), expr_t::check_expr_pair(expr_t(b),
                                              keyword == "assert" ?
                                              expr_t::EXPR_ASSERTION :
-                                             expr_t::EXPR_CHECK)));
+                                             (keyword == "debug" ?
+                                              expr_t::EXPR_DEBUG :
+                                              expr_t::EXPR_CHECK))));
     }
   }
 }
@@ -1173,6 +1182,13 @@ void instance_t::assert_directive(char * line)
   expr_t expr(line);
   if (! expr.calc(*context.scope).to_boolean())
     throw_(parse_error, _f("Assertion failed: %1%") % line);
+}
+
+void instance_t::debug_directive(char * line)
+{
+  expr_t expr(line);
+  std::cerr << (_f("debug: %1% %2%")
+                % line % expr.calc(*context.scope).to_string()) << std::endl;
 }
 
 void instance_t::check_directive(char * line)
@@ -1326,7 +1342,11 @@ bool instance_t::general_directive(char * line)
     break;
 
   case 'd':
-    if (std::strcmp(p, "def") == 0 || std::strcmp(p, "define") == 0) {
+    if (std::strcmp(p, "debug") == 0) {
+      debug_directive(arg);
+      return true;
+    }
+    else if (std::strcmp(p, "def") == 0 || std::strcmp(p, "define") == 0) {
       eval_directive(arg);
       return true;
     }
@@ -1897,10 +1917,12 @@ xact_t * instance_t::parse_xact(char *          line,
               std::strncmp(p, "assert", 6) == 0 && std::isspace(p[6])) ||
              (remlen > 6 && *p == 'c' &&
               std::strncmp(p, "check", 5) == 0 && std::isspace(p[5])) ||
+             (remlen > 6 && *p == 'd' &&
+              std::strncmp(p, "debug", 5) == 0 && std::isspace(p[5])) ||
              (remlen > 5 && *p == 'e' &&
               std::strncmp(p, "expr", 4) == 0 && std::isspace(p[4]))) {
       const char c = *p;
-      p = skip_ws(&p[*p == 'a' ? 6 : (*p == 'c' ? 5 : 4)]);
+      p = skip_ws(&p[*p == 'a' ? 6 : ((*p == 'c' || *p == 'd') ? 5 : 4)]);
       expr_t expr(p);
       bind_scope_t bound_scope(*context.scope, *item);
       if (c == 'e') {

--- a/src/xact.cc
+++ b/src/xact.cc
@@ -696,11 +696,19 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context)
             pair.first.calc(bound_scope);
           }
           else if (! pair.first.calc(bound_scope).to_boolean()) {
-            if (pair.second == expr_t::EXPR_ASSERTION)
+            if (pair.second == expr_t::EXPR_ASSERTION) {
               throw_(parse_error,
                      _f("Transaction assertion failed: %1%") % pair.first);
-            else
+            }
+            else if (pair.second == expr_t::EXPR_DEBUG) {
+              std::cerr << (_f("transaction debug: %1% %2%")
+                            % pair.first
+                            % pair.first.calc(bound_scope).to_string())
+                        << std::endl;
+            }
+            else {
               context.warning(_f("Transaction check failed: %1%") % pair.first);
+            }
           }
         }
       }


### PR DESCRIPTION
Add new value expression function `debug`: prints the value of a value
expression to stderr.

Probably this should be called `print`?  Or possibly should instead add a
second argument to assert which is printed when the assertion fails (similar
meaning to Python)?