### PR TITLE
Fix garbled dates when using --date-format

### DIFF
--- a/src/print.cc
+++ b/src/print.cc
@@ -103,11 +103,13 @@ namespace {
   void print_xact(report_t& report, std::ostream& out, xact_t& xact)
   {
     format_type_t          format_type = FMT_WRITTEN;
+    string                 format_str;
     optional<const char *> format;
 
     if (report.HANDLED(date_format_)) {
       format_type = FMT_CUSTOM;
-      format      = report.HANDLER(date_format_).str().c_str();
+      format_str  = report.HANDLER(date_format_).str();
+      format      = format_str.c_str();
     }
 
     std::ostringstream buf;


### PR DESCRIPTION
Capture the `std::string` value from options in a local variable that
lives as long as the `c_str()` taken from it to ensure it does not get
freed prematurely.

Fixes: #546