### PR TITLE
Suppress fallthrough warnings

### DIFF
--- a/src/mask.cc
+++ b/src/mask.cc
@@ -75,9 +75,8 @@ mask_t& mask_t::assign_glob(const string& pat)
       if (i + 1 < len) {
         re_pat += pat[++i];
         break;
-      } else {
-        // fallthrough...
       }
+      // fall through...
     default:
       re_pat += pat[i];
       break;

--- a/src/query.cc
+++ b/src/query.cc
@@ -155,6 +155,7 @@ query_t::lexer_t::next_token(query_t::lexer_t::token_t::kind_t tok_context)
       case ')':
         if (! consume_next && tok_context == token_t::TOK_EXPR)
           goto test_ident;
+        // fall through...
       case '(':
       case '&':
       case '|':
@@ -228,10 +229,13 @@ void query_t::lexer_t::token_t::unexpected()
   switch (prev_kind) {
   case END_REACHED:
     throw_(parse_error, _("Unexpected end of expression"));
+    break;
   case TERM:
     throw_(parse_error, _f("Unexpected string '%1%'") % *value);
+    break;
   default:
     throw_(parse_error, _f("Unexpected token '%1%'") % symbol());
+    break;
   }
 }
 

--- a/src/report.cc
+++ b/src/report.cc
@@ -1343,21 +1343,26 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind,
       case 'i':
         throw_(std::runtime_error,
                _("The i value expression variable is no longer supported"));
+        break;
       case 'A':
         throw_(std::runtime_error,
                _("The A value expression variable is no longer supported"));
+        break;
       case 'v':
       case 'V':
         throw_(std::runtime_error,
                _("The V and v value expression variables are no longer supported"));
+        break;
       case 'I':
       case 'B':
         throw_(std::runtime_error,
                _("The I and B value expression variables are no longer supported"));
+        break;
       case 'g':
       case 'G':
         throw_(std::runtime_error,
                _("The G and g value expression variables are no longer supported"));
+        break;
       default:
         return NULL;
       }

--- a/src/times.cc
+++ b/src/times.cc
@@ -1692,6 +1692,7 @@ void date_parser_t::lexer_t::token_t::unexpected()
   case END_REACHED:
     kind = UNKNOWN;
     throw_(date_error, _("Unexpected end of expression"));
+    break;
   default: {
     string desc = to_string();
     kind = UNKNOWN;

--- a/src/token.cc
+++ b/src/token.cc
@@ -478,24 +478,31 @@ void expr_t::token_t::unexpected(const char wanted)
     switch (prev_kind) {
     case TOK_EOF:
       throw_(parse_error, _("Unexpected end of expression"));
+      break;
     case IDENT:
       throw_(parse_error, _f("Unexpected symbol '%1%'") % value);
+      break;
     case VALUE:
       throw_(parse_error, _f("Unexpected value '%1%'") % value);
+      break;
     default:
       throw_(parse_error, _f("Unexpected expression token '%1%'") % symbol);
+      break;
     }
   } else {
     switch (prev_kind) {
     case TOK_EOF:
       throw_(parse_error,
              _f("Unexpected end of expression (wanted '%1%')") % wanted);
+      break;
     case IDENT:
       throw_(parse_error,
              _f("Unexpected symbol '%1%' (wanted '%2%')") % value % wanted);
+      break;
     case VALUE:
       throw_(parse_error,
              _f("Unexpected value '%1%' (wanted '%2%')") % value % wanted);
+      break;
     default:
       throw_(parse_error, _f("Unexpected expression token '%1%' (wanted '%2%')")
              % symbol % wanted);

--- a/src/value.cc
+++ b/src/value.cc
@@ -105,6 +105,7 @@ value_t::operator bool() const
     throw_(value_error,
            _f("Cannot determine truth of %1% (did you mean 'account =~ %2%'?)")
            % label() % out.str());
+    break;
   }
   case SEQUENCE:
     if (! as_sequence().empty()) {


### PR DESCRIPTION
My compiler has new warnings switched on by default, so that now it is visible that the compiler does not understand that the macro+template combo about throw_ is actually unconditionally throwing an exception (and exiting the function).

This change is about adding 
 - 'break' statements where needed to help the compiler 
 - add "// fall through" comments where fall through is wanted, also to make the compiler not warn about it.