### PR TITLE
compare_by_commodity: Always return the result of the recursive call

### DIFF
--- a/src/commodity.cc
+++ b/src/commodity.cc
@@ -465,18 +465,23 @@ int commodity_t::compare_by_commodity::operator()(const amount_t * left,
     amount_t rightprice(*arightcomm.details.price);
 
     if (leftprice.commodity() != rightprice.commodity()) {
-      // Since we have two different amounts, there's really no way
-      // to establish a true sorting order; we'll just do it based
-      // on the numerical values.
-      leftprice.clear_commodity();
-      rightprice.clear_commodity();
+      // Since we have two different amounts, there's really no way to
+      // establish a true sorting order; we'll just do it based on the
+      // numerical values, before falling back to comparing the prices
+      // with their original commodity.
+      amount_t leftpricenumeric(leftprice);
+      amount_t rightpricenumeric(rightprice);
+      leftpricenumeric.clear_commodity();
+      rightpricenumeric.clear_commodity();
       DEBUG("commodity.compare",
             "both have price, commodities don't match, recursing");
-      int cmp2 = commodity_t::compare_by_commodity()(&leftprice, &rightprice);
+      int cmp2 = commodity_t::compare_by_commodity()(&leftpricenumeric, &rightpricenumeric);
       if (cmp2 != 0) {
         DEBUG("commodity.compare", "recursion found a disparity");
         return cmp2;
       }
+      DEBUG("commodity.compare", "recursion found no difference, comparing prices with commodity");
+      return commodity_t::compare_by_commodity()(&leftprice, &rightprice);
     } else {
       if (leftprice < rightprice) {
         DEBUG("commodity.compare", "left price is less");

--- a/test/regress/1998.test
+++ b/test/regress/1998.test
@@ -1,0 +1,14 @@
+2021-01-02 Same commodity, different values
+    Assets            -1 Stock {100 USD} [2021-01-01]
+    Assets             1 Stock {100 EUR} [2021-01-01]
+    Equity
+
+test bal --lots
+1 Stock {EUR100} [2021/01/01]
+-1 Stock {USD100} [2021/01/01]  Assets
+-1 Stock {EUR100} [2021/01/01]
+1 Stock {USD100} [2021/01/01]  Equity
+--------------------
+                   0
+end test
+


### PR DESCRIPTION
Commit 501fbc08ae5493db77bb34f4c4fbe1f3a3bc14e3 changed the behavior of this function to not return the "equal" result (==0) from the recursive call. Previously, the function returned the result of the recursive call unconditionally.

The new behavior causes an assertion error for certain postings. The regression test added in this commit shows such a posting.

This commit reverts to the old behavior, which fixes issue #1998.