### PR TITLE
Improve fix of issue #1187

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -3230,6 +3230,45 @@ A balance assertion has this general form:
 This simply asserts that after subtracting $20.00 from Assets:Cash,
 that the resulting total matches $500.00.  If not, it is an error.
 
+The assertion has an effect only on the specified commodity. If an account has
+multiple commodities, then only the one asserted is verified:
+
+@smallexample
+2012-03-10 KFC New York
+    Expenses:Food                $20.00
+    Assets:Cash                 $-20.00 = $500.00
+
+2012-03-11 KFC Montreal
+    Expenses:Food                 15.00 CAD
+    Assets:Cash                  -15.00 CAD = $500.00
+@end smallexample
+
+In this case, the amount in USD of cash (which has not changed) is validated.
+Nothing is asserted about the current amount of Canadian dollars in @samp{Asset:Cash}.
+
+@subsubsection Special assertion value 0
+
+The only value that can be asserted without a commodity is @samp{0}.
+This results in a cross-commodities assertion, which makes it possible to
+assert that an account is totally empty.
+
+@smallexample
+2012-03-09 Fill Wallet
+    Revenue                      $20.00
+    Revenue                       15.00 CAD
+    Assets:Cash
+
+2012-03-10 KFC New York
+    Expenses:Food                $20.00
+    Assets:Cash                 $-20.00
+
+2012-03-11 KFC Montreal
+    Expenses:Food                 15.00 CAD
+    Assets:Cash                  -15.00 CAD = 0
+@end smallexample
+
+The last transaction will assert that we are out of cash of any sort.
+
 @node Balance assignments, Resetting a balance, Balance assertions, Balance verification
 @subsection Balance assignments
 

--- a/test/regress/1187_5.test
+++ b/test/regress/1187_5.test
@@ -1,0 +1,36 @@
+2013/12/01 * Initial State
+    Crédit:Viseca:MasterCard P1                        -618.50 CHF
+    Crédit:Viseca:MasterCard P2                         -52.10 CHF
+    Equity:Opening Balances
+
+2013/12/15 * Buy Some Chocolate
+    Dépenses:Nourriture                                  19.00 EUR ; #1
+    Crédit:Viseca:MasterCard P1
+
+2013/12/15 * Buy Some Chocolate
+    Crédit:Viseca:MasterCard P1                          18.00 EUR ; #2
+    Recettes:Erreurs
+
+2013/12/23 * Facture Viseca
+    Crédit:Viseca:MasterCard P2                          52.10 CHF = 0 ; #3
+    Crédit:Viseca:MasterCard P1                         618.50 CHF = 0 CHF ; #4
+    Dépenses:Frais:Gestion Comptes                        1.50 CHF
+    Crédit:Viseca                                      -672.10 CHF
+
+2014/01/03 * Facture Viseca
+    Crédit:Viseca                                       672.10 CHF = 0
+    Actif:Comptes:CP courant
+
+test bal
+         -672.10 CHF  Actif:Comptes:CP courant
+           -1.00 EUR  Crédit:Viseca
+           -1.00 EUR    MasterCard P1
+            1.50 CHF
+           19.00 EUR  Dépenses
+            1.50 CHF    Frais:Gestion Comptes
+           19.00 EUR    Nourriture
+          670.60 CHF  Equity:Opening Balances
+          -18.00 EUR  Recettes:Erreurs
+--------------------
+                   0
+end test


### PR DESCRIPTION
I coded a bit on a better fix for issue 1187. What I did:
- the computation of the diff between what is in the account and the assertion is now a `balance_t` instead of `amount_t`, so it handles multiple currencies.
- it then checks only the the commodity specified in the assertion amount when verifying the assertion
- if the assertion value is 0 without a commodity, it will ensure that the diff is zero for all commodities.

Added a test, updated documentation. Feel free to comment.