### PR TITLE
Strip annotation before adding exchange value

### DIFF
--- a/src/pool.cc
+++ b/src/pool.cc
@@ -262,6 +262,9 @@ commodity_pool_t::exchange(const amount_t&             amount,
   if (! cost.has_commodity())
     per_unit_cost.clear_commodity();
 
+  if (cost.has_annotation())
+    per_unit_cost = per_unit_cost.strip_annotations(keep_details_t());
+
   DEBUG("commodity.prices.add", "exchange: per-unit-cost = " << per_unit_cost);
 
   // Do not record commodity exchanges where amount's commodity has a


### PR DESCRIPTION
This trivial PR fixes a bug in ledger when we have costs with lot prices:

    2002/03/04 Buy actions
        Assets:Broker          10 Foo @ 4 Bar {5.00 EUR}
        Assets:Broker
    
    2002/03/04 Buy actions
      Assets:Broker          10 Foo @ 4 Bar {6.00 EUR}
      Assets:Broker

In the first transaction, ledger sees the first commodity as a `Foo {4 Bar {5.00 EUR}}`, and then when he reads the second, he tries to compare `Bar {5.00 EUR}` with `Bar {6.00 EUR}`, which he cannot.

This modification strips the price of the lot price, thus storing `Foo {4 Bar}` instead of `Foo {4 Bar {5.00 EUR}}`.

Explanations:
Although it makes sense to have cost values dependent on a lot price (for taxation lot tracking), I couldn’t find a valid case where a lot price should itself have a lot price: if 1 Foo has a price 4 Bar, then it’s not important whether those 4 Bar's where bought at 5 EUR or 6 EUR.
If it has an importance, then the commodity is no longer 'fongible' (sorry for the French term) and should be two separated commodities.

This is how I understand things, please correct me if I’m wrong.