### PR TITLE
Add note regarding $account under --strict or --pedantic modes

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -3889,6 +3889,12 @@ Becomes:
     Assets:Cash                 $-20.00
 @end smallexample
 
+Keep in mind that if you are using @option{--strict} or @option{--pedantic} you will have to explicitly define an account @samp{$account} to avoid errors.
+
+@smallexample @c input:validate
+account $account
+@end smallexample
+
 @node Applying metadata to every matched posting, Applying metadata to the generated posting, Referring to the matching posting's account, Automated Transactions
 @subsection Applying metadata to every matched posting
 


### PR DESCRIPTION
This change adds a warning in the documentation for users using automated transactions with `--strict` or `--pedantic`, as ledger will throw an error when `$account` is not defined explicitly (see #545).