### PR TITLE
Add support for '%F' date format specifier

### DIFF
--- a/src/times.cc
+++ b/src/times.cc
@@ -55,18 +55,18 @@ namespace {
 
     temporal_io_t(const char * _fmt_str, bool _input)
       : fmt_str(_fmt_str),
-        traits(icontains(fmt_str, "%y"),
-               icontains(fmt_str, "%m") || icontains(fmt_str, "%b"),
-               icontains(fmt_str, "%d")),
+        traits(icontains(fmt_str, "%F") || icontains(fmt_str, "%y"),
+               icontains(fmt_str, "%F") || icontains(fmt_str, "%m") || icontains(fmt_str, "%b"),
+               icontains(fmt_str, "%F") || icontains(fmt_str, "%d")),
         input(_input) {
     }
 
     void set_format(const char * fmt) {
       fmt_str  = fmt;
-      traits   = date_traits_t(icontains(fmt_str, "%y"),
-                               icontains(fmt_str, "%m") ||
-                               icontains(fmt_str, "%b"),
-                               icontains(fmt_str, "%d"));
+      traits   = date_traits_t(icontains(fmt_str, "%F") || icontains(fmt_str, "%y"),
+                               icontains(fmt_str, "%F") ||
+                               icontains(fmt_str, "%m") || icontains(fmt_str, "%b"),
+                               icontains(fmt_str, "%F") || icontains(fmt_str, "%d"));
     }
 
     T parse(const char *) {}

--- a/src/times.cc
+++ b/src/times.cc
@@ -114,7 +114,6 @@ namespace {
 
   shared_ptr<datetime_io_t> input_datetime_io;
   shared_ptr<datetime_io_t> timelog_datetime_io;
-  shared_ptr<date_io_t>     input_date_io;
   shared_ptr<datetime_io_t> written_datetime_io;
   shared_ptr<date_io_t>     written_date_io;
   shared_ptr<datetime_io_t> printed_datetime_io;
@@ -174,13 +173,6 @@ namespace {
 
   date_t parse_date_mask(const char * date_str, date_traits_t * traits = NULL)
   {
-    if (input_date_io.get()) {
-      date_t when = parse_date_mask_routine(date_str, *input_date_io.get(),
-                                            traits);
-      if (! when.is_not_a_date())
-        return when;
-    }
-
     foreach (shared_ptr<date_io_t>& reader, readers) {
       date_t when = parse_date_mask_routine(date_str, *reader.get(), traits);
       if (! when.is_not_a_date())
@@ -1745,7 +1737,6 @@ void times_shutdown()
   if (is_initialized) {
     input_datetime_io.reset();
     timelog_datetime_io.reset();
-    input_date_io.reset();
     written_datetime_io.reset();
     written_date_io.reset();
     printed_datetime_io.reset();

--- a/test/regress/1775.test
+++ b/test/regress/1775.test
@@ -1,0 +1,20 @@
+2017-02-28 * Test
+    Assets:A                10.00 EUR
+    Assets:B               -10.00 EUR
+
+2017-03-30 * Test
+    Assets:A                10.00 EUR
+    Assets:B               -10.00 EUR
+
+2018-03-30 * Test
+    Assets:A                10.00 EUR
+    Assets:B               -10.00 EUR
+
+test reg --input-date-format %F
+17-Feb-28 Test                  Assets:A                  10.00 EUR    10.00 EUR
+                                Assets:B                 -10.00 EUR            0
+17-Mar-30 Test                  Assets:A                  10.00 EUR    10.00 EUR
+                                Assets:B                 -10.00 EUR            0
+18-Mar-30 Test                  Assets:A                  10.00 EUR    10.00 EUR
+                                Assets:B                 -10.00 EUR            0
+end test


### PR DESCRIPTION
'%F' is equivalent to '%Y-%m-%d'. Using the '%F' format without this
change this would not give any hard errors but instead give dates with
wrong years because the 'has_year' trait would not be correctly
detected and thus parsed dates would get set to the current year.

Fixes #1775