### PR TITLE
Use PAGER when environment variable is set

### DIFF
--- a/doc/NEWS.md
+++ b/doc/NEWS.md
@@ -1,5 +1,9 @@
 # Ledger NEWS
 
+## 3.2.x (unreleased)
+
+- Use $PAGER when environment variable is set (bug #1674)
+
 ## 3.2.1 (2020-05-18)
 
 - Fix regression with expression evaluation by reverting commit

--- a/src/report.h
+++ b/src/report.h
@@ -811,16 +811,21 @@ public:
   OPTION__
   (report_t, pager_,
    CTOR(report_t, pager_) {
-     if (! std::getenv("PAGER") && isatty(STDOUT_FILENO)) {
-       bool have_less = false;
-       if (exists(path("/opt/local/bin/less")) ||
-           exists(path("/usr/local/bin/less")) ||
-           exists(path("/usr/bin/less")))
-         have_less = true;
+     if (isatty(STDOUT_FILENO)) {
+       if (! std::getenv("PAGER")) {
+         bool have_less = false;
+         if (exists(path("/opt/local/bin/less")) ||
+             exists(path("/usr/local/bin/less")) ||
+             exists(path("/usr/bin/less")))
+           have_less = true;
 
-       if (have_less) {
-         on(none, "less");
-         setenv("LESS", "-FRSX", 0); // don't overwrite
+         if (have_less) {
+           on(none, "less");
+           setenv("LESS", "-FRSX", 0); // don't overwrite
+         }
+       } else {
+           on(none, std::getenv("PAGER"));
+           setenv("LESS", "-FRSX", 0); // don't overwrite
        }
      }
    });


### PR DESCRIPTION
The code looked for "less" if $PAGER is not set, but it didn't
actually use $PAGER when it it defined.

Fixes #1674