### PR TITLE
Fix issues related to payees declared on posting's metadata

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -3104,10 +3104,6 @@ date is not repeated), but they have different payees now.
 If using the @option{--strict} or @option{--pedantic} options, you must
 declare this tag to avoid warnings and errors.
 
-The payee name used with the tag is not enforced by the
-@option{--check-payees} option, due to a bug:
-@url{https://github.com/ledger/ledger/issues/556}.
-
 @node Metadata values, Typed metadata, Metadata tags, Metadata
 @subsection Metadata values
 

--- a/src/journal.h
+++ b/src/journal.h
@@ -157,7 +157,8 @@ public:
 
   account_t * register_account(const string& name, post_t * post,
                                account_t * master = NULL);
-  string      register_payee(const string& name, xact_t * xact);
+  string      register_payee(const string& name);
+  string      validate_payee(const string& name_or_alias);
   void        register_commodity(commodity_t& comm,
                                  variant<int, xact_t *, post_t *> context);
   void        register_metadata(const string& key, const value_t& value,
@@ -194,7 +195,12 @@ public:
   bool valid() const;
 
 private:
+
   std::size_t read_textual(parse_context_stack_t& context);
+
+  bool        should_check_payees();
+  bool        payee_not_registered(const string& name);
+  string      translate_payee_name(const string& name);
 };
 
 } // namespace ledger

--- a/src/post.cc
+++ b/src/post.cc
@@ -120,12 +120,22 @@ optional<date_t> post_t::aux_date() const
   return date;
 }
 
