### PR TITLE
Specify namespace of uintmax_t

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -253,7 +253,7 @@ void anonymize_posts::operator()(post_t& post)
     xact.copy_details(*post.xact);
 
     std::ostringstream buf;
-    buf << reinterpret_cast<uintmax_t>(post.xact->payee.c_str())
+    buf << reinterpret_cast<boost::uintmax_t>(post.xact->payee.c_str())
         << integer_gen() << post.xact->payee.c_str();
 
 		sha.reset();

--- a/src/filters.h
+++ b/src/filters.h
@@ -371,7 +371,7 @@ class anonymize_posts : public item_handler<post_t>
 public:
   anonymize_posts(post_handler_ptr handler)
     : item_handler<post_t>(handler), next_comm_id(0), last_xact(NULL),
-      rnd_gen(static_cast<unsigned int>(static_cast<uintmax_t>(std::time(0)))),
+      rnd_gen(static_cast<unsigned int>(static_cast<boost::uintmax_t>(std::time(0)))),
       integer_range(1, 2000000000L),
       integer_gen(rnd_gen, integer_range) {
     TRACE_CTOR(anonymize_posts, "post_handler_ptr");

--- a/src/journal.h
+++ b/src/journal.h
@@ -77,10 +77,10 @@ class journal_t : public noncopyable
 public:
   struct fileinfo_t
   {
-    optional<path> filename;
-    uintmax_t      size;
-    datetime_t     modtime;
-    bool           from_stream;
+    optional<path>   filename;
+    boost::uintmax_t size;
+    datetime_t       modtime;
+    bool             from_stream;
 
     fileinfo_t() : size(0), from_stream(true) {
       TRACE_CTOR(journal_t::fileinfo_t, "");


### PR DESCRIPTION
This fixes #1833 for me. @jwiegley said it's reasonable change, and
nobody else took action so here it goes.

The patch is the same as proposed originally, modulo whitespace.