### PR TITLE
Make it so that the include directive sorts when using wildcards.

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -753,12 +753,12 @@ void instance_t::include_directive(char * line)
   if (exists(parent_path)) {
     filesystem::directory_iterator end;
 
-		// Sort parent_path since on some file systems it is unsorted.
-		std::vector<path> sorted_parent_path;
-	  std::copy(filesystem::directory_iterator(parent_path),
-							filesystem::directory_iterator(),
-							std::back_inserter(sorted_parent_path));
-		std::sort(sorted_parent_path.begin(), sorted_parent_path.end());
+    // Sort parent_path since on some file systems it is unsorted.
+    std::vector<path> sorted_parent_path;
+    std::copy(filesystem::directory_iterator(parent_path),
+              filesystem::directory_iterator(),
+              std::back_inserter(sorted_parent_path));
+    std::sort(sorted_parent_path.begin(), sorted_parent_path.end());
 
 		for (std::vector<path>::const_iterator iter(sorted_parent_path.begin()),
 					 it_end(sorted_parent_path.end()); iter != it_end; ++iter) {

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -40,6 +40,7 @@
 #include "query.h"
 #include "pstream.h"
 #include "pool.h"
+#include <algorithm>
 #if HAVE_BOOST_PYTHON
 #include "pyinterp.h"
 #endif
@@ -751,12 +752,19 @@ void instance_t::include_directive(char * line)
   bool files_found = false;
   if (exists(parent_path)) {
     filesystem::directory_iterator end;
-    for (filesystem::directory_iterator iter(parent_path);
-         iter != end;
-         ++iter) {
+
+		// Sort parent_path since on some file systems it is unsorted.
+		std::vector<path> sorted_parent_path;
+	  std::copy(filesystem::directory_iterator(parent_path),
+							filesystem::directory_iterator(),
+							std::back_inserter(sorted_parent_path));
+		std::sort(sorted_parent_path.begin(), sorted_parent_path.end());
+
+		for (std::vector<path>::const_iterator iter(sorted_parent_path.begin()),
+					 it_end(sorted_parent_path.end()); iter != it_end; ++iter) {
       if (is_regular_file(*iter))
         {
-        string base = (*iter).path().filename().string();
+        string base = (*iter).filename().string();
         if (glob.match(base)) {
           journal_t *  journal  = context.journal;
           account_t *  master   = top_account();


### PR DESCRIPTION
Before this commit, doing something like `include data/*.dat` would
produce undesired behavior because the matches for `data/*.dat` would
not be sorted correctly.

See https://github.com/ledger/ledger/issues/1659 for details.

To verify what is going on, you can use the attached zip file with some test data: 
[ltest.zip](https://github.com/ledger/ledger/files/5009782/ltest.zip)

Do something like
```sh
unzip ~/code/ltest.zip -d /tmp/ && ./ledger -f /tmp/ltest/main.dat bal
```
and on an Ubuntu 18 system you should get a balance assertion error because the files are parsed in the wrong order.

Once you compile with the proposed fix the balance assertion error goes away.