### PR TITLE
Homebrew installs Python bindings by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,6 @@ You can use [Homebrew] or [MacPorts] to install Ledger easily on OS X.
 You can see the parameters you can pass while installing with brew by the command `brew options ledger`. To install ledger, simply type the following command:
 
     $ brew install ledger
-    
-If everything worked well, you should have ledger working now. If you want to install this with python bindings, you can use the following command:
-
-    $ brew install ledger --with-python
 
 If you to want to startup python, use the following command:
 


### PR DESCRIPTION
As per https://github.com/Homebrew/homebrew-core/blob/2dfe5715a8f11f07b6460bed40d885c168c09ca7/Formula/ledger.rb#L19 there is `--without-python` instead. The default installs Python bindings.
  