### PR TITLE
Fix segfault when using --market with --group-by

### DIFF
--- a/src/filters.h
+++ b/src/filters.h
@@ -565,9 +565,9 @@ public:
     last_display_total = value_t();
 
     temps.clear();
-    create_accounts();
-
     item_handler<post_t>::clear();
+
+    create_accounts();
   }
 };
 
@@ -627,9 +627,9 @@ public:
     last_total = value_t();
 
     temps.clear();
-    create_accounts();
-
     item_handler<post_t>::clear();
+
+    create_accounts();
   }
 };
 

--- a/test/regress/market-group-by.test
+++ b/test/regress/market-group-by.test
@@ -1,0 +1,26 @@
+D 1000.00 EUR
+
+2008/04/15 * Paid expenses back from cie.
+   Expenses:Cie-Reimbursements    2000 CAD @ 1.10 EUR
+   Assets:Checking
+
+2008/04/15 * Paid expenses back from cie.
+   Expenses:Cie-Reimbursements    2000 USD @ 1.10 EUR
+   Assets:Checking
+
+P 2008/04/20 00:00:00 CAD 1.20 EUR
+P 2008/04/20 00:00:00 USD 1.20 EUR
+
+test reg -V --group-by commodity
+CAD
+08-Apr-15 Paid expenses back .. Exp:Cie-Reimbursements  2200.00 EUR  2200.00 EUR
+08-Apr-20 Commodities revalued  <Revalued>               200.00 EUR  2400.00 EUR
+
+EUR
+08-Apr-15 Paid expenses back .. Assets:Checking        -2200.00 EUR -2200.00 EUR
+08-Apr-15 Paid expenses back .. Assets:Checking        -2200.00 EUR -4400.00 EUR
+
+USD
+08-Apr-15 Paid expenses back .. Exp:Cie-Reimbursements  2200.00 EUR  2200.00 EUR
+08-Apr-20 Commodities revalued  <Revalued>               200.00 EUR  2400.00 EUR
+end test


### PR DESCRIPTION
`changed_value_posts::create_accounts()` reuses the `<Revalued>` account
from `display_filter`, but when clearing `changed_value_posts`
`create_accounts()` would be called before the account had been
recreated by `display_filter_posts`. This results in a segfault when
using the --group-by option.

I'm not sure if `display_filter_posts` has the same problem but I
reordered the calls there too for good measure.