### PR TITLE
test: Unbreak one more test case with python3 bridge

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ macro(add_ledger_harness_tests _class)
           $<TARGET_FILE:ledger> ${PROJECT_SOURCE_DIR}
           ${TestFile} ${TEST_PYTHON_FLAGS})
         set_tests_properties(${_class}Test_${TestFile_Name}
-          PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE}")
+          PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=${Ledger_TEST_TIMEZONE}")
       endif()
     endforeach()
   endif()
@@ -45,7 +45,7 @@ if (Python_EXECUTABLE)
       COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/${_class}.py
       --ledger $<TARGET_FILE:ledger> --file ${TestFile})
     set_tests_properties(${_class}Test_${TestFile_Name}
-      PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE}")
+      PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=${Ledger_TEST_TIMEZONE}")
   endforeach()
 
   # CheckManpage and CheckTexinfo are disabled, since they do not work
@@ -56,7 +56,7 @@ if (Python_EXECUTABLE)
       COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/${_class}.py
       --ledger $<TARGET_FILE:ledger> --source ${PROJECT_SOURCE_DIR})
     set_tests_properties(${_class}
-      PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE}")
+      PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=${Ledger_TEST_TIMEZONE}")
   endforeach()
 endif()
 

--- a/test/regress/1057.test
+++ b/test/regress/1057.test
@@ -4,7 +4,7 @@
     * Passif:Crédit:BanqueAccord           -171,63 €
 
 test --now=2014/06/27 emacs
-(("$sourcepath/test/regress/1057.test" 1 (21308 60112 0) nil "www.amazon.fr"
+(("$sourcepath/test/regress/1057.test" 1 (21308 38512 0) nil "www.amazon.fr"
   (2 "Dépense:Loisir:Ordi:Matériel" "101,50 €" nil " disque dur portable 2,5\" 2000 Go")
   (3 "Dépense:Maison:Service:Poste" "70,13 €" nil)
   (4 "Passif:Crédit:BanqueAccord" "-171,63 €" t)))

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -2,7 +2,7 @@ macro(add_ledger_test _name)
   target_link_libraries(${_name} libledger)
   add_test(Ledger${_name} ${PROJECT_BINARY_DIR}/${_name})
   set_tests_properties(Ledger${_name}
-    PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE}")
+    PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=${Ledger_TEST_TIMEZONE}")
 endmacro(add_ledger_test _name)
 
 include_directories(${PROJECT_SOURCE_DIR}/src)


### PR DESCRIPTION
python3 has buffered output by default, hence testcase option_py
returned no output when executed under test harness. I think this is a
real problem in the way python interpreter is embeded, and i.e. stdout
is not flushed until after test case has died. However, running things
unbuffered seems to make everything work.

But for some reason I had to adjust 1057.test slightly. I have no idea
what those numbers mean, and if running things unbuffered break stuff.

Should be down to just 6 failures with python3.