### PR TITLE
Fix amount tokenizer re: embedded minus sign.

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -975,8 +975,15 @@ namespace {
   {
     char buf[256];
     char c = peek_next_nonws(in);
-    READ_INTO(in, buf, 255, c,
-              std::isdigit(c) || c == '-' || c == '.' || c == ',');
+    int max = 255;
+    char *p = buf;
+    if (c == '-') {
+      *p++ = c;
+      max--;
+      in.get(c);
+    }
+    READ_INTO(in, p, max, c,
+              std::isdigit(c) || c == '.' || c == ',');
 
     string::size_type len = std::strlen(buf);
     while (len > 0 && ! std::isdigit(buf[len - 1])) {

--- a/test/regress/2001.test
+++ b/test/regress/2001.test
@@ -1,0 +1,12 @@
+2021/4/1  Was Already Working
+    Expenses:Something          (3 - 1)
+    Assets:Cash
+
+2021/4/2  Now Fixed
+    Expenses:Something          (3-1)
+    Assets:Cash
+
+test reg exp
+21-Apr-01 Was Already Working   Expenses:Something                2            2
+21-Apr-02 Now Fixed             Expenses:Something                2            4
+end test


### PR DESCRIPTION
An amount may have a (single) leading minus sign, but none after that.
Bug #2001 (and #1809).