### PR TITLE
Escape all string values output by the lisp report.

### DIFF
--- a/src/emacs.cc
+++ b/src/emacs.cc
@@ -41,7 +41,7 @@ namespace ledger {
 	void format_emacs_posts::write_xact(xact_t& xact)
 	{
 		if (xact.pos)
-			out << "\"" << xact.pos->pathname.string() << "\" "
+			out << "\"" << escape_string(xact.pos->pathname.string()) << "\" "
 					<< xact.pos->beg_line << " ";
 		else
 			out << "\"\" " << -1 << " ";
@@ -52,14 +52,14 @@ namespace ledger {
 		out << "(" << (date / 65536) << " " << (date % 65536) << " 0) ";
 
 		if (xact.code)
-			out << "\"" << *xact.code << "\" ";
+			out << "\"" << escape_string(*xact.code) << "\" ";
 		else
 			out << "nil ";
 
 		if (xact.payee.empty())
 			out << "nil";
 		else
-			out << "\"" << xact.payee << "\"";
+			out << "\"" << escape_string(xact.payee) << "\"";
 
 		out << "\n";
 	}
@@ -85,8 +85,8 @@ namespace ledger {
 			else
 				out << "  (" << -1 << " ";
 
-			out << "\"" << post.reported_account()->fullname() << "\" \""
-					<< post.amount << "\"";
+			out << "\"" << escape_string(post.reported_account()->fullname()) << "\" \""
+					<< escape_string(post.amount) << "\"";
 
 			switch (post.state()) {
 			case item_t::UNCLEARED:
@@ -101,7 +101,7 @@ namespace ledger {
 			}
 
 			if (post.cost)
-				out << " \"" << *post.cost << "\"";
+				out << " \"" << escape_string(*post.cost) << "\"";
 			if (post.note)
 				out << " \"" << escape_string(*post.note) << "\"";
 			out << ")";


### PR DESCRIPTION
Notes were already being escaped. The filename, the transaction code,
the payee, postings' account names, and postings' cost expressions
were not. Everything else the lisp report prints appears to be a
number or a constant-valued non-string token for Lisp.

Here's an example journal file, for reproduction:

```
;; The lisp report prints the quantity as "123 "X Y"",
;; which won't parse properly in Emacs Lisp.
2021/05/30 * Buy some X Y
    A  123 "X Y"
    Z

;; Here's a pathological transaction with lots of stray double quotes
;; and backslashes. The lisp report won't parse right.
2021/05/30 * (1\2) Bad\ly named"payee 
    A:\:B  123 "X Y"
    Z
```

This is the output of the lisp report when that content is in /tmp/bad.ledger:

```
(("/tmp/bad.ledger" 4 (24755 3520 0) nil "Buy some X Y"
  (5 "A" "123 "X Y"" t)
  (6 "Z" "-123 "X Y"" t))
 ("/tmp/bad.ledger" 10 (24755 3520 0) "1\2" "Bad\ly named"payee"
  (11 "A:\:B" "123 "X Y"" t)
  (12 "Z" "-123 "X Y"" t)))
```

And here's the reference to the Elisp manual on String syntax:

https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-for-Strings.html