### PR TITLE
Improve bash completion

### DIFF
--- a/contrib/ledger-completion.bash
+++ b/contrib/ledger-completion.bash
@@ -59,7 +59,7 @@ _ledger()
     accounts="Assets Liabilities Equity Revenue Expenses"
 
     case $prev in
-        --@(cache|file|init-file|output|pager|price-db|script))
+        --@(cache|file|init-file|output|pager|price-db|script)|-@(f|i|o))
             _filedir
             return 0
             ;;


### PR DESCRIPTION
Add completion of option shorthands `-f`, `-i` and `-o`.

/cc @thdox 