### PR TITLE
Make automated transactions work with assertions

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -806,8 +806,9 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context)
         xact.add_post(new_post);
         new_post->account->add_post(new_post);
 
-        // Add flag so this post updates the account balance
+        // Add flags so this post updates the account balance
         new_post->xdata().add_flags(POST_EXT_VISITED);
+        new_post->account->xdata().add_flags(ACCOUNT_EXT_VISITED);
 
         if (new_post->must_balance())
           needs_further_verification = true;

--- a/test/regress/1127.test
+++ b/test/regress/1127.test
@@ -1,0 +1,15 @@
+; Test that automated transactions are added to accounts soon enough
+; for assertions to work.
+
+= expr account =~ /^Assets/
+    (Foo)                            1
+
+2018-06-09 Something
+    Assets                           $100
+    Equity
+
+2018-06-09 Assert amount added by automated transaction
+    [Foo]                            = $100
+test bal Foo
+                $100  Foo
+end test


### PR DESCRIPTION
This fixes issue #1127.  In my understanding, PR #552 was meant to fix
this, but was incomplete.

Without this patch, automated transactions are invisible to
assertions.

This patch fixes this by adding a flag to the account to tell it that
there is a new posting, analogous to the behavior of finalize().

I dug up issue #1127 too late to find that this is the same solution
proposed by @tbm.  Although I wrote this independently, credit goes to
Martin Michlmayr (@tbm).