### PR TITLE
Python3 fixes and passing CI 🤞️

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ env:
     - PY_MAJOR=2
     - PY_MAJOR=3
 
-jobs:
-  allow_failures:
-    - env: PY_MAJOR=3
-
 addons:
   coverity_scan:
     project:

--- a/src/pyinterp.cc
+++ b/src/pyinterp.cc
@@ -331,13 +331,15 @@ value_t python_interpreter_t::python_command(call_scope_t& args)
 #if PY_MAJOR_VERSION >= 3
   wchar_t ** argv = new wchar_t *[args.size() + 1];
 
-  argv[0] = new wchar_t[std::strlen(argv0) + 1];
-  mbstowcs(argv[0], argv0, std::strlen(argv0));
+  std::size_t len = std::strlen(argv0) + 1;
+  argv[0] = new wchar_t[len];
+  mbstowcs(argv[0], argv0, len);
 
   for (std::size_t i = 0; i < args.size(); i++) {
     string arg = args.get<string>(i);
-    argv[i + 1] = new wchar_t[arg.length() + 1];
-    mbstowcs(argv[0], arg.c_str(), std::strlen(arg.c_str()));
+    std::size_t len = arg.length() + 1;
+    argv[i + 1] = new wchar_t[len];
+    mbstowcs(argv[i + 1], arg.c_str(), len);
   }
 #else
   char ** argv = new char *[args.size() + 1];


### PR DESCRIPTION
This fixes what I hope are the remaining issues blocking python3 tests from passing. It's certainly possible I missed something though so I'll review once Travis jobs complete.

*  fix python3 command (argv) wchar_t conversion

Ensure strings passed to `Py_Main` have a terminating null character by
including the extra character allocated for terminating null in the size
passed to `mbstowcs`.

Fix argv index so all arguments are not copied to `argv[0]`. Fixes
potential buffer overflow due to passing `argv[0]` as destination with
`argv[i + 1]` src and size to `mbstowcs`.

* fix builtin ledger module for python command

With python3 the `python` ledger command wound up loading the ledger
module shared library rather than using the builtin module as intended.
This resulted in duplicated initialization and crashing on cleanup. It
was also visible as duplicate converter warnings when importing ledger:

    $ ./ledger --no-pager python
    Python 3.7.5 (default, Nov 20 2019, 09:21:52)
    [...]
    >>> import ledger
    /usr/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: to-Python converter for boost::posix_time::ptime already registered; second conversion method ignored.
    [...]
    /usr/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: to-Python converter for ledger::xact_t already registered; second conversion method ignored.
    [...]
    >>> ledger
    <module 'ledger' from '/home/q/src/ledger/ledger.so'>
    >>> exit()
    Segmentation fault (core dumped)

After this change:

    Python 3.7.5 (default, Nov 20 2019, 09:21:52)
    [...]
    >>> import ledger
    >>> ledger
    <module 'ledger' (built-in)>
    >>> exit()
    $

Switches to `PyImport_AppendInittab` from `python::detail::init_module`
because 1) that is what the boost docs and examples show and 2)
`init_module` appears to be undocumented and not intended for outside use.

Fixes #1867 