### PR TITLE
[WIP] force travis to show full test output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ before_script:
   - make
 
 script:
-  - ctest --output-on-failure
+  - ctest --verbose
   - PYTHONPATH=. python python/demo.py
 
 after_script:

--- a/src/org.cc
+++ b/src/org.cc
@@ -96,7 +96,7 @@ void posts_to_org_table::operator()(post_t& post)
     bind_scope_t bound_scope(report, post);
 
     if (! header_printed) {
-      out << "|Date|Code|Payee|X|Account|Amount|Total|Note|\n"
+      out << "|BUG|Code|Payee|X|Account|Amount|Total|Note|\n"
           << "|-|\n"
           << "|||<20>|||<r>|<r>|<20>|\n";
       header_printed = true;


### PR DESCRIPTION
This is not really intended to be accepted and merged.

I just want Travis to run one build with this verbose ctest setting.  I'm finding it hard to believe that  baseline/cmd-org.test is passing on Travis, given issue 1706 and my own walkthrough of `org.cc` 