### PR TITLE
Fix setting TZ in tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,7 @@ macro(add_ledger_harness_tests _class)
           $<TARGET_FILE:ledger> ${PROJECT_SOURCE_DIR}
           ${TestFile} ${TEST_PYTHON_FLAGS})
         set_tests_properties(${_class}Test_${TestFile_Name}
-          PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=${Ledger_TEST_TIMEZONE}")
+          PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1;TZ=${Ledger_TEST_TIMEZONE}")
       endif()
     endforeach()
   endif()
@@ -53,7 +53,7 @@ if (Python_EXECUTABLE)
       COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/${_class}.py
       --ledger $<TARGET_FILE:ledger> --file ${TestFile})
     set_tests_properties(${_class}Test_${TestFile_Name}
-      PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=${Ledger_TEST_TIMEZONE}")
+      PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1;TZ=${Ledger_TEST_TIMEZONE}")
   endforeach()
 
   # CheckManpage and CheckTexinfo are disabled, since they do not work
@@ -64,7 +64,7 @@ if (Python_EXECUTABLE)
       COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/${_class}.py
       --ledger $<TARGET_FILE:ledger> --source ${PROJECT_SOURCE_DIR})
     set_tests_properties(${_class}
-      PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=${Ledger_TEST_TIMEZONE}")
+      PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1;TZ=${Ledger_TEST_TIMEZONE}")
   endforeach()
 endif()
 

--- a/test/regress/1057.test
+++ b/test/regress/1057.test
@@ -4,7 +4,7 @@
     * Passif:Crédit:BanqueAccord           -171,63 €
 
 test --now=2014/06/27 emacs
-(("$sourcepath/test/regress/1057.test" 1 (21308 38512 0) nil "www.amazon.fr"
+(("$sourcepath/test/regress/1057.test" 1 (21308 60112 0) nil "www.amazon.fr"
   (2 "Dépense:Loisir:Ordi:Matériel" "101,50 €" nil " disque dur portable 2,5\" 2000 Go")
   (3 "Dépense:Maison:Service:Poste" "70,13 €" nil)
   (4 "Passif:Crédit:BanqueAccord" "-171,63 €" t)))

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -2,7 +2,7 @@ macro(add_ledger_test _name)
   target_link_libraries(${_name} libledger)
   add_test(Ledger${_name} ${PROJECT_BINARY_DIR}/${_name})
   set_tests_properties(Ledger${_name}
-    PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=${Ledger_TEST_TIMEZONE}")
+    PROPERTIES ENVIRONMENT "PYTHONUNBUFFERED=1;TZ=${Ledger_TEST_TIMEZONE}")
 endmacro(add_ledger_test _name)
 
 include_directories(${PROJECT_SOURCE_DIR}/src)


### PR DESCRIPTION
This was regressed in 139beba which set `PYTHONUNBUFFERED` to fix other
test issues. When setting multiple environment variables in this way
they need to be delimited with semicolons rather than spaces. As it is
`PYTHONUNBUFFERED` is being set to `1 TZ=America/Chicago`. The CMake docs
are not as clear about this as they probably should be.

This can be verified by throwing together a CTestTestfile.cmake:

    add_test(incorrect_env "printenv" "PYTHONUNBUFFERED" "TZ")
    set_tests_properties(incorrect_env PROPERTIES  ENVIRONMENT "PYTHONUNBUFFERED=1 TZ=America/Chicago")
    add_test(correct_env "printenv" "PYTHONUNBUFFERED" "TZ")
    set_tests_properties(correct_env PROPERTIES  ENVIRONMENT "PYTHONUNBUFFERED=1;TZ=America/Chicago")

When run with `ctest -V`:

    1: Test command: /usr/bin/printenv "PYTHONUNBUFFERED" "TZ"
    1: Environment variables:
    1:  PYTHONUNBUFFERED=1 TZ=America/Chicago
    1: Test timeout computed to be: 10000000
    1: 1 TZ=America/Chicago
    1/2 Test #1: incorrect_env ....................***Failed    0.00 sec
    test 2
        Start 2: correct_env

    2: Test command: /usr/bin/printenv "PYTHONUNBUFFERED" "TZ"
    2: Environment variables:
    2:  PYTHONUNBUFFERED=1
    2:  TZ=America/Chicago
    2: Test timeout computed to be: 10000000
    2: 1
    2: America/Chicago
    2/2 Test #2: correct_env ......................   Passed    0.00 sec