### PR TITLE
Remove the-kenny from list of maintainers in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,6 @@ pkgs.stdenv.mkDerivation {
     '';
 
     platforms = pkgs.stdenv.lib.platforms.all;
-    maintainers = with pkgs.stdenv.lib.maintainers; [ the-kenny jwiegley ];
+    maintainers = with pkgs.stdenv.lib.maintainers; [ jwiegley ];
   };
 }


### PR DESCRIPTION
Without this fix, the Nix build is broken, which causes `ledger-mode` CI builds to fail.

See https://github.com/NixOS/nixpkgs/commit/887295fd2d8c4da06acdaa185cbb3cc214d83285