### PR TITLE
Fix compilation with Boost 1.76

### DIFF
--- a/src/expr.cc
+++ b/src/expr.cc
@@ -35,6 +35,8 @@
 #include "parser.h"
 #include "scope.h"
 
+#include <boost/smart_ptr/scoped_ptr.hpp>
+
 namespace ledger {
 
 expr_t::expr_t() : base_type()

--- a/src/format.h
+++ b/src/format.h
@@ -45,6 +45,8 @@
 #include "expr.h"
 #include "unistring.h"
 
+#include <boost/smart_ptr/scoped_ptr.hpp>
+
 namespace ledger {
 
 class unistring;


### PR DESCRIPTION
We were previously relying on an indirect include within Boost headers. We're
using scoped_ptr which is defined in <boost/smart_ptr/scoped_ptr.hpp>.

Bug: https://bugs.gentoo.org/790176
Closes: #2030