### PR TITLE
Don't throw away as many posts during budgeting

### DIFF
--- a/src/chain.cc
+++ b/src/chain.cc
@@ -69,7 +69,7 @@ post_handler_ptr chain_pre_post_handlers(post_handler_ptr base_handler,
   if (report.budget_flags != BUDGET_NO_BUDGET) {
     budget_posts * budget_handler =
       new budget_posts(handler, report.terminus.date(), report.budget_flags);
-    budget_handler->add_period_xacts(report.session.journal->period_xacts);
+    budget_handler->add_budgets(report.session.journal->period_xacts);
     handler.reset(budget_handler);
 
     // Apply this before the budget handler, so that only matching posts are

--- a/src/filters.h
+++ b/src/filters.h
@@ -955,6 +955,8 @@ class budget_posts : public generate_posts
   uint_least8_t flags;
   date_t        terminus;
 
+  std::set<account_t *> budgeted_accounts;
+
   budget_posts();
 
 public:
@@ -969,6 +971,7 @@ public:
   }
 
   void report_budget_items(const date_t& date);
+  void add_budgets(period_xacts_list& period_xacts);
 
   virtual void flush();
   virtual void operator()(post_t& post);


### PR DESCRIPTION
This doesn't really work nicely, my fix probably needs to have some idea of
intervals and dates as well.

The problem: https://groups.google.com/d/msg/ledger-cli/myzaSkSxYHA/Bn85TrDhBQAJ
Essentially, using `~ Monthly 2018/02` caused `ledger budget` to filter out
transactions. Only one budget category would be correctly processed. `~ Monthly`
worked.

I think the root problem is that we use `pending_posts` logically both for
1. Have we made the budget txn for this interval yet
2. Should some non-periodic txn be considered part of the budget?
   i.e. `post_in_budget`

This commit begins to separate that out. I started just using a set of "accounts
that have a budget" to prove that conflating the logic caused the UI bugs I saw.
But this still has issues with multiple dates if the budget categories change.
And `ledger --unbudgeted reg` and `ledger --budget reg` aren't quite right
either. It seems like the postings are split between the two views (but my code
is probably just not correctly adding the `Assets` account to my new set).