### PR TITLE
add step $ ./acprep dependencies to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,7 @@
 
 To build this code after doing a Git clone, run:
 
+    $ ./acprep dependencies
     $ ./acprep update
 
 If anything goes wrong, see "COMMON CONFIGURE/BUILD PROBLEMS" below.


### PR DESCRIPTION
I followed the steps in the INSTALL.md and ran into issues.

I would have avoided troubleshooting if the `./acprep dependencies` had been at the top of INSTALL.md
The documentation shows all three steps.