### PR TITLE
Add notes to 5.7.1.1 Payee metadata tag doc

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -3104,8 +3104,11 @@ This shows that they are all in the same transaction (which is why the
 date is not repeated), but they have different payees now.
 
 If using the @option{--strict} or @option{--pedantic} options, you must
-declare this tag to avoid warnings and errors. The payee name used with
-the tag is not enforced by the @option{--check-payees} option.
+declare this tag to avoid warnings and errors.
+
+The payee name used with the tag is not enforced by the
+@option{--check-payees} option, due to a bug:
+@url{https://github.com/ledger/ledger/issues/556}.
 
 @node Metadata values, Typed metadata, Metadata tags, Metadata
 @subsection Metadata values

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -3103,6 +3103,10 @@ it appears as:
 This shows that they are all in the same transaction (which is why the
 date is not repeated), but they have different payees now.
 
+If using the @option{--strict} or @option{--pedantic} options, you must
+declare this tag to avoid warnings and errors. The payee name used with
+the tag is not enforced by the @option{--check-payees} option.
+
 @node Metadata values, Typed metadata, Metadata tags, Metadata
 @subsection Metadata values
 


### PR DESCRIPTION
Based on my observations. The first behavior makes sense to me. For the second, it would be nice if ledger would enforce `--check-payees` on the tag. In either case I thought it would be helpful to call these out.