### PR TITLE
Unbreak build against Boost 1.68

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -44,7 +44,11 @@
 #ifndef _UTILS_H
 #define _UTILS_H
 
+#if (BOOST_VERSION >= 106600)
+#include <boost/uuid/detail/sha1.hpp>
+#else
 #include <boost/uuid/sha1.hpp>
+#endif
 
 /**
  * @name Default values


### PR DESCRIPTION
After boostorg/uuid@33da3e2a5b87 (and boostorg/uuid@3d2f7758e9e1) build fails. See [error log](https://ptpb.pw/Mtja).
Can you also backport to `master` and `release/3.1.2` branches?

CC @ilovezfs
