### PR TITLE
acprep: support build on ubuntu 20.04 focal

### DIFF
--- a/acprep
+++ b/acprep
@@ -63,8 +63,8 @@ class BoostInfo(object):
         if system in ['centos']:
             return [ 'boost-devel' ]
 
-        elif system in ['ubuntu-bionic', 'ubuntu-xenial', 'ubuntu-eoan',
-                        'ubuntu-trusty', 'ubuntu-cosmic']:
+        elif system in ['ubuntu-focal', 'ubuntu-bionic', 'ubuntu-xenial',
+                        'ubuntu-eoan', 'ubuntu-trusty', 'ubuntu-cosmic']:
             return [ 'libboost-dev',
                      'libboost-date-time-dev',
                      'libboost-filesystem-dev',
@@ -548,8 +548,24 @@ class PrepareBuild(CommandLineApp):
                         'sudo', 'apt-get', 'install',
                         'build-essential',
                     ]
-
-                    if release == 'bionic':
+                    if release == 'focal':
+                        packages.extend([
+                            'doxygen',
+                            'cmake',
+                            'ninja-build',
+                            'zlib1g-dev',
+                            'libbz2-dev',
+                            'python-dev',
+                            'libgmp3-dev',
+                            'libmpfr-dev',
+                            'gettext',
+                            'libedit-dev',
+                            'texinfo',
+                            'lcov',
+                            'libutfcpp-dev',
+                            'sloccount'
+                        ])
+                    elif release == 'bionic':
                         packages.extend([
                             'doxygen',
                             'cmake',


### PR DESCRIPTION
**Problem:**
Unable build `ledger` from source code at Ubuntu 20.04 Focal
```
./acprep dependencies
```
will return
```
acprep: INFO: Invoking primary phase: dependencies
acprep: INFO: Executing phase: dependencies
acprep: INFO: Installing Ledger's build dependencies ...
acprep: INFO: Looks like you are using APT on Ubuntu focal
acprep: INFO: I do not recognize your version of Ubuntu!
```

**Environment:**
```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.2 LTS"
```

**Solution:** 
Add 'focal' to ubuntu-releases