### PR TITLE
Document how one might pass multiple debug flags

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -9908,7 +9908,7 @@ Ignore init files and environment variables for the ledger run.
 If Ledger has been built with debug options this will provide extra
 data during the run.  Listed below are the available @var{CODES} to
 debug. You can provide multiple using a regex expression like 
-"(@code{account.display}|@code{expr.calc})".
+"(@code{account.display|expr.calc})".
 
 @multitable @columnfractions .32 .43 .27
 @item @code{account.display}             @tab @code{draft.xact}                       @tab @code{option.names}

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -9908,7 +9908,7 @@ Ignore init files and environment variables for the ledger run.
 If Ledger has been built with debug options this will provide extra
 data during the run.  Listed below are the available @var{CODES} to
 debug. You can provide multiple using a regex expression like 
-"(@code{account.display|expr.calc})".
+"@code{(account.display|expr.calc)}".
 
 @multitable @columnfractions .32 .43 .27
 @item @code{account.display}             @tab @code{draft.xact}                       @tab @code{option.names}

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -9906,8 +9906,9 @@ Ignore init files and environment variables for the ledger run.
 
 @item --debug @var{CODE}
 If Ledger has been built with debug options this will provide extra
-data during the run.  The following are the available @var{CODES} to
-debug:
+data during the run.  Listed below are the available @var{CODES} to
+debug. You can provide multiple using a regex expression like 
+"(@code{account.display}|@code{expr.calc})".
 
 @multitable @columnfractions .32 .43 .27
 @item @code{account.display}             @tab @code{draft.xact}                       @tab @code{option.names}


### PR DESCRIPTION
Issue #1062 mentions how someone might pass multiple debug flags to ledger using a regular expression, though it was never mentioned in the documentation from what I could see. I've added a small patch to the relevant section of the documentation with a single example to make this functionality easier to find.