### PR TITLE
Fix warnings for -Wimplicit-fallthrough

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -47,7 +47,7 @@ namespace ledger {
 extern std::ostringstream _desc_buffer;
 
 template <typename T>
-inline void throw_func(const string& message) {
+[[ noreturn ]] inline void throw_func(const string& message) {
   _desc_buffer.clear();
   _desc_buffer.str("");
   throw T(message);

--- a/src/mask.cc
+++ b/src/mask.cc
@@ -75,9 +75,8 @@ mask_t& mask_t::assign_glob(const string& pat)
       if (i + 1 < len) {
         re_pat += pat[++i];
         break;
-      } else {
-        // fallthrough...
       }
+      // fallthrough...
     default:
       re_pat += pat[i];
       break;

--- a/src/query.cc
+++ b/src/query.cc
@@ -155,6 +155,7 @@ query_t::lexer_t::next_token(query_t::lexer_t::token_t::kind_t tok_context)
       case ')':
         if (! consume_next && tok_context == token_t::TOK_EXPR)
           goto test_ident;
+        // fall through...
       case '(':
       case '&':
       case '|':


### PR DESCRIPTION
I have not tested these for `clang`, but I think ``[[ noreturn ]]` is standard.