### PR TITLE
Add --check-cleared option

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -406,6 +406,8 @@ Specify the format to use for the
 report.
 .It Fl \-by-payee Pq Fl P
 Group postings in the register report by common payee names.
+.It Fl \-check-cleared
+Enable strict and pedantic checking for cleared transactions too.
 .It Fl \-check-payees
 Enable strict and pedantic checking for payees as well as accounts,
 commodities and tags.

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -93,6 +93,7 @@ void journal_t::initialize()
   current_context   = NULL;
   was_loaded        = false;
   force_checking    = false;
+  check_cleared     = false;
   check_payees      = false;
   day_break         = false;
   checking_style    = CHECK_NORMAL;
@@ -152,8 +153,9 @@ account_t * journal_t::register_account(const string& name, post_t * post,
           fixed_accounts = true;
         result->add_flags(ACCOUNT_KNOWN);
       }
-      else if (! fixed_accounts && post->_state != item_t::UNCLEARED) {
-        result->add_flags(ACCOUNT_KNOWN);
+      else if (! fixed_accounts
+              && (post->_state != item_t::UNCLEARED && ! check_cleared)) {
+          result->add_flags(ACCOUNT_KNOWN);
       }
       else if (checking_style == CHECK_WARNING) {
         current_context->warning(_f("Unknown account '%1%'") % result->fullname());

--- a/src/journal.h
+++ b/src/journal.h
@@ -116,6 +116,7 @@ public:
   bool                   fixed_metadata;
   bool                   was_loaded;
   bool                   force_checking;
+  bool                   check_cleared;
   bool                   check_payees;
   bool                   day_break;
   bool                   recursive_aliases;

--- a/src/session.cc
+++ b/src/session.cc
@@ -115,6 +115,8 @@ std::size_t session_t::read_data(const string& master_account)
 
   if (HANDLED(explicit))
     journal->force_checking = true;
+  if (HANDLED(check_cleared))
+    journal->check_cleared = true;
   if (HANDLED(check_payees))
     journal->check_payees = true;
 
@@ -317,6 +319,7 @@ option_t<session_t> * session_t::lookup_option(const char * p)
     OPT_CH(price_exp_);
     break;
   case 'c':
+    OPT(check_cleared);
     OPT(check_payees);
     break;
   case 'd':

--- a/src/session.h
+++ b/src/session.h
@@ -107,6 +107,7 @@ public:
 
   void report_options(std::ostream& out)
   {
+    HANDLER(check_cleared).report(out);
     HANDLER(check_payees).report(out);
     HANDLER(day_break).report(out);
     HANDLER(download).report(out);
@@ -135,6 +136,7 @@ public:
    * Option handlers
    */
 
+  OPTION(session_t, check_cleared);
   OPTION(session_t, check_payees);
   OPTION(session_t, day_break);
   OPTION(session_t, download); // -Q


### PR DESCRIPTION
Currently if the transaction is cleared, ledger skips the pedantic and
strict checking for it. This flag force the transaction to be checked
even if that's the case.