### PR TITLE
use built-in cmake precompiled header support when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ addons:
       - mpfr
 
 before_script:
-  # On macOS, precompiling system.hh does not work, and boost-python packaging is broken
-  - if [ "$TRAVIS_OS_NAME" = osx ]; then EXTRA_CMAKE_ARGS="-DPRECOMPILE_SYSTEM_HH=OFF -DBoost_NO_BOOST_CMAKE=ON"; fi
+  # On macOS boost-python packaging is broken
+  - if [ "$TRAVIS_OS_NAME" = osx ]; then EXTRA_CMAKE_ARGS="-DBoost_NO_BOOST_CMAKE=ON"; fi
   - cmake . -DUSE_PYTHON=ON -DPython_FIND_VERSION_MAJOR=${PY_MAJOR} -DBUILD_DEBUG=ON $EXTRA_CMAKE_ARGS
   - make VERBOSE=1
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -265,7 +265,8 @@ else()
   endmacro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
 endif()
 
-if(PRECOMPILE_SYSTEM_HH)
+if(PRECOMPILE_SYSTEM_HH AND NOT (COMMAND target_precompile_headers))
+  # enable fallback for CMake versions older than 3.16 without target_precompile_headers
   add_pch_rule(${PROJECT_BINARY_DIR}/system.hh LEDGER_SOURCES LEDGER_CLI_SOURCES)
 endif()
 
@@ -292,6 +293,15 @@ if (BUILD_LIBRARY)
 else()
   add_executable(ledger ${LEDGER_SOURCES} main.cc global.cc)
   add_ledger_library_dependencies(ledger)
+endif()
+
+if (PRECOMPILE_SYSTEM_HH AND (COMMAND target_precompile_headers) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+  if (BUILD_LIBRARY)
+    target_precompile_headers(libledger PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
+    target_precompile_headers(ledger REUSE_FROM libledger)
+  else()
+    target_precompile_headers(ledger PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
+  endif()
 endif()
 
 if (USE_PYTHON)


### PR DESCRIPTION
Ledger supports precompiling headers as a build speed optimization.
This is provided via a custom add_pch_rule macro. Similar functionality
is now built-in to CMake starting with the 3.16 release in November
2019. Let's use this when available to fix #1774 and start towards not
needing to maintain our own implementation.

I originally considered removing the macro fallback but in my tests it
saves enough build time that I think it is worth keeping for now.

Fixes #1774