### PR TITLE
fix #1850: segfault when using ledger print

### DIFF
--- a/src/journal.cc
+++ b/src/journal.cc
@@ -136,7 +136,7 @@ account_t * journal_t::register_account(const string& name, post_t * post,
   // the payee indicates an account that should be used.
   if (result->name == _("Unknown")) {
     foreach (account_mapping_t& value, payees_for_unknown_accounts) {
-      if (post && value.first.match(post->xact->payee)) {
+      if (post && post->xact && value.first.match(post->xact->payee)) {
         result = value.second;
         break;
       }


### PR DESCRIPTION
This solution does not break any tests, but seems wrong to me: what are the actual invariants w.r.t posts and their associated accounts? What is an xact_t anyway? 

However this is good enough as a workaround for me. Maybe someone else finds it useful as well.