### PR TITLE
fix macports dependencies on 10.14+

### DIFF
--- a/acprep
+++ b/acprep
@@ -57,7 +57,7 @@ class BoostInfo(object):
             return [ 'boost' ]
 
         if system in ['darwin-macports']:
-            return [ 'boost-jam', 'boost', '+python27+universal' ]
+            return [ 'boost-jam', 'boost', '+python27' ]
 
         if system in ['centos']:
             return [ 'boost-devel' ]
@@ -510,13 +510,13 @@ class PrepareBuild(CommandLineApp):
                 packages = [
                     'sudo', 'port', 'install', '-f',
                     'automake', 'autoconf', 'libtool',
-                    'python27', '+universal',
-                    'libiconv', '+universal',
-                    'zlib', '+universal',
-                    'gmp' ,'+universal', 'mpfr', '+universal',
-                    'ncurses', '+universal',
-                    'gettext' ,'+universal',
-                    'libedit' ,'+universal',
+                    'python27',
+                    'libiconv',
+                    'zlib',
+                    'gmp', 'mpfr',
+                    'ncurses',
+                    'gettext',
+                    'libedit',
                     'texlive-xetex', 'doxygen', 'graphviz', 'texinfo',
                     'lcov', 'sloccount'
                 ] + BoostInfo().dependencies('darwin-macports')


### PR DESCRIPTION
10.14+ does not support universal builds:

	Error: python27 cannot be installed for the configured universal_archs 'x86_64 i386' because the arch(s) 'i386' are not supported.

From https://trac.macports.org/ticket/57369#comment:6

> You just can't install ports universal on Mojave, so don't try to do so. Don't specify +universal on the command line