### PR TITLE
Do not set dependencies for target check

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,8 +27,6 @@ macro(add_ledger_harness_tests _class)
           ${TestFile} ${TEST_PYTHON_FLAGS})
         set_tests_properties(${_class}Test_${TestFile_Name}
           PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE}")
-        set_target_properties(check 
-          PROPERTIES DEPENDS ${_class}Test_${TestFile_Name})
       endif()
     endforeach()
   endif()
@@ -48,8 +46,6 @@ if (PYTHONINTERP_FOUND)
       --ledger $<TARGET_FILE:ledger> --file ${TestFile})
     set_tests_properties(${_class}Test_${TestFile_Name}
       PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE}")
-    set_target_properties(check
-      PROPERTIES DEPENDS ${_class}Test_${TestFile_Name})
   endforeach()
 
   # CheckManpage and CheckTexinfo are disabled, since they do not work

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -20,7 +20,4 @@ if (BUILD_LIBRARY)
     target_link_libraries(MathTests ${PYTHON_LIBRARIES})
   endif()
   add_ledger_test(MathTests)
-
-  set_target_properties(check PROPERTIES DEPENDS LedgerUtilTests)
-  set_target_properties(check PROPERTIES DEPENDS LedgerMathTests)
 endif()


### PR DESCRIPTION
The set_target_properties() commands themselves do not cause the tests
to run if the target check is made, and as the target check executes
ctest, all tests will be run anyway.