### PR TITLE
Fix tag value parsing

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -4,6 +4,8 @@
 
 - Properly reject postings with a comment right after the flag (bug #1753)
 
+- Fix bug in tag value parsing (bug #1702)
+
 * 3.1.2 (2019-02-05)
 
 - Increase maximum length for regex from 255 to 4095 (bug #981)

--- a/src/item.cc
+++ b/src/item.cc
@@ -198,7 +198,7 @@ void item_t::parse_tags(const char * p,
       tag = string(q, len - index);
 
       string_map::iterator i;
-      string field(p + len + index);
+      string field(p + (q - buf.get()) + len);
       trim(field);
       if (by_value) {
         bind_scope_t bound_scope(scope, *this);

--- a/test/regress/1702.test
+++ b/test/regress/1702.test
@@ -1,0 +1,17 @@
+tag Foo
+    assert value =~ /^Bar$/
+
+2019/01/01 * Payee
+    ;; Foo: Bar
+    Income:Foo    $-1
+    Assets:Cash    $1
+2019/01/01 * Another Payee
+    Assets:Cash   $-1
+    Expenses:Baz   $1
+
+test bal
+                  $1  Expenses:Baz
+                 $-1  Income:Foo
+--------------------
+                   0
+end test


### PR DESCRIPTION
If a tag is more than 2 characters from the beginning of the comment the
tag value offset will be wrong. #1702 gives an example where the tag
line starts with `;;` and the tag value thus becomes `: Bar` because of
this bug.

The use `index` in the offset calulation seems to be a lucky coincidence
that works in the common case: "; tag: value"

Fixes #1702