### PR TITLE
Add support for --prepend-format in accounts command

### DIFF
--- a/src/output.cc
+++ b/src/output.cc
@@ -282,8 +282,23 @@ void format_accounts::operator()(account_t& account)
 void report_accounts::flush()
 {
   std::ostream& out(report.output_stream);
+  format_t      prepend_format;
+  std::size_t   prepend_width;
+
+  if (report.HANDLED(prepend_format_)) {
+    prepend_format.parse_format(report.HANDLER(prepend_format_).str());
+    prepend_width = report.HANDLED(prepend_width_)
+      ? lexical_cast<std::size_t>(report.HANDLER(prepend_width_).str())
+      : 0;
+  }
 
   foreach (accounts_pair& entry, accounts) {
+    if (prepend_format) {
+      bind_scope_t bound_scope(report, *entry.first);
+      out.width(static_cast<std::streamsize>(prepend_width));
+      out << prepend_format(bound_scope);
+    }
+
     if (report.HANDLED(count))
       out << entry.second << ' ';
     out << *entry.first << '\n';

--- a/test/baseline/opt-prepend-format.test
+++ b/test/baseline/opt-prepend-format.test
@@ -15,3 +15,8 @@ VMMXX07-Feb-02 RD VMMXX              As:Inves:Vanguar:VMMXX  0.350 VMMXX  0.350 
 VMMXX                                In:Divid:Vanguar:VMMXX       $-0.35       $-0.35
                                                                      0.350 VMMXX
 end test
+
+test accounts --prepend-format "%(account_base) "
+VMMXX Assets:Investments:Vanguard:VMMXX
+VMMXX Income:Dividends:Vanguard:VMMXX
+end test

--- a/test/baseline/opt-prepend-width.test
+++ b/test/baseline/opt-prepend-width.test
@@ -15,3 +15,8 @@ test reg --prepend-format "%(account_base) " --prepend-width=10
     VMMXX                                 In:Divid:Vanguar:VMMXX       $-0.35       $-0.35
                                                                                0.350 VMMXX
 end test
+
+test accounts --prepend-format "%(account_base) " --prepend-width=10
+    VMMXX Assets:Investments:Vanguard:VMMXX
+    VMMXX Income:Dividends:Vanguard:VMMXX
+end test


### PR DESCRIPTION
Add support for the `--prepend-format` and `--prepend-width` options in
the `accounts` command.