### PR TITLE
Add regression tests for issue #1894

### DIFF
--- a/test/regress/1894_1.test
+++ b/test/regress/1894_1.test
@@ -1,0 +1,16 @@
+= /Expenses:Transportation/ and not expr "has_tag(/NOTAX/)"
+         Expenses:Tax                     0.2
+         $account                        -0.2
+
+2020-05-06 * Test
+    Expenses:Transportation            200.00 EUR
+    Assets:Bank                       -200.00 EUR
+
+test bal
+         -200.00 EUR  Assets:Bank
+          200.00 EUR  Expenses
+           40.00 EUR    Tax
+          160.00 EUR    Transportation
+--------------------
+                   0
+end test

--- a/test/regress/1894_2.test
+++ b/test/regress/1894_2.test
@@ -1,0 +1,21 @@
+= ^Expenses and expr "any(account =~ /^A:Assets/ and R)"
+    [A:Assets:Split]              (amount / 2)
+    [B:Assets:Split]              (-amount / 2)
+
+= ^Expenses and expr "any(account =~ /^B:Assets/ and R)"
+    [B:Assets:Split]              (amount / 2)
+    [A:Assets:Split]              (-amount / 2)
+
+2020-05-08 * Test
+    Expenses:Transportation            200.00 EUR
+    A:Assets:Checking
+
+test bal
+         -100.00 EUR  A:Assets
+         -200.00 EUR    Checking
+          100.00 EUR    Split
+         -100.00 EUR  B:Assets:Split
+          200.00 EUR  Expenses:Transportation
+--------------------
+                   0
+end test


### PR DESCRIPTION
Add tests for wrong behavior caused by commit 49b07a1c1948 ("Correction to the way parens are parsed in query expressions") which was reverted with commit 869302ae9ce3.

I made sure the tests fail prior to the fix and pass with the revert applied.