### PR TITLE
Format annotations using format that can be parsed

### DIFF
--- a/src/annotate.cc
+++ b/src/annotate.cc
@@ -206,7 +206,7 @@ void annotation_t::print(std::ostream& out, bool keep_base,
 
   if (date &&
       (! no_computed_annotations || ! has_flags(ANNOTATION_DATE_CALCULATED)))
-    out << " [" << format_date(*date, FMT_PRINTED) << ']';
+    out << " [" << format_date(*date, FMT_WRITTEN) << ']';
 
   if (tag &&
       (! no_computed_annotations || ! has_flags(ANNOTATION_TAG_CALCULATED)))

--- a/src/times.cc
+++ b/src/times.cc
@@ -1696,11 +1696,13 @@ namespace {
 
 void set_datetime_format(const char * format)
 {
+  written_datetime_io->set_format(format);
   printed_datetime_io->set_format(format);
 }
 
 void set_date_format(const char * format)
 {
+  written_date_io->set_format(format);
   printed_date_io->set_format(format);
 }
 

--- a/test/baseline/opt-register-format.test
+++ b/test/baseline/opt-register-format.test
@@ -3,6 +3,6 @@
     Income:Dividends:Vanguard:VMMXX        $-0.35
 
 test reg --register-format='%(amount)\n'
-0.350 VMMXX {$1.00} [07-Feb-02]
+0.350 VMMXX {$1.00} [2007/02/02]
 $-0.35
 end test

--- a/test/baseline/opt-rich-data.test
+++ b/test/baseline/opt-rich-data.test
@@ -27,14 +27,14 @@ end test
 test -f /dev/null convert test/baseline/feat-convert-with-directives.dat --rich-data --date-format %d-%m-%Y --now '2014/08/01'
 01-01-2012 * KFC
     ; CSV: 2012/01/01,KFC,$10
-    ; Imported: 2014/08/01
+    ; Imported: 01-08-2014
     ; UUID: 4352cc5a03f882f6f159b90a518667bde7200351
     Expenses:Unknown                             $10
     Equity:Unknown
 
 02-01-2012 * REWE SAGT DANKE  123454321
     ; CSV: 2012/01/02,"REWE SAGT DANKE  123454321",10€
-    ; Imported: 2014/08/01
+    ; Imported: 01-08-2014
     ; UUID: 4d04439fba0c7336377d1191c545efd0cfa15437
     Expenses:Unknown                             10€
     Equity:Unknown

--- a/test/regress/78AB4B87_py.test
+++ b/test/regress/78AB4B87_py.test
@@ -5,7 +5,7 @@ Total is presently: (0.00 EUR)
 Converted to EUR:   (-5.73 EUR)
 Total is now:       (-5.73 EUR)
 
--5.00 EUR {0.8733 GBP} [12-Jan-03]
+-5.00 EUR {0.8733 GBP} [2012/01/03]
 EUR
 Total is presently: (-5.73 EUR)
 Converted to EUR:   (-5.00 EUR)

--- a/test/regress/9188F587_py.test
+++ b/test/regress/9188F587_py.test
@@ -5,7 +5,7 @@ Total is presently: (0.00 EUR)
 Converted to EUR:   (-6.00 EUR)
 Total is now:       (-6.00 EUR)
 
--5.00 EUR {0.8733 GBP} [12-Jan-03]
+-5.00 EUR {0.8733 GBP} [2012/01/03]
 EUR
 Total is presently: (-6.00 EUR)
 Converted to EUR:   (-5.00 EUR)


### PR DESCRIPTION
I expect an output of `ledger print` to be consumable by ledger.

But on the next journal

```
2019/11/25 * test
    Foo    1 AAPL {1.00 EUR} [2019/11/24]
    Bar
```

it prints [19-Nov-24], which it does not understand with default options.

With this patch it prints [2019/11/24].