### PR TITLE
Add --averaged-lot-prices

### DIFF
--- a/src/balance.h
+++ b/src/balance.h
@@ -603,6 +603,8 @@ inline std::ostream& operator<<(std::ostream& out, const balance_t& bal) {
 
 void put_balance(property_tree::ptree& pt, const balance_t& bal);
 
+balance_t average_lot_prices(const balance_t& bal);
+
 } // namespace ledger
 
 #endif // _BALANCE_H

--- a/src/report.cc
+++ b/src/report.cc
@@ -563,6 +563,14 @@ value_t report_t::fn_should_bold(call_scope_t& scope)
     return false;
 }
 
+value_t report_t::fn_averaged_lots(call_scope_t& args)
+{
+  if (args.has<balance_t>(0))
+    return average_lot_prices(args.get<balance_t>(0));
+  else
+    return args[0];
+}
+
 value_t report_t::fn_market(call_scope_t& args)
 {
   value_t result;
@@ -1130,6 +1138,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT(average);
     else OPT(account_width_);
     else OPT(amount_width_);
+    else OPT(average_lot_prices);
     break;
   case 'b':
     OPT(balance_format_);
@@ -1370,6 +1379,8 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind,
         return MAKE_FUNCTOR(report_t::fn_ansify_if);
       else if (is_eq(p, "abs"))
         return MAKE_FUNCTOR(report_t::fn_abs);
+      else if (is_eq(p, "averaged_lots"))
+        return MAKE_FUNCTOR(report_t::fn_averaged_lots);
       break;
 
     case 'b':

--- a/src/report.h
+++ b/src/report.h
@@ -202,6 +202,7 @@ public:
   value_t fn_to_string(call_scope_t& scope);
   value_t fn_to_mask(call_scope_t& scope);
   value_t fn_to_sequence(call_scope_t& scope);
+  value_t fn_averaged_lots(call_scope_t& scope);
 
   value_t fn_now(call_scope_t&) {
     return terminus;
@@ -298,6 +299,7 @@ public:
     HANDLER(limit_).report(out);
     HANDLER(lot_dates).report(out);
     HANDLER(lot_prices).report(out);
+    HANDLER(average_lot_prices).report(out);
     HANDLER(lot_notes).report(out);
     HANDLER(lots).report(out);
     HANDLER(lots_actual).report(out);
@@ -745,6 +747,13 @@ public:
 
   OPTION(report_t, lot_dates);
   OPTION(report_t, lot_prices);
+  OPTION_(report_t, average_lot_prices, DO() {
+      OTHER(lot_prices).on(whence);
+      OTHER(display_amount_)
+        .on(whence, "averaged_lots(display_amount)");
+      OTHER(display_total_)
+        .on(whence, "averaged_lots(display_total)");
+    });
   OPTION(report_t, lot_notes);
   OPTION(report_t, lots);
   OPTION(report_t, lots_actual);


### PR DESCRIPTION
This joins together lots of the same underlying, averaging the reported price
and using the date of the oldest lot.