-string post_t::payee() const
+string post_t::payee_from_tag() const
 {
   if (optional<value_t> post_payee = get_tag(_("Payee")))
     return post_payee->as_string();
   else
-    return xact->payee;
+    return "";
+}
+
+string post_t::payee() const
+{
+  if (_payee)
+    return *_payee;
+
+  string post_payee = payee_from_tag();
+
+  return post_payee != "" ? post_payee : xact->payee;
 }
 
 namespace {

--- a/src/post.h
+++ b/src/post.h
@@ -73,6 +73,12 @@ public:
   optional<datetime_t> checkin;
   optional<datetime_t> checkout;
 
+private:
+
+  optional<string> _payee;
+
+public:
+
   post_t(account_t * _account = NULL,
          flags_t     _flags   = ITEM_NORMAL)
     : item_t(_flags), xact(NULL), account(_account)
@@ -132,7 +138,11 @@ public:
   virtual date_t primary_date() const;
   virtual optional<date_t> aux_date() const;
 
+  string payee_from_tag() const;
   string payee() const;
+  void set_payee(const string& payee) {
+    _payee = payee;
+  }
 
   bool must_balance() const {
     return ! has_flags(POST_VIRTUAL) || has_flags(POST_MUST_BALANCE);

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1033,7 +1033,7 @@ void instance_t::account_value_directive(account_t * account, string expr_str)
 
 void instance_t::payee_directive(char * line)
 {
-  string payee = context.journal->register_payee(line, NULL);
+  string payee = context.journal->register_payee(line);
 
   while (peek_whitespace_line()) {
     read_line(line);
@@ -1752,6 +1752,10 @@ post_t * instance_t::parse_post(char *          line,
   foreach (string& tag, tags)
     post->parse_tags(tag.c_str(), *context.scope, true);
 
+  string post_payee = post->payee_from_tag();
+  if (post_payee != "")
+    post->set_payee(context.journal->validate_payee(post_payee));
+
   TRACE_STOP(post_details, 1);
 
   return post.release();
@@ -1870,7 +1874,7 @@ xact_t * instance_t::parse_xact(char *          line,
       }
       ++p;
     }
-    xact->payee = context.journal->register_payee(next, xact.get());
+    xact->payee = context.journal->validate_payee(next);
     next = p;
   } else {
     xact->payee = _("<Unspecified payee>");

--- a/test/baseline/dir-payee.test
+++ b/test/baseline/dir-payee.test
@@ -8,6 +8,10 @@ payee Foo Bar Inc
     A            10
     B
 
+2012-03-26 * KFC
+    A            10 ; Payee: Kentucky Fried Chicken
+    B
+
 2014-05-13 * UNHELPFUL PAYEE  ; will be read as being 'Foo Bar Inc'
     ; UUID: 2a2e21d434356f886c84371eebac6e44f1337fda
     A            20
@@ -15,6 +19,8 @@ payee Foo Bar Inc
 
 test reg
 12-Mar-25 KFC                   A                                10           10
+                                B                               -10            0
+12-Mar-26 KFC                   A                                10           10
                                 B                               -10            0
 14-May-13 Foo Bar Inc           A                                20           20
                                 B                               -20            0

--- a/test/baseline/opt-check-payees.test
+++ b/test/baseline/opt-check-payees.test
@@ -5,7 +5,10 @@ account Expenses:Food
 commodity EUR
 commodity GBP
 payee Phone
+    alias MobilePhone
+payee Several
 tag food
+tag Payee
 
 2012-03-20 Phone
     Expenses:Phone            20.00 GBP
@@ -20,18 +23,24 @@ tag food
     Expenses:Food             20.00 EUR
     Assets:Cash
 
+2012-03-23 Several
+    Expenses:Food              10.00 EUR ; Payee: Food
+    Expenses:Phone             10.00 EUR ; Payee: MobilePhone
+    Assets:Cash
+
 test bal --strict --check-payees
-          -20.00 EUR
+          -40.00 EUR
          -570.00 GBP  Assets:Cash
-           20.00 EUR
+           40.00 EUR
           570.00 GBP  Expenses
-           20.00 EUR    Food
+           30.00 EUR    Food
+           10.00 EUR
            20.00 GBP    Phone
           550.00 GBP    Rent
 --------------------
                    0
 __ERROR__
-Warning: "$FILE", line 14: Unknown payee 'Rent'
-Warning: "$FILE", line 18: Unknown payee 'Food'
+Warning: "$FILE", line 17: Unknown payee 'Rent'
+Warning: "$FILE", line 21: Unknown payee 'Food'
+Warning: "$FILE", line 27: Unknown payee 'Food'
 end test
-


### PR DESCRIPTION
Hi, everyone! :wave:

Payees declared on posting's metadata are now validated with `--check-payees` option. Also, their aliases are now considered on reports as well.

Fixes https://github.com/ledger/ledger/issues/556.
Fixes https://github.com/ledger/ledger/issues/1892.

## Scenarios

### Issue https://github.com/ledger/ledger/issues/556

Considering the following `test.dat` file:

```ledger
account Assets:Cash
account Expenses:Food
payee Example
tag Payee
commodity $

2020-03-04 Example
    Expenses:Food                $20.00 ; Payee: Testing
    Assets:Cash
```

#### Before

```shell
$ ledger -f test.dat reg --pedantic --check-payees
20-Mar-04 Testing                    Expenses:Food                          $20.00          $20.00
                                     Assets:Cash                           $-20.00               0
```

#### After

```shell
$ ledger -f test.dat reg --pedantic --check-payees
While parsing file "/wat/ledger/test.dat", line 8:
While parsing posting:
  Expenses:Food                $20.00 ; Payee: Testing
                               ^^^^^^^^^^^^^^^^^^^^^^^
Error: Unknown payee 'Testing'
```

### Issue https://github.com/ledger/ledger/issues/1892

Considering the following `test.dat` file:

```ledger
payee Test
    alias Testing

2020-03-04 Test
    Expenses:Food                $20.00 ; Payee: Testing
    Assets:Cash
```

#### Before

```shell
$ ledger -f test.dat reg
20-Mar-04 Testing                    Expenses:Food                          $20.00          $20.00
                                     Assets:Cash                           $-20.00               0
```

#### After

```shell
$ ledger -f test.dat reg
20-Mar-04 Test                       Expenses:Food                          $20.00          $20.00
                                     Assets:Cash                           $-20.00               0
```