### PR TITLE
Fix possible fail acprep make doc [ci skip]

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -401,7 +401,7 @@ options.  You can run `make check` to confirm the result, and `make
 install` to install.  If these intructions do not work for you can check the
 `INSTALL.md` in the source directory for more up do date build instructions.
 
-@node Getting help, , Building the program, Introduction to Ledger
+@node Getting help, Third-Party Ledger Tutorials, Building the program, Introduction to Ledger
 @section Getting help
 @findex help
 


### PR DESCRIPTION
on macos 10.14.2 with

- boost : 1.68.0
- makeinfo : 4.8
- texi2pdf : 1.34

error before correction 
```
/Users/samuel/github.com/ledger/ledger/doc/ledger3.texi:421: Le champ Prev du noeud « Third-Party Ledger Tutorials » n'a pas de pointeur de retour en amont.
/Users/samuel/github.com/ledger/ledger/doc/ledger3.texi:404: Ce noeud (Getting help) a un noeud « Next » erroné.
```