### PR TITLE
Fix IRC bullet point in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Now that you're up and running, here are a few resources to keep in mind:
 
  - [Homepage]
  - [Documentation]
- - [IRC channel][IRC]
+ - [IRC channel][IRC]: #ledger channel on Freenode
  - [Mailing List / Forum][mailing list]
  - [GitHub project page][github]
  - [Code analysis][openhub]


### PR DESCRIPTION
Currently the IRC link is broken in the rendered readme page on Github.
Speculating that Github's markdown renderer might not display the text
as a link since it starts with "irc://" instead of "http://" or similar.

> ![ledger-readme-list-bug](https://user-images.githubusercontent.com/43632885/115166764-a7134400-a069-11eb-8e7b-0278f92e4253.png)

Added some text to the bullet point specifying channel and server.

I left the link in-place in case the above issue is resolved at some
point, or if other websites render this README.md file without the
issue.