### PR TITLE
Use an std::set instead of an std::list to store the the journal file paths

### DIFF
--- a/src/session.cc
+++ b/src/session.cc
@@ -76,7 +76,7 @@ std::size_t session_t::read_data(const string& master_account)
       file = path(home_var) / ".ledger";
 
     if (! file.empty() && exists(file))
-      HANDLER(file_).data_files.push_back(file);
+      HANDLER(file_).data_files.insert(file);
     else
       throw_(parse_error, "No journal file was specified (please use -f)");
 
@@ -214,7 +214,7 @@ journal_t * session_t::read_journal_files()
 journal_t * session_t::read_journal(const path& pathname)
 {
   HANDLER(file_).data_files.clear();
-  HANDLER(file_).data_files.push_back(pathname);
+  HANDLER(file_).data_files.insert(pathname);
 
   return read_journal_files();
 }

--- a/src/session.h
+++ b/src/session.h
@@ -52,6 +52,16 @@ namespace ledger {
 
 class xact_t;
 
+struct ComparePaths
+{
+  bool operator()(const path& p1, const path& p2) const
+  {
+    return p1 < p2 && !boost::filesystem::equivalent(p1, p2);
+  }
+};
+
+#define COMMA ,
+
 class session_t : public symbol_scope_t
 {
   friend void set_session_context(session_t * session);
@@ -143,7 +153,7 @@ public:
 
   OPTION__
   (session_t, file_, // -f
-   std::set<path> data_files;
+   std::set<path COMMA ComparePaths> data_files;
    CTOR(session_t, file_) {}
    DO_(str) {
      if (parent->flush_on_next_data_file) {

--- a/src/session.h
+++ b/src/session.h
@@ -143,14 +143,14 @@ public:
 
   OPTION__
   (session_t, file_, // -f
-   std::list<path> data_files;
+   std::set<path> data_files;
    CTOR(session_t, file_) {}
    DO_(str) {
      if (parent->flush_on_next_data_file) {
        data_files.clear();
        parent->flush_on_next_data_file = false;
      }
-     data_files.push_back(str);
+     data_files.insert(str);
    });
 
   OPTION_(session_t, input_date_format_, DO_(str) {


### PR DESCRIPTION
As it does not make sense to use a certain journal file several times we should use a set instead of a list to store the journal file paths in order to ensure that the paths added are actually unique. Unfortunately, this change does not account for the fact that links and relative paths might be used to get different paths that actually point to the same file, but it is a first step in the right direction.

Please don't pull this yet, as its is a work in progress