### PR TITLE
Drop conditionals for Boost earlier than 1.49

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2018, John Wiegley.  All rights reserved.
+ * Copyright (c) 2003-2019, John Wiegley.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -113,11 +113,7 @@ inline parse_context_t open_for_reading(const path& pathname,
                                         const path& cwd)
 {
   path filename = resolve_path(pathname);
-#if BOOST_VERSION >= 104600 && BOOST_FILESYSTEM_VERSION >= 3
   filename = filesystem::absolute(filename, cwd);
-#else
-  filename = filesystem::complete(filename, cwd);
-#endif
   if (! exists(filename) || is_directory(filename))
     throw_(std::runtime_error,
            _f("Cannot read journal file %1%") % filename);

--- a/src/main.cc
+++ b/src/main.cc
@@ -73,9 +73,6 @@ int main(int argc, char * argv[], char * envp[])
 
   // Initialize global Boost/C++ environment
   std::ios::sync_with_stdio(false);
-#if BOOST_VERSION < 104600
-  filesystem::path::default_name_check(filesystem::portable_posix_name);
-#endif
 
   std::signal(SIGINT, sigint_handler);
 #if !defined(_WIN32) && !defined(__CYGWIN__)

--- a/src/pyinterp.cc
+++ b/src/pyinterp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2018, John Wiegley.  All rights reserved.
+ * Copyright (c) 2003-2019, John Wiegley.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -222,27 +222,13 @@ object python_interpreter_t::import_option(const string& str)
   python::list paths(sys_dict["path"]);
 
   if (contains(str, ".py")) {
-#if BOOST_VERSION >= 103700
     path& cwd(parsing_context.get_current().current_directory);
-#if BOOST_VERSION >= 104600 && BOOST_FILESYSTEM_VERSION >= 3
     path parent(filesystem::absolute(file, cwd).parent_path());
-#else
-    path parent(filesystem::complete(file, cwd).parent_path());
-#endif
     DEBUG("python.interp", "Adding " << parent << " to PYTHONPATH");
     paths.insert(0, parent.string());
     sys_dict["path"] = paths;
 
-#if BOOST_VERSION >= 104600
     name = file.stem().string();
-#else
-    name = file.stem();
-#endif
-#else // BOOST_VERSION >= 103700
-    paths.insert(0, file.branch_path().string());
-    sys_dict["path"] = paths;
-    name = file.leaf();
-#endif // BOOST_VERSION >= 103700
   }
 
   try {

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2018, John Wiegley.  All rights reserved.
+ * Copyright (c) 2003-2019, John Wiegley.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -89,11 +89,7 @@ namespace {
     else {                      // parent
       close(pfd[0]);
       typedef iostreams::stream<iostreams::file_descriptor_sink> fdstream;
-#if BOOST_VERSION >= 104400
       *os = new fdstream(pfd[1], iostreams::never_close_handle);
-#else // BOOST_VERSION >= 104400
-      *os = new fdstream(pfd[1]);
-#endif // BOOST_VERSION >= 104400
     }
     return pfd[1];
 #else

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2018, John Wiegley.  All rights reserved.
+ * Copyright (c) 2003-2019, John Wiegley.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -743,17 +743,8 @@ void instance_t::include_directive(char * line)
   DEBUG("textual.include", "resolved path: " << filename.string());
 
   mask_t glob;
-#if BOOST_VERSION >= 103700
   path   parent_path = filename.parent_path();
-#if BOOST_VERSION >= 104600
   glob.assign_glob('^' + filename.filename().string() + '$');
-#else
-  glob.assign_glob('^' + filename.filename() + '$');
-#endif
-#else // BOOST_VERSION >= 103700
-  path   parent_path = filename.branch_path();
-  glob.assign_glob('^' + filename.leaf() + '$');
-#endif // BOOST_VERSION >= 103700
 
   bool files_found = false;
   if (exists(parent_path)) {
@@ -761,21 +752,9 @@ void instance_t::include_directive(char * line)
     for (filesystem::directory_iterator iter(parent_path);
          iter != end;
          ++iter) {
-#if BOOST_VERSION <= 103500
-      if (is_regular(*iter))
-#else
       if (is_regular_file(*iter))
-#endif
         {
-#if BOOST_VERSION >= 103700
-#if BOOST_VERSION >= 104600
         string base = (*iter).path().filename().string();
-#else
-        string base = (*iter).filename();
-#endif
-#else // BOOST_VERSION >= 103700
-        string base = (*iter).leaf();
-#endif // BOOST_VERSION >= 103700
         if (glob.match(base)) {
           journal_t *  journal  = context.journal;
           account_t *  master   = top_account();

--- a/src/value.cc
+++ b/src/value.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2018, John Wiegley.  All rights reserved.
+ * Copyright (c) 2003-2019, John Wiegley.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -129,11 +129,7 @@ value_t::operator bool() const
 void value_t::set_type(type_t new_type)
 {
   if (new_type == VOID) {
-#if BOOST_VERSION >= 103700
     storage.reset();
-#else
-    storage = intrusive_ptr<storage_t>();
-#endif
   } else {
     if (! storage || storage->refc > 1)
       storage = new storage_t;

--- a/src/value.h
+++ b/src/value.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003-2018, John Wiegley.  All rights reserved.
+ * Copyright (c) 2003-2019, John Wiegley.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -878,22 +878,14 @@ public:
     VERIFY(! is_null());
 
     if (! is_sequence()) {
-#if BOOST_VERSION >= 103700
       storage.reset();
-#else
-      storage = intrusive_ptr<storage_t>();
-#endif
     } else {
       as_sequence_lval().pop_back();
 
       const sequence_t& seq(as_sequence());
       std::size_t new_size = seq.size();
       if (new_size == 0) {
-#if BOOST_VERSION >= 103700
         storage.reset();
-#else
-        storage = intrusive_ptr<storage_t>();
-#endif
       }
       else if (new_size == 1) {
         *this = seq.front();


### PR DESCRIPTION
Ledger requires Boost 1.49 or later and enforces this in
CMakeLists.txt.  This means BOOST_VERSION will always be
104900 or higher.  Also, since Boost 1.46,
BOOST_FILESYSTEM_VERSION is 3.