### PR TITLE
Make explicit option a no-op

### DIFF
--- a/doc/NEWS.md
+++ b/doc/NEWS.md
@@ -4,6 +4,10 @@
 
 - Add support for '%F' date format specifier (bug #1775)
 
+- Entities are no longer regarded as defined due to being part of a cleared
+  transaction. `--explicit` is effectively enabled by default and is now a
+  no-op.
+
 ## 3.1.3 (2019-03-31)
 
 - Properly reject postings with a comment right after the flag (bug #1753)

--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -576,12 +576,6 @@ posting occurring in that period.
 Display values in terms of the given
 .Ar COMMODITY .
 The latest available price is used.
-.It Fl \-explicit
-Direct
-.Nm
-to require pre-declarations for entities (such as accounts,
-commodities and tags) rather than taking entities from cleared
-transactions as defined.
 .It Fl \-file Ar FILE Pq Fl f
 Read journal data from
 .Ar FILE .

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -6085,12 +6085,6 @@ Direct Ledger to download prices.
 @c using the script defined via the option
 @c @option{--getquote @var{FILE}}.
 
-@item --explicit
-Direct Ledger to require pre-declarations for entities (such as accounts,
-commodities and tags) rather than taking entities from cleared
-transactions as defined.  This option is useful in combination with
-@option{--strict} or @option{--pedantic}.
-
 @item --file @var{FILE}
 @itemx -f @var{FILE}
 Specify the input @file{FILE} for this invocation.

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -86,13 +86,8 @@ void journal_t::initialize()
 {
   master            = new account_t;
   bucket            = NULL;
-  fixed_accounts    = false;
-  fixed_payees      = false;
-  fixed_commodities = false;
-  fixed_metadata    = false;
   current_context   = NULL;
   was_loaded        = false;
-  force_checking    = false;
   check_payees      = false;
   day_break         = false;
   checking_style    = CHECK_NORMAL;
@@ -148,8 +143,6 @@ account_t * journal_t::register_account(const string& name, post_t * post,
   if (checking_style == CHECK_WARNING || checking_style == CHECK_ERROR) {
     if (! result->has_flags(ACCOUNT_KNOWN)) {
       if (! post) {
-        if (force_checking)
-          fixed_accounts = true;
         result->add_flags(ACCOUNT_KNOWN);
       }
       else if (checking_style == CHECK_WARNING) {
@@ -230,8 +223,6 @@ string journal_t::register_payee(const string& name, xact_t * xact)
 
     if (i == known_payees.end()) {
       if (! xact) {
-        if (force_checking)
-          fixed_payees = true;
         known_payees.insert(name);
       }
       else if (checking_style == CHECK_WARNING) {
@@ -259,8 +250,6 @@ void journal_t::register_commodity(commodity_t& comm,
   if (checking_style == CHECK_WARNING || checking_style == CHECK_ERROR) {
     if (! comm.has_flags(COMMODITY_KNOWN)) {
       if (context.which() == 0) {
-        if (force_checking)
-          fixed_commodities = true;
         comm.add_flags(COMMODITY_KNOWN);
       }
       else if (checking_style == CHECK_WARNING) {
@@ -281,8 +270,6 @@ void journal_t::register_metadata(const string& key, const value_t& value,
 
     if (i == known_tags.end()) {
       if (context.which() == 0) {
-        if (force_checking)
-          fixed_metadata = true;
         known_tags.insert(key);
       }
       else if (checking_style == CHECK_WARNING) {

--- a/src/journal.h
+++ b/src/journal.h
@@ -110,12 +110,7 @@ public:
   std::list<fileinfo_t>  sources;
   std::set<string>       known_payees;
   std::set<string>       known_tags;
-  bool                   fixed_accounts;
-  bool                   fixed_payees;
-  bool                   fixed_commodities;
-  bool                   fixed_metadata;
   bool                   was_loaded;
-  bool                   force_checking;
   bool                   check_payees;
   bool                   day_break;
   bool                   recursive_aliases;

--- a/src/session.cc
+++ b/src/session.cc
@@ -114,7 +114,7 @@ std::size_t session_t::read_data(const string& master_account)
     journal->no_aliases = true;
 
   if (HANDLED(explicit))
-    journal->force_checking = true;
+    ; // No-op
   if (HANDLED(check_payees))
     journal->check_payees = true;
 

--- a/test/baseline/opt-check-payees.test
+++ b/test/baseline/opt-check-payees.test
@@ -20,7 +20,7 @@ tag food
     Expenses:Food             20.00 EUR
     Assets:Cash
 
-test bal --explicit --strict --check-payees
+test bal --strict --check-payees
           -20.00 EUR
          -570.00 GBP  Assets:Cash
            20.00 EUR


### PR DESCRIPTION
This continues the work from #1819, resolves #1877 and also removes all the "dead" code that I can find from `explicit` becoming a no-op.