### PR TITLE
Add tzdata to build dependencies for Ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,7 +57,7 @@ A: You're probably missing some dependency libraries.  If you tried
         libboost-date-time-dev libboost-filesystem-dev \
         libboost-graph-dev libboost-iostreams-dev \
         libboost-python-dev libboost-regex-dev libboost-test-dev \
-        doxygen libedit-dev libmpc-dev
+        doxygen libedit-dev libmpc-dev tzdata
 
 ----------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ following packages (current as of Ubuntu 18.04):
          libboost-system-dev libboost-dev python-dev gettext git \
          libboost-date-time-dev libboost-filesystem-dev \
          libboost-iostreams-dev libboost-python-dev libboost-regex-dev \
-         libboost-test-dev libedit-dev libgmp3-dev libmpfr-dev texinfo
+         libboost-test-dev libedit-dev libgmp3-dev libmpfr-dev texinfo tzdata
 
 ### Debian
 

--- a/acprep
+++ b/acprep
@@ -62,7 +62,8 @@ class BoostInfo(object):
         if system == 'centos':
             return [ 'boost-devel' ]
 
-        elif system == 'ubuntu-bionic' or system == 'ubuntu-xenial' or system == 'ubuntu-trusty':
+        elif system in ('ubuntu-bionic', 'ubuntu-xenial',
+                        'ubuntu-trusty', 'ubuntu-cosmic'):
             return [ 'libboost-dev',
                      'libboost-date-time-dev',
                      'libboost-filesystem-dev',
@@ -70,7 +71,8 @@ class BoostInfo(object):
                      'libboost-python-dev',
                      'libboost-regex-dev',
                      'libboost-system-dev',
-                     'libboost-test-dev' ]
+                     'libboost-test-dev',
+                     'tzdata' ]
 
         elif system == 'ubuntu-saucy' or system == 'ubuntu-precise':
             return [ 'autopoint',


### PR DESCRIPTION
The test suite uses the symbolic time zone name "America/Chicago".  To
resolve that, the tzdata package needs to be installed.  This fixes
#1739.