### PR TITLE
Remove unused function py_dump_relaxed()

### DIFF
--- a/src/py_value.cc
+++ b/src/py_value.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2018, John Wiegley.  All rights reserved.
+ * Copyright (c) 2003-2019, John Wiegley.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -85,12 +85,6 @@ namespace {
   string py_dump(const value_t& value) {
     std::ostringstream buf;
     value.dump(buf);
-    return buf.str();
-  }
-
-  string py_dump_relaxed(const value_t& value) {
-    std::ostringstream buf;
-    value.dump(buf, true);
     return buf.str();
   }
 


### PR DESCRIPTION
The only user of py_dump_relaxed() was removed in commit
0bbb4f2f0cbaa6ffb5c7a2c018a3819cca0b2405.