### PR TITLE
Remove know-ification of elements due to post state

### DIFF
--- a/src/journal.cc
+++ b/src/journal.cc
@@ -152,9 +152,6 @@ account_t * journal_t::register_account(const string& name, post_t * post,
           fixed_accounts = true;
         result->add_flags(ACCOUNT_KNOWN);
       }
-      else if (! fixed_accounts && post->_state != item_t::UNCLEARED) {
-        result->add_flags(ACCOUNT_KNOWN);
-      }
       else if (checking_style == CHECK_WARNING) {
         current_context->warning(_f("Unknown account '%1%'") % result->fullname());
       }
@@ -237,9 +234,6 @@ string journal_t::register_payee(const string& name, xact_t * xact)
           fixed_payees = true;
         known_payees.insert(name);
       }
-      else if (! fixed_payees && xact->_state != item_t::UNCLEARED) {
-        known_payees.insert(name);
-      }
       else if (checking_style == CHECK_WARNING) {
         current_context->warning(_f("Unknown payee '%1%'") % name);
       }
@@ -269,13 +263,6 @@ void journal_t::register_commodity(commodity_t& comm,
           fixed_commodities = true;
         comm.add_flags(COMMODITY_KNOWN);
       }
-      else if (! fixed_commodities &&
-               ((context.which() == 1 &&
-                 boost::get<xact_t *>(context)->_state != item_t::UNCLEARED) ||
-                (context.which() == 2 &&
-                 boost::get<post_t *>(context)->_state != item_t::UNCLEARED))) {
-        comm.add_flags(COMMODITY_KNOWN);
-      }
       else if (checking_style == CHECK_WARNING) {
         current_context->warning(_f("Unknown commodity '%1%'") % comm);
       }
@@ -296,13 +283,6 @@ void journal_t::register_metadata(const string& key, const value_t& value,
       if (context.which() == 0) {
         if (force_checking)
           fixed_metadata = true;
-        known_tags.insert(key);
-      }
-      else if (! fixed_metadata &&
-               ((context.which() == 1 &&
-                 boost::get<xact_t *>(context)->_state != item_t::UNCLEARED) ||
-                (context.which() == 2 &&
-                 boost::get<post_t *>(context)->_state != item_t::UNCLEARED))) {
         known_tags.insert(key);
       }
       else if (checking_style == CHECK_WARNING) {

--- a/test/baseline/opt-pedantic.test
+++ b/test/baseline/opt-pedantic.test
@@ -6,12 +6,16 @@
     Expenses:Phone            20.00 GBP
     Assets:Cash
 
-test bal --pedantic -> 1
+test bal --pedantic -> 2
 __ERROR__
 While parsing file "$FILE", line 2:
 While parsing posting:
   Expenses:Phone            20.00 GBP
 
 Error: Unknown account 'Expenses:Phone'
-end test
+While parsing file "$FILE", line 6:
+While parsing posting:
+  Expenses:Phone            20.00 GBP
 
+Error: Unknown account 'Expenses:Phone'
+end test

--- a/test/baseline/opt-strict.test
+++ b/test/baseline/opt-strict.test
@@ -18,5 +18,13 @@ test reg --strict
 07-Feb-02 Baz                   Expenses:Foodx               $30.00       $30.00
                                 Assets:Cash                 $-30.00            0
 __ERROR__
+Warning: "$FILE", line 2: Unknown account 'Expenses:Food'
+Warning: "$FILE", line 2: Unknown commodity '$'
+Warning: "$FILE", line 3: Unknown account 'Assets:Cash'
+Warning: "$FILE", line 6: Unknown account 'Expenses:Food'
+Warning: "$FILE", line 6: Unknown commodity '$'
+Warning: "$FILE", line 7: Unknown account 'Assets:Cash'
 Warning: "$FILE", line 10: Unknown account 'Expenses:Foodx'
+Warning: "$FILE", line 10: Unknown commodity '$'
+Warning: "$FILE", line 11: Unknown account 'Assets:Cash'
 end test


### PR DESCRIPTION
While it seems intentional, elements (accounts, commodities, payees and tags) becoming "known" because they happen to be in a non-uncleared posting is very surprising (and undocumented?) behaviour. It seems to be not very useful and rather unfitting with the terms "strict" and "pedantic".

This PR removes this "know-ification" and updates the tests for strict and pedantic to match their newly expected output.