### PR TITLE
budget_posts: Keep pending items until the last day they apply

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1245,18 +1245,33 @@ void generate_posts::add_post(const date_interval_t& period, post_t& post)
 
 void budget_posts::report_budget_items(const date_t& date)
 {
+  { // Cleanup pending items that finished before date
+    // We have to keep them until the last day they apply because operator() needs them to see if a
+    // posting is budgeted or not
+    std::list<pending_posts_list::iterator> posts_to_erase;
+    for (pending_posts_list::iterator i = pending_posts.begin(); i != pending_posts.end(); i++) {
+      pending_posts_list::value_type& pair(*i);
+      if (pair.first.finish && ! pair.first.start && pair.first.finish < date) {
+        posts_to_erase.push_back(i);
+      }
+    }
+    foreach (pending_posts_list::iterator& i, posts_to_erase)
+      pending_posts.erase(i);
+  }
+  
   if (pending_posts.size() == 0)
     return;
 
   bool reported;
   do {
-    std::list<pending_posts_list::iterator> posts_to_erase;
-
     reported = false;
     for (pending_posts_list::iterator i = pending_posts.begin();
          i != pending_posts.end();
          i++) {
       pending_posts_list::value_type& pair(*i);
+
+      if (pair.first.finish && ! pair.first.start)
+        continue;               // skip expired posts
 
       optional<date_t> begin = pair.first.start;
       if (! begin) {
@@ -1285,9 +1300,6 @@ void budget_posts::report_budget_items(const date_t& date)
         post_t& post = *pair.second;
 
         ++pair.first;
-        if (! pair.first.start)
-          posts_to_erase.push_back(i);
-
         DEBUG("budget.generate", "Reporting budget for "
               << post.reported_account()->fullname());
 
@@ -1312,9 +1324,6 @@ void budget_posts::report_budget_items(const date_t& date)
         reported = true;
       }
     }
-
-    foreach (pending_posts_list::iterator& i, posts_to_erase)
-      pending_posts.erase(i);
   } while (reported);
 }
 

--- a/test/regress/fix-missing-trans-in-last-budget-period.test
+++ b/test/regress/fix-missing-trans-in-last-budget-period.test
@@ -1,0 +1,79 @@
+= ~ ^A
+    [Balance]                                                 1
+    [Budget:$account]                                         -1
+
+~ Monthly from 2014/01 to 2014/12/31
+  [Budget:A]    100.00 USD
+  [Balance]
+
+~ Monthly from 2014/01 to 2014/12/31
+  [Budget:Z]    100.00 USD
+  [Balance]
+
+2014/10/01  toto0
+	    [Budget:A:B]  0.01 USD
+	    [Balance]
+
+2014/11/01  toto1
+   A:B      51.00 USD
+   Cash
+
+2014/11/02  toto2
+   A:B      52.00 USD
+   Cash
+
+2014/11/03  toto3
+   A:B      53.00 USD
+   Cash
+
+2014/11/04  toto4
+   A:B      54.00 USD
+   Cash
+
+2014/12/08  toto5
+   A:B      55.00 USD
+   Cash
+
+2014/12/09  toto6
+   A:B      56.00 USD
+   Cash
+
+2014/12/10  toto7
+   A:B      57.00 USD
+   Cash
+
+2014/12/11  toto8
+   A:B      58.00 USD
+   Cash
+
+2014/12/12  toto9
+   A:B      59.00 USD
+   Cash
+
+2014/12/12  toto9
+   C      59.00 USD
+   Cash
+
+2015/01/12  toto10
+   A:B     59.00 USD
+   Cash
+
+test reg --budget -b 2014/10 -e 2015/02 --columns 80 --date-format "%F" reg ^Bu
+2014-10-01 Budget transaction   [Budget:A]              -100.00 USD  -100.00 USD
+2014-10-01 Budget transaction   [Budget:Z]              -100.00 USD  -200.00 USD
+2014-10-01 toto0                [Budget:A]                 0.01 USD  -199.99 USD
+2014-11-01 Budget transaction   [Budget:A]              -100.00 USD  -299.99 USD
+2014-11-01 Budget transaction   [Budget:Z]              -100.00 USD  -399.99 USD
+2014-11-01 toto1                [Budget:A]               -51.00 USD  -450.99 USD
+2014-11-02 toto2                [Budget:A]               -52.00 USD  -502.99 USD
+2014-11-03 toto3                [Budget:A]               -53.00 USD  -555.99 USD
+2014-11-04 toto4                [Budget:A]               -54.00 USD  -609.99 USD
+2014-12-01 Budget transaction   [Budget:A]              -100.00 USD  -709.99 USD
+2014-12-01 Budget transaction   [Budget:Z]              -100.00 USD  -809.99 USD
+2014-12-08 toto5                [Budget:A]               -55.00 USD  -864.99 USD
+2014-12-09 toto6                [Budget:A]               -56.00 USD  -920.99 USD
+2014-12-10 toto7                [Budget:A]               -57.00 USD  -977.99 USD
+2014-12-11 toto8                [Budget:A]               -58.00 USD -1035.99 USD
+2014-12-12 toto9                [Budget:A]               -59.00 USD -1094.99 USD
+2015-01-12 toto10               [Budget:A]               -59.00 USD -1153.99 USD
+end test


### PR DESCRIPTION
@mthurman as myself found out that posts that belong to a budget are missing from the register report on the last period of a budget.
This should fix that and may replace pull request https://github.com/ledger/ledger/pull/537.
@mthurman thanks for spotting the location this saved me a lot of time.
 