### PR TITLE
Remove reference to lisp from default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,20 +9,11 @@ in
 stdenv.mkDerivation {
   name = "ledger-${version}-${rev}";
 
-  # NOTE: fetchgit because ledger has submodules not included in the
-  # default github tarball.
   src = ./.;
 
   buildInputs = [ cmake boost gmp mpfr libedit python texinfo gnused ];
 
   enableParallelBuilding = true;
-
-  # Skip byte-compiling of emacs-lisp files because this is currently
-  # broken in ledger...
-  postInstall = ''
-    mkdir -p $out/share/emacs/site-lisp/
-    cp -v "$src/lisp/"*.el $out/share/emacs/site-lisp/
-  '';
 
   cmakeFlags = [ "-DCMAKE_INSTALL_LIBDIR=lib" ];
 


### PR DESCRIPTION
There is no longer a submodule which provides elisp, so the `cp` portion of this expression fails.

Also remove obsolete comment about presence of gitmodules.

Background to this is that we're using nix to obtain `ledger` for the `ledger-mode` Travis builds, and building from this expression [fails in CI](https://travis-ci.org/ledger/ledger-mode/jobs/594317052).