### PR TITLE
Allow printing the depth of the first displayed parent

### DIFF
--- a/src/account.cc
+++ b/src/account.cc
@@ -309,6 +309,20 @@ namespace {
     return long(&account);
   }
 
+  value_t get_depth_parent(account_t& account)
+  {
+    std::size_t depth = 0;
+    for (const account_t * acct = account.parent;
+         acct && acct->parent;
+         acct = acct->parent) {
+      std::size_t count = acct->children_with_flags(ACCOUNT_EXT_TO_DISPLAY);
+      assert(count > 0);
+      if (count > 1 || acct->has_xflags(ACCOUNT_EXT_TO_DISPLAY))
+        depth++;
+    }
+    return long(depth);
+  }
+
   value_t get_depth_spacer(account_t& account)
   {
     std::size_t depth = 0;
@@ -425,6 +439,8 @@ expr_t::ptr_op_t account_t::lookup(const symbol_t::kind_t kind,
   case 'd':
     if (fn_name == "depth")
       return WRAP_FUNCTOR(get_wrapper<&get_depth>);
+    else if (fn_name == "depth_parent")
+      return WRAP_FUNCTOR(get_wrapper<&get_depth_parent>);
     else if (fn_name == "depth_spacer")
       return WRAP_FUNCTOR(get_wrapper<&get_depth_spacer>);
     break;


### PR DESCRIPTION
For balance reports ledger uses the `depth_spacer` function.
Alas, when creating reports for LaTeX spaces as indentation don't work.

This commit introduces the `depth_parent` command that returns the indentation level equal to the one used in native balance reports.

The command `depth` returns the depth of the current account, which results in unexpected indentation when some accounts collapse.