### PR TITLE
Ignore null deferred postings

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -45,6 +45,9 @@
 - Fix parsing issue of effective dates (bug #1722, TALOS-2017-0303,
   CVE-2017-2807)
 
+- Fix use-after-free issue with deferred postings (bug #1723, TALOS-2017-0304,
+  CVE-2017-2808)
+
 - Python: Removed double quotes from Unicode values.
 
 - Python: Ensure that parse errors produce useful RuntimeErrors

--- a/src/xact.cc
+++ b/src/xact.cc
@@ -395,10 +395,12 @@ bool xact_base_t::finalize()
         some_null = true;
       }
 
-      if (post->has_flags(POST_DEFERRED))
-        post->account->add_deferred_post(id(), post);
-      else
+      if (post->has_flags(POST_DEFERRED)) {
+        if (!post->amount.is_null())
+            post->account->add_deferred_post(id(), post);
+      } else {
         post->account->add_post(post);
+      }
 
       post->xdata().add_flags(POST_EXT_VISITED);
       post->account->xdata().add_flags(ACCOUNT_EXT_VISITED);

--- a/test/regress/1723.test
+++ b/test/regress/1723.test
@@ -1,0 +1,5 @@
+2017/3/17 deferred posting
+    <deferred posting>
+
+test reg
+end test


### PR DESCRIPTION
All-null transactions are discarded and thus freed, but with a deferred
posting this results in a use-after-free error when the deferred
postings are applied.

Ignore null deferred postings to prevent this.

Fixes #1723