### PR TITLE
Expose journal expand_aliases to Python

### DIFF
--- a/src/py_journal.cc
+++ b/src/py_journal.cc
@@ -286,6 +286,10 @@ void export_journal()
          return_internal_reference<1,
              with_custodian_and_ward_postcall<1, 0> >())
 
+    .def("expand_aliases", &journal_t::expand_aliases,
+         return_internal_reference<1,
+             with_custodian_and_ward_postcall<1, 0> >())
+
     .def("add_xact", &journal_t::add_xact)
     .def("remove_xact", &journal_t::remove_xact)
 


### PR DESCRIPTION
Allows expanding account aliases in Python.

Example:

```python
>>> import ledger
>>> journal = ledger.read_journal('alias-test.dat')
>>> journal.expand_aliases('Assets:Account:GB04BARC20474473160944').fullname()
'Assets:Current
```

```
account Assets:Current
    alias Assets:Account:GB04BARC20474473160944
```