### PR TITLE
Fix build issues with boost 1.70

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,15 @@ env:
   matrix:
     # Boost version to build against; an empty string means the
     # distribution's default.
-    - BOOST_VERSION=""
-    - BOOST_VERSION="1.61.0"
+    - BOOST_VERSION="" CMAKE_VERSION=""
+    - BOOST_VERSION="1.70.0" CMAKE_VERSION="3.15.3"
 
 # The configuration for macOS only works with Boost installed by
 # homebrew, so exclude the other combinations.
 matrix:
   exclude:
-    - os: linux
-      env: BOOST_VERSION=""
     - os: osx
-      env: BOOST_VERSION="1.61.0"
+      env: BOOST_VERSION="1.70.0" CMAKE_VERSION="3.15.3"
 
 addons:
   coverity_scan:
@@ -57,10 +55,12 @@ addons:
       - libboost-serialization-dev
   homebrew:
     packages:
+      - cmake
       - boost
       - boost-python
       - gmp
       - mpfr
+    update: true
 
 before_install:
   - |
@@ -81,17 +81,27 @@ install:
         popd
         rm -Rf "${BOOST_SOURCE}"
     fi
+  - |
+    if [ -n "${CMAKE_VERSION}" ]; then
+      export CMAKE_ROOT="${HOME}/cmake"
+      mkdir "$CMAKE_ROOT"
+      CMAKE_BIN_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+      curl -Ls "$CMAKE_BIN_URL" |
+      tar x -C "$CMAKE_ROOT" --strip-components 1
+    fi
 
 before_script:
   # On macOS, CMake finds the Boost.Python installed by homebrew only
   # with the component name "python27".  Also, precompiling system.hh
   # does not work.
   - if [ "$TRAVIS_OS_NAME" = osx -a -z "$BOOST_VERSION" ]; then EXTRA_CMAKE_ARGS="-DPRECOMPILE_SYSTEM_HH=OFF -DUSE_PYTHON27_COMPONENT=ON"; fi
-  - cmake . -DUSE_PYTHON=ON -DBUILD_DEBUG=ON $EXTRA_CMAKE_ARGS
+  - if [ -n "${CMAKE_VERSION}" ]; then CMAKE="${CMAKE_ROOT}/bin/cmake"; else CMAKE="cmake"; fi
+  - $CMAKE . -DUSE_PYTHON=ON -DBUILD_DEBUG=ON $EXTRA_CMAKE_ARGS
   - make VERBOSE=1
 
 script:
-  - ctest --output-on-failure
+  - if [ -n "${CMAKE_VERSION}" ]; then CTEST="${CMAKE_ROOT}/bin/ctest"; else CTEST="ctest"; fi
+  - $CTEST --output-on-failure
   - PYTHONPATH=. python python/demo.py
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ install:
       mkdir "$CMAKE_ROOT"
       CMAKE_BIN_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
       curl -Ls "$CMAKE_BIN_URL" |
-      tar x -C "$CMAKE_ROOT" --strip-components 1
+      tar zx -C "$CMAKE_ROOT" --strip-components 1
     fi
 
 before_script:
@@ -96,6 +96,7 @@ before_script:
   # does not work.
   - if [ "$TRAVIS_OS_NAME" = osx -a -z "$BOOST_VERSION" ]; then EXTRA_CMAKE_ARGS="-DPRECOMPILE_SYSTEM_HH=OFF -DUSE_PYTHON27_COMPONENT=ON"; fi
   - if [ -n "${CMAKE_VERSION}" ]; then CMAKE="${CMAKE_ROOT}/bin/cmake"; else CMAKE="cmake"; fi
+  - echo "\$EXTRA_CMAKE_ARGS=\"${EXTRA_CMAKE_ARGS}\""
   - $CMAKE . -DUSE_PYTHON=ON -DBUILD_DEBUG=ON $EXTRA_CMAKE_ARGS
   - make VERBOSE=1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ endif()
 
 # Set BOOST_ROOT to help CMake to find the right Boost version
 set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_NO_BOOST_CMAKE ON)
 message(STATUS "Boost.Python component name: ${BOOST_PYTHON}")
 find_package(Boost 1.49.0
   REQUIRED date_time filesystem system iostreams regex unit_test_framework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ else()
 endif()
 
 # Set BOOST_ROOT to help CMake to find the right Boost version
+set(Boost_USE_STATIC_LIBS OFF)
+message(STATUS "Boost.Python component name: ${BOOST_PYTHON}")
 find_package(Boost 1.49.0
   REQUIRED date_time filesystem system iostreams regex unit_test_framework
   ${BOOST_PYTHON})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,7 +282,7 @@ if (BUILD_LIBRARY)
     SOVERSION ${Ledger_VERSION_MAJOR})
 
   add_executable(ledger main.cc global.cc)
-  target_link_libraries(ledger libledger)
+  target_link_libraries(ledger libledger rt)
   if (CMAKE_SYSTEM_NAME STREQUAL Darwin AND HAVE_BOOST_PYTHON)
     target_link_libraries(ledger ${PYTHON_LIBRARIES})
   endif()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,5 @@
 macro(add_ledger_test _name)
-  target_link_libraries(${_name} libledger)
+  target_link_libraries(${_name} libledger rt)
   add_test(Ledger${_name} ${PROJECT_BINARY_DIR}/${_name})
   set_tests_properties(Ledger${_name}
     PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE}")

--- a/test/unit/t_amount.cc
+++ b/test/unit/t_amount.cc
@@ -1,5 +1,6 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE math
+#include <boost/test/included/unit_test.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <system.hh>

--- a/test/unit/t_times.cc
+++ b/test/unit/t_times.cc
@@ -1,5 +1,6 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE util
+#include <boost/test/included/unit_test.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <system.hh>


### PR DESCRIPTION
Fixes https://github.com/ledger/ledger/issues/1822 when building with boost 1.70.

Credit: https://stackoverflow.com/questions/14715837/can-i-link-multiple-boost-unit-tests-into-a-single-test-binary

Could we possibly create a release or pre-release to include these changes? conda-forge prefers to build only on full releases instead of master.