### PR TITLE
Remove workaround for isspace() on FreeBSD 4 and earlier

### DIFF
--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -136,11 +136,6 @@ typedef std::ostream::pos_type ostream_pos_type;
 #include <cstring>
 #include <csignal>
 
-#if defined __FreeBSD__ && __FreeBSD__ <= 4
-// FreeBSD has a broken isspace macro, so don't use it
-#undef isspace(c)
-#endif
-
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <io.h>
 #else


### PR DESCRIPTION
FreeBSD 4 was declared end-of-life in 2006
(https://lists.freebsd.org/pipermail/freebsd-security/2006-October/004111.html).
Currently, only FreeBSD 11 and 12 are supported
(https://www.freebsd.org/security/security.html#sup).