### PR TITLE
Make --depth in register report collapse sub-accounts

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -513,7 +513,10 @@ will print balances only for accounts with two levels, i.e.
 but not
 .Sy Expenses:Entertainment:Dining .
 This is a display predicate, which means it only affects display,
-not the total calculations.
+not the total calculations.  In register reports,
+.Fl \-depth
+will collapse postings of child accounts beyond the given level and add
+their balances to the parent account.
 .It Fl \-detail
 Related to
 .Ic convert

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -8012,7 +8012,7 @@ The market value of a posting or an account, without its children.
 The net gain (market value minus cost basis), for a posting or an
 account, without its children.  It is the same as @samp{v-b}.
 
-@item l
+@item depth
 The depth (``level'') of an account.  If an account has one parent,
 its depth is one.
 

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -6471,7 +6471,9 @@ Limit the depth of the account tree.  In a balance report, for example,
 a @samp{--depth 2} statement will print balances only for accounts with
 two levels, i.e. @samp{Expenses:Entertainment} but not
 @samp{Expenses:Entertainment:Dining}.  This is a display predicate, which
-means it only affects display, not the total calculations.
+means it only affects display, not the total calculations.  In register
+reports, @samp{--depth} will collapse postings of child accounts beyond
+the given level and add their balances to the parent account.
 
 @item --deviation
 Report each posting’s deviation from the average.  It is only meaningful

--- a/src/chain.cc
+++ b/src/chain.cc
@@ -193,10 +193,16 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler,
 
     // collapse_posts causes xacts with multiple posts to appear as xacts
     // with a subtotaled post for each commodity used.
-    if (report.HANDLED(collapse))
+    if (report.HANDLED(collapse)) {
+      unsigned short collapse_depth = 0;
+      if (report.HANDLED(depth_))
+        collapse_depth = lexical_cast<int>(report.HANDLER(depth_).str());
+
       handler.reset(new collapse_posts(handler, report, expr,
                                        display_predicate, only_predicate,
-                                       report.HANDLED(collapse_if_zero)));
+                                       report.HANDLED(collapse_if_zero),
+                                       collapse_depth));
+    }
 
     // subtotal_posts combines all the posts it receives into one subtotal
     // xact, which has one post for each commodity in each account.

--- a/src/chain.cc
+++ b/src/chain.cc
@@ -193,7 +193,7 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler,
 
     // collapse_posts causes xacts with multiple posts to appear as xacts
     // with a subtotaled post for each commodity used.
