### PR TITLE
Fix auto xact posts not getting applied to account total durring journal parse

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -396,9 +396,9 @@ bool xact_base_t::finalize()
       }
 
       if (post->has_flags(POST_DEFERRED))
-          post->account->add_deferred_post(id(), post);
-        else
-          post->account->add_post(post);
+        post->account->add_deferred_post(id(), post);
+      else
+        post->account->add_post(post);
 
       post->xdata().add_flags(POST_EXT_VISITED);
       post->account->xdata().add_flags(ACCOUNT_EXT_VISITED);
@@ -805,6 +805,9 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context)
 
         xact.add_post(new_post);
         new_post->account->add_post(new_post);
+
+        // Add flag so this post updates the account balance
+        new_post->xdata().add_flags(POST_EXT_VISITED);
 
         if (new_post->must_balance())
           needs_further_verification = true;


### PR DESCRIPTION
This fixes some open issues related to balance assertions and auto transactions.

Durring journal parse, the auto xact posts are added but not flagged as visited like normal posts. So when the balance assertion is calculated, the account amount does not include the auto xacts in the calculation.

Should fix #538, #525, and my own use case :)