### PR TITLE
Add Travis CI setup for macOS and homebrew-installed Boost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler:
   - gcc
 os:
   - linux
+  - osx
 sudo: false
 cache:
   apt: true
@@ -20,7 +21,17 @@ env:
   matrix:
     # Boost version to build against; an empty string means the
     # distribution's default.
+    - BOOST_VERSION=""
     - BOOST_VERSION="1.61.0"
+
+# The configuration for macOS only works with Boost installed by
+# homebrew, so exclude the other combinations.
+matrix:
+  exclude:
+    - os: linux
+      env: BOOST_VERSION=""
+    - os: osx
+      env: BOOST_VERSION="1.61.0"
 
 addons:
   coverity_scan:
@@ -44,6 +55,12 @@ addons:
       - libboost-iostreams-dev
       - libboost-filesystem-dev
       - libboost-serialization-dev
+  homebrew:
+    packages:
+      - boost
+      - boost-python
+      - gmp
+      - mpfr
 
 before_install:
   - |
@@ -66,8 +83,12 @@ install:
     fi
 
 before_script:
-  - cmake . -DUSE_PYTHON=ON -DBUILD_DEBUG=ON
-  - make
+  # On macOS, CMake finds the Boost.Python installed by homebrew only
+  # with the component name "python27".  Also, precompiling system.hh
+  # does not work.
+  - if [ "$TRAVIS_OS_NAME" = osx -a -z "$BOOST_VERSION" ]; then EXTRA_CMAKE_ARGS="-DPRECOMPILE_SYSTEM_HH=OFF -DUSE_PYTHON27_COMPONENT=ON"; fi
+  - cmake . -DUSE_PYTHON=ON -DBUILD_DEBUG=ON $EXTRA_CMAKE_ARGS
+  - make VERBOSE=1
 
 script:
   - ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,12 @@ endif()
 ########################################################################
 
 option(USE_PYTHON "Build support for the Python scripting bridge" OFF)
+OPTION(USE_PYTHON27_COMPONENT "Use python27 as name of Boost.Python component" OFF)
 option(USE_DOXYGEN "Build reference documentation using Doxygen" OFF)
 
 option(DISABLE_ASSERTS "Build without any internal consistency checks" OFF)
 option(BUILD_DEBUG "Build support for runtime debugging" OFF)
+option(PRECOMPILE_SYSTEM_HH "Precompile system.hh" ON)
 
 option(BUILD_LIBRARY "Build and install Ledger as a library" ON)
 option(BUILD_DOCS "Build and install documentation" OFF)
@@ -67,7 +69,11 @@ if (USE_PYTHON)
 
   find_package(PythonLibs)
   if (PYTHONLIBS_FOUND)
-    set(BOOST_PYTHON python)
+    if(USE_PYTHON27_COMPONENT)
+      set(BOOST_PYTHON "python27")
+    else()
+      set(BOOST_PYTHON "python")
+    endif()
     set(HAVE_BOOST_PYTHON 1)
     include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
   else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,7 +267,9 @@ else()
   endmacro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
 endif()
 
-add_pch_rule(${PROJECT_BINARY_DIR}/system.hh LEDGER_SOURCES LEDGER_CLI_SOURCES)
+if(PRECOMPILE_SYSTEM_HH)
+  add_pch_rule(${PROJECT_BINARY_DIR}/system.hh LEDGER_SOURCES LEDGER_CLI_SOURCES)
+endif()
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
On macOS, CMake detects the Boost.Python component installed by
homebrew only when named "python27".  Thus this change not only adds a
Travis CI setup for macOS, but also a CMake option to switch the
component name between "python" and "python27".  In addition,
precompiling system.hh does not work with the current setup for Clang,
so another CMake option to disable it is added.

The currently used commands to compile specific versions of Boost do
not produce a result that works out of the box on macOS.  It should be
possible just to mimic homebrew's formula for boost-python
(https://github.com/Homebrew/homebrew-core/blob/master/Formula/boost-python.rb),
but for the moment on macOS this change tests only against Boost
installed by homebrew.