### PR TITLE
fix: Fix #543 by tracking an account's real balance

### DIFF
--- a/src/account.h
+++ b/src/account.h
@@ -170,6 +170,7 @@ public:
     struct details_t
     {
       value_t            total;
+      value_t            real_total;
       bool               calculated;
       bool               gathered;
 
@@ -277,7 +278,7 @@ public:
     return *xdata_;
   }
 
-  value_t amount(const optional<expr_t&>& expr = none) const;
+  value_t amount(const optional<bool> real_only = false, const optional<expr_t&>& expr = none) const;
   value_t total(const optional<expr_t&>& expr = none) const;
 
   const xdata_t::details_t& self_details(bool gather_all = true) const;

--- a/src/py_account.cc
+++ b/src/py_account.cc
@@ -105,7 +105,7 @@ namespace {
 
   value_t py_amount_1(const account_t& account, const boost::optional<expr_t&>& expr)
   {
-      return account.amount(expr);
+      return account.amount(false, expr);
   }
 
   value_t py_total_0(const account_t& account)
@@ -133,6 +133,7 @@ void export_account()
 
   class_< account_t::xdata_t::details_t > ("AccountXDataDetails")
     .def_readonly("total", &account_t::xdata_t::details_t::total)
+    .def_readonly("real_total", &account_t::xdata_t::details_t::real_total)
     .def_readonly("calculated", &account_t::xdata_t::details_t::calculated)
     .def_readonly("gathered", &account_t::xdata_t::details_t::gathered)
 

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1633,7 +1633,7 @@ post_t * instance_t::parse_post(char *          line,
 
       const amount_t& amt(*post->assigned_amount);
       value_t account_total
-        (post->account->amount().strip_annotations(keep_details_t()));
+        (post->account->amount(!post->has_flags(POST_VIRTUAL)).strip_annotations(keep_details_t()));
 
       DEBUG("post.assign", "line " << context.linenum << ": "
             << "account balance = " << account_total);
@@ -1666,7 +1666,7 @@ post_t * instance_t::parse_post(char *          line,
 
       // Subtract amounts from previous posts to this account in the xact.
       for (post_t* p : xact->posts) {
-        if (p->account == post->account) {
+        if (p->account == post->account && p->has_flags(POST_VIRTUAL) == post->has_flags(POST_VIRTUAL)) {
           diff -= p->amount;
           DEBUG("textual.parse", "line " << context.linenum << ": "
                 << "Subtracting " << p->amount << ", diff = " << diff);

--- a/test/regress/543_a.test
+++ b/test/regress/543_a.test
@@ -1,0 +1,26 @@
+2018/01/01 * Opening Balance
+    Assets:Checking                             $100.00
+    Equity:Opening Balances
+
+2018/01/01 * Budget
+    [Assets:Checking]                           -$100.00
+    [Assets:Budget:Food:Groceries]              $20.00
+    [Assets:Budget:Food:Restaurants]            $80.00
+
+2018/01/02 * Assertion
+    [Assets:Checking]                           = $0.00
+
+2018/01/02 * Assertion
+    Assets:Checking                             = $100.00
+
+test bal Assets
+             $100.00  Assets:Budget:Food
+              $20.00    Groceries
+              $80.00    Restaurants
+--------------------
+             $100.00
+end test
+
+test bal Assets -R
+             $100.00  Assets:Checking
+end test

--- a/test/regress/543_b.test
+++ b/test/regress/543_b.test
@@ -1,0 +1,22 @@
+2018/01/01 * Opening Balance
+    Assets:Checking                             $100.00
+    Equity:Opening Balances
+
+2018/01/01 * Budget
+    [Assets:Checking]                           -$100.00
+    [Assets:Budget:Food:Groceries]              $20.00
+    [Assets:Budget:Food:Restaurants]            $80.00
+
+2018/01/02 * Buy Groceries
+    [Assets:Budget:Food:Groceries]              -$20 = $0
+    [Assets:Checking]                           $20
+    Assets:Checking                             -$20 = $80
+    Expenses:Food:Groceries                     $20
+
+test bal Assets
+              $80.00  Assets:Budget:Food:Restaurants
+end test
+
+test bal Assets -R
+              $80.00  Assets:Checking
+end test

--- a/test/regress/543_c.test
+++ b/test/regress/543_c.test
@@ -1,0 +1,24 @@
+2018/01/01 * Opening Balance
+    Assets:Checking                             $100.00
+    Equity:Opening Balances
+
+2018/01/01 * Budget
+    [Assets:Checking]                           -$100.00
+    [Assets:Budget:Food:Groceries]              $20.00
+    [Assets:Budget:Food:Restaurants]            $80.00
+
+2018/01/02 * Budget Groceries
+    [Assets:Budget:Food:Groceries]              -$20 = $0
+    [Assets:Checking]                           $20
+
+2018/01/02 * Buy Groceries
+    Assets:Checking                             -$20 = $80
+    Expenses:Food:Groceries                     $20
+
+test bal Assets
+              $80.00  Assets:Budget:Food:Restaurants
+end test
+
+test bal Assets -R
+              $80.00  Assets:Checking
+end test

--- a/test/regress/543_d.test
+++ b/test/regress/543_d.test
@@ -1,0 +1,32 @@
+2018/01/01 * Opening Balance
+    Assets:Checking                             $100.00
+    Equity:Opening Balances
+
+2018/01/01 * Budget
+    [Assets:Checking]                           = 0
+    [Assets:Budget:Food:Groceries]              $20.00
+    [Assets:Budget:Food:Restaurants]            $80.00
+
+2018/01/02 * Groceries
+    Assets:Checking                             = $80.00
+    Expenses:Groceries
+
+test bal
+              $80.00  Assets
+             $100.00    Budget:Food
+              $20.00      Groceries
+              $80.00      Restaurants
+             $-20.00    Checking
+            $-100.00  Equity:Opening Balances
+              $20.00  Expenses:Groceries
+--------------------
+                   0
+end test
+
+test bal -R
+              $80.00  Assets:Checking
+            $-100.00  Equity:Opening Balances
+              $20.00  Expenses:Groceries
+--------------------
+                   0
+end test


### PR DESCRIPTION
Without these changes, whether an account's balance is virtual
or real is not considered when asserting it's balance. This lead
to situations where the user must consider their virtual postings
when attemping to assert the real balance of the account. See
test/regress/543_a.test for that testcase, taken from the original
issue. This commit also includes other, fringe, situations that I
noticed while working on the fix. It essentially just adds a separate
attribute to the account class(?) that hold's the account's "real"
balance, which is only updated when the user attempts an assertion on a
real account. The virtual account's balance is updated the way it always
was.