### PR TITLE
Prefer system utf8cpp if available

### DIFF
--- a/cmake/FindUtfcpp.cmake
+++ b/cmake/FindUtfcpp.cmake
@@ -10,7 +10,8 @@ set(UTFCPP_FOUND FALSE)
 
 find_path(UTFCPP_INCLUDE_DIR
     NAMES utf8.h
-    HINTS  "${UTFCPP_PATH}" "${PROJECT_SOURCE_DIR}/lib/utfcpp/v2_0/source"
+    HINTS "${UTFCPP_PATH}"
+    PATHS "${PROJECT_SOURCE_DIR}/lib/utfcpp/v2_0/source"
 )
 
 if (UTFCPP_INCLUDE_DIR)


### PR DESCRIPTION
The current logic always uses the bundled utf8cpp.  This is contrary
to the stated intent of commit
1d7dd3e082be8a046f21d4a2d51026ac3c1f7c14 if UTFCPP_PATH is not set
explicitly.