### PR TITLE
Fix use-after-free when destroying filter chain

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -54,6 +54,8 @@
 - Fix possible stack overflow in date parsing routine (bug #1224,
   CVE-2017-12482)
 
+- Fix use-after-free when using --gain (bug #541)
+
 - Python: Removed double quotes from Unicode values.
 
 - Python: Ensure that parse errors produce useful RuntimeErrors

--- a/src/filters.h
+++ b/src/filters.h
@@ -604,6 +604,7 @@ public:
 
   virtual ~changed_value_posts() {
     TRACE_DTOR(changed_value_posts);
+    temps.clear();
     handler.reset();
   }
 


### PR DESCRIPTION
When using the `--gain` option the `temporaries_t` in
`changed_value_posts` filter stores a reference to the `<Revalued>` temp
account created in `display_filter_posts`. When destroying the filter
chain `display_filter_posts` is destroyed before `changed_value_posts`
and this can result in a use-after-free in `temporaries_t::clear()` when
`temps` in `changed_value_posts` is cleared during destruction if there
are any temp posts referencing the `<Revalued>` account.

Fix the issue by clearing the `temporaries_t` in `changed_value_posts`
before destroying the rest of the filter chain (which includes
`display_filter_posts`).

Fixes #541