### PR TITLE
Timelog: Not able to check-in to multiple accounts at a time

### DIFF
--- a/src/timelog.cc
+++ b/src/timelog.cc
@@ -170,7 +170,7 @@ void time_log_t::close()
     foreach (account_t * account, accounts) {
       DEBUG("timelog", "Clocking out from account " << account->fullname());
       context.count += clock_out_from_timelog
-        (time_xacts, time_xact_t(none, CURRENT_TIME(), account), context);
+        (time_xacts, time_xact_t(none, CURRENT_TIME(), false, account), context);
     }
     assert(time_xacts.empty());
   }


### PR DESCRIPTION
Checking-in to multiple accounts at a time throws the following error
"When multiple check-ins are active, checking out requires an account"

Issue is that the acount name was sent as 3rd parameter to time_xact_t
constructor whereas it is supposed to be sent as 4th parameter

Corrected the argument position of account name in constructor call to
time_xact_t