-    if (report.HANDLED(collapse)) {
+    if (report.HANDLED(collapse) || report.HANDLED(depth_)) {
       unsigned short collapse_depth = 0;
       if (report.HANDLED(depth_))
         collapse_depth = lexical_cast<int>(report.HANDLER(depth_).str());

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -451,7 +451,7 @@ void collapse_posts::report_subtotal()
 
     foreach (totals_map::value_type& pat, totals) {
       handle_value(/* value=      */ pat.second,
-                   /* account=    */ &temps.create_account(pat.first),
+                   /* account=    */ pat.first,
                    /* xact=       */ &xact,
                    /* temps=      */ temps,
                    /* handler=    */ handler,
@@ -473,10 +473,10 @@ void collapse_posts::report_subtotal()
 value_t& collapse_posts::find_totals(account_t* account)
 {
   if (collapse_depth == 0)
-    return totals[_("<Total>")];
+    return totals[global_totals_account];
 
   if (account->depth <= collapse_depth)
-    return totals[account->fullname()];
+    return totals[account];
 
   //else recurse
   return find_totals(account->parent);

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -472,12 +472,10 @@ void collapse_posts::report_subtotal()
 
 value_t& collapse_posts::find_totals(account_t* account)
 {
-  unsigned short depth=3;
-
-  if (depth == 0)
+  if (collapse_depth == 0)
     return totals[_("<Total>")];
 
-  if (account->depth == depth)
+  if (account->depth == collapse_depth)
     return totals[account->fullname()];
 
   //else recurse

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -475,7 +475,7 @@ value_t& collapse_posts::find_totals(account_t* account)
   if (collapse_depth == 0)
     return totals[_("<Total>")];
 
-  if (account->depth == collapse_depth)
+  if (account->depth <= collapse_depth)
     return totals[account->fullname()];
 
   //else recurse

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -420,7 +420,7 @@ void collapse_posts::report_subtotal()
       displayed_count++;
   }
 
-  if (displayed_count == 1) {
+  if (collapse_depth == 0 && displayed_count == 1) {
     item_handler<post_t>::operator()(*last_post);
   }
   else if (only_collapse_if_zero && ! subtotal.is_zero()) {

--- a/src/filters.h
+++ b/src/filters.h
@@ -439,6 +439,7 @@ class collapse_posts : public item_handler<post_t>
   temporaries_t       temps;
   totals_map          totals;
   bool                only_collapse_if_zero;
+  unsigned short      collapse_depth;
   std::list<post_t *> component_posts;
   report_t&           report;
 
@@ -450,12 +451,14 @@ public:
                  expr_t&          _amount_expr,
                  predicate_t      _display_predicate,
                  predicate_t      _only_predicate,
-                 bool             _only_collapse_if_zero = false)
+                 bool             _only_collapse_if_zero = false,
+                 unsigned short   _collapse_depth = 0)
     : item_handler<post_t>(handler), amount_expr(_amount_expr),
       display_predicate(_display_predicate),
       only_predicate(_only_predicate), count(0),
       last_xact(NULL), last_post(NULL),
-      only_collapse_if_zero(_only_collapse_if_zero), report(_report) {
+      only_collapse_if_zero(_only_collapse_if_zero),
+      collapse_depth(_collapse_depth), report(_report) {
     TRACE_CTOR(collapse_posts, "post_handler_ptr, ...");
   }
   virtual ~collapse_posts() {

--- a/src/filters.h
+++ b/src/filters.h
@@ -427,7 +427,7 @@ public:
 class collapse_posts : public item_handler<post_t>
 {
 
-  typedef std::map<string,value_t> totals_map;
+  typedef std::map<account_t *,value_t> totals_map;
 
   expr_t&             amount_expr;
   predicate_t         display_predicate;
@@ -437,6 +437,7 @@ class collapse_posts : public item_handler<post_t>
   xact_t *            last_xact;
   post_t *            last_post;
   temporaries_t       temps;
+  account_t *         global_totals_account;
   totals_map          totals;
   bool                only_collapse_if_zero;
   unsigned short      collapse_depth;
@@ -459,12 +460,18 @@ public:
       last_xact(NULL), last_post(NULL),
       only_collapse_if_zero(_only_collapse_if_zero),
       collapse_depth(_collapse_depth), report(_report) {
+    create_accounts();
     TRACE_CTOR(collapse_posts, "post_handler_ptr, ...");
   }
   virtual ~collapse_posts() {
     TRACE_DTOR(collapse_posts);
     handler.reset();
   }
+
+  void create_accounts() {
+    global_totals_account = &temps.create_account(_("<Total>"));
+  }
+
   value_t& find_totals(account_t* account);
 
   virtual void flush() {
@@ -487,6 +494,7 @@ public:
     last_post = NULL;
 
     temps.clear();
+    create_accounts();
     totals.clear();
     component_posts.clear();
 

--- a/src/filters.h
+++ b/src/filters.h
@@ -426,6 +426,9 @@ public:
 
 class collapse_posts : public item_handler<post_t>
 {
+
+  typedef std::map<string,value_t> totals_map;
+
   expr_t&             amount_expr;
   predicate_t         display_predicate;
   predicate_t         only_predicate;
@@ -434,7 +437,7 @@ class collapse_posts : public item_handler<post_t>
   xact_t *            last_xact;
   post_t *            last_post;
   temporaries_t       temps;
-  account_t *         totals_account;
+  totals_map          totals;
   bool                only_collapse_if_zero;
   std::list<post_t *> component_posts;
   report_t&           report;
@@ -453,17 +456,13 @@ public:
       only_predicate(_only_predicate), count(0),
       last_xact(NULL), last_post(NULL),
       only_collapse_if_zero(_only_collapse_if_zero), report(_report) {
-    create_accounts();
     TRACE_CTOR(collapse_posts, "post_handler_ptr, ...");
   }
   virtual ~collapse_posts() {
     TRACE_DTOR(collapse_posts);
     handler.reset();
   }
-
-  void create_accounts() {
-    totals_account = &temps.create_account(_("<Total>"));
-  }
+  value_t& find_totals(account_t* account);
 
   virtual void flush() {
     report_subtotal();
@@ -485,7 +484,7 @@ public:
     last_post = NULL;
 
     temps.clear();
-    create_accounts();
+    totals.clear();
     component_posts.clear();
 
     item_handler<post_t>::clear();


### PR DESCRIPTION
This is my attempt to revive PR #216 which was merged prematurely and then reverted again.  I've taken @johannesgerer's original work and built a (hopefully) working implementation of this feature (which was also reqested in #987).

This PR changes the behavior of `--depth` in the register report so that accounts are collapsed to the requested level instead of cut off.  This is essentially the `--collapse` behavior, but the given depth level specifies how far accounts should be collapsed (`--collapse`/`-n` behaves like `--depth 0`).

### Example
The following register report

```text
$ ledger reg ^Expenses
20-May-13 Test                Expenses:AA:BB          3.00 EUR    3.00 EUR
                              Expenses:AA             3.00 EUR    6.00 EUR
20-May-14 Test                Expenses:AA:BB:CC       2.00 EUR    8.00 EUR
                              Expenses:DD             4.00 EUR   12.00 EUR
```

can be collapsed to only the second level like this:

```text
$ ledger reg ^Expenses --depth 2
20-May-13 Test                Expenses:AA             6.00 EUR    6.00 EUR
20-May-14 Test                Expenses:AA             2.00 EUR    8.00 EUR
                              Expenses:DD             4.00 EUR   12.00 EUR
```

---

First of all: I have little experience with C++ so for the most part I just tried to mimic the rest of the codebase.  Please let me know if I fell into some pit-falls while doing that ...

I split the work into small commits to clearly separate the changes I needed to do.  The commit-messages contain the details and reasons for each change.

There are a few points that I'd like to bring up:

- [ ] Right now, I changed the behavior of `--depth` directly and unconditionally.  It would also be possible to retain the old `--depth` behavior by default and only change it if combined with `--collapse`.  I feel like this would be very unintuitive but if keeping the old `--depth` behavior is important, this would be an option (although `--display 'depth <= X'` will always archieve the same if needed).
- [ ] The interaction with `--collapse-if-zero` is weird because both are implemented by the same filter.  I think it should be possible to make the two work together more nicely but I have not tried that yet.  I think the best route would be to treat it as two separate instances of the same filter.  Is this something I should work on?
- [ ] Right now I am using an `account_t*` as the key of the totals map.  Will this always work or could it lead to issues when there are multiple `account_t` instances for the same account?
- [x] When virtual postings are involved, somehow them being virtual is lost.  I couldn't easily find out why this is the case ... What should be the behavior here?  Is it ok as is or should collapsed postings which are entirely virtual be marked as such?