### PR TITLE
Use CMAKE_CXX_COMPILER_ID for conditions based on compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,8 +296,7 @@ configure_file(
   ${PROJECT_SOURCE_DIR}/src/system.hh.in
   ${PROJECT_BINARY_DIR}/system.hh)
 
-if((CMAKE_CXX_COMPILER MATCHES "clang") OR
-   (CMAKE_CXX_COMPILER MATCHES "clang\\+\\+"))
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,7 +144,7 @@ if (WIN32 OR CYGWIN)
 endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  if (CMAKE_CXX_COMPILER MATCHES "clang\\+\\+")
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     add_definitions(
       # -Weverything
       # -Wno-disabled-macro-expansion
@@ -199,7 +199,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         DEPENDS ${_header_filename})
     endmacro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
 
-  elseif (CMAKE_CXX_COMPILER MATCHES "g\\+\\+")
+  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(GXX_WARNING_FLAGS
       -pedantic
       -Wall


### PR DESCRIPTION
CMAKE_CXX_COMPILER is the path to the compiler binary and does not
need to follow a specific pattern.  For example, on Linux with GCC and
without an explicit "-DCMAKE_CXX_COMPILER:PATH=" option,
CMAKE_CXX_COMPILER is "/usr/bin/c++" which does not match "g++".
CMAKE_CXX_COMPILER_ID however will always reliably be "Clang" or
"GNU".