### PR TITLE
Expose post_t::given_cost over python

### DIFF
--- a/src/py_post.cc
+++ b/src/py_post.cc
@@ -153,6 +153,11 @@ void export_post()
                               return_value_policy<return_by_value>()),
                   make_setter(&post_t::cost,
                               return_value_policy<return_by_value>()))
+    .add_property("given_cost",
+                  make_getter(&post_t::given_cost,
+                              return_value_policy<return_by_value>()),
+                  make_setter(&post_t::given_cost,
+                              return_value_policy<return_by_value>()))
     .add_property("assigned_amount",
                   make_getter(&post_t::assigned_amount,
                               return_value_policy<return_by_value>()),


### PR DESCRIPTION
This fixes #1655 by making the post_t::given_cost variable accessible
over python.

This allows access to the given cost of a posting.  For example, here
it will be "-2 EUR":

A  -2 XXX {1 EUR} [2018-01-01] @@ 2 EUR

If a per-unit cost is given, the given_cost variable will still
contain the cost of the posting.  For example, here it will be
"-4 EUR":

B  -2 XXX {1 EUR} [2018-01-01] @ 2 EUR