### PR TITLE
Fix contrib bash-completion

### DIFF
--- a/contrib/ledger-completion.bash
+++ b/contrib/ledger-completion.bash
@@ -23,7 +23,7 @@
 
 _ledger()
 {
-    local cur prev command options
+    local cur prev commands options
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"


### PR DESCRIPTION
Fix shellcheck warning SC2034: command appears unused.
Fix completion script if used by zsh with bashcompinit.