### PR TITLE
Fix some boost format strings

### DIFF
--- a/src/draft.cc
+++ b/src/draft.cc
@@ -68,7 +68,7 @@ void draft_t::xact_template_t::dump(std::ostream& out) const
   } else {
     foreach (const post_template_t& post, posts) {
       out << std::endl
-          << _f("[Posting \"%1\"]") % (post.from ? _("from") : _("to"))
+          << _f("[Posting \"%1%\"]") % (post.from ? _("from") : _("to"))
           << std::endl;
 
       if (post.account_mask)

--- a/src/xact.h
+++ b/src/xact.h
@@ -115,7 +115,7 @@ public:
   virtual string description() {
     if (pos) {
       std::ostringstream buf;
-      buf << _f("transaction at line %1") << pos->beg_line;
+      buf << _f("transaction at line %1%") % pos->beg_line;
       return buf.str();
     } else {
       return string(_("generated transaction"));
@@ -177,7 +177,7 @@ public:
   virtual string description() {
     if (pos) {
       std::ostringstream buf;
-      buf << _f("automated transaction at line %1") << pos->beg_line;
+      buf << _f("automated transaction at line %1%") % pos->beg_line;
       return buf.str();
     } else {
       return string(_("generated automated transaction"));
@@ -220,7 +220,7 @@ class period_xact_t : public xact_base_t
   virtual string description() {
     if (pos) {
       std::ostringstream buf;
-      buf << _f("periodic transaction at line %1") << pos->beg_line;
+      buf << _f("periodic transaction at line %1%") % pos->beg_line;
       return buf.str();
     } else {
       return string(_("generated periodic transaction"));


### PR DESCRIPTION
Noticed while trying to run with --debug.

Not completely sure about `draft.cc` as I didn't run that, but seems plausible.

Fixes:

Error: boost::bad_format_string: format-string is ill-formed