### PR TITLE
explain round brackets in section 3.8 on multiple funds

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -1384,10 +1384,11 @@ account:
     (Funds:School)                   $-100.00
 @end smallexample
 
-When reports are generated, by default they'll appear in terms of the
-funds.  In this case, you will likely want to mask out your
-@samp{Assets} account, because otherwise the balance won't make much
-sense:
+The use of round brackets creates a virtual posting without ensuring 
+a balance to zero. When reports are generated, by default they'll 
+appear in terms of the funds. In this case, you will likely want to 
+mask out your @samp{Assets} account, because otherwise the balance 
+won't make much sense:
 
 @smallexample @c command:396F24E
 $ ledger --no-total bal not ^Assets


### PR DESCRIPTION
Section "Working with multiple funds and accounts" introduces square brackets and explains them but does not explain round brackets in the following example. This commit adds the explanation what the round brackets do.