### PR TITLE
Transfer null_post flags to generated postings

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -145,7 +145,7 @@ namespace {
         first = false;
       } else {
         unique_ptr<post_t> p(new post_t(null_post->account, amount.negated(),
-                                        ITEM_GENERATED | POST_CALCULATED));
+                                        null_post->flags() | ITEM_GENERATED | POST_CALCULATED));
         p->set_state(null_post->state());
         xact.add_post(p.release());
       }


### PR DESCRIPTION
Resolve issue where generated balanced postings would become real when the original null post was virtual.

Happens when multiple currencies are mixed with virtual null postings, reproduced like so:

```
2018/01/01 * Virtual
	[Account]  -2 USD
	[Account]  -2 JPY
	[Weird]
```

Would incorrectly generate a real balancing post:
```
$ ledger r
18-Jan-01 Virtual               [Account]                     -2 USD       -2 USD
                                [Account]                     -2 JPY       -2 JPY
                                                                           -2 USD
                                [Weird]                        2 JPY       -2 USD
                                Weird                          2 USD            0
```