### PR TITLE
Use amount_width for balance report

### DIFF
--- a/src/report.h
+++ b/src/report.h
@@ -419,8 +419,8 @@ public:
    CTOR(report_t, balance_format_) {
     on(none,
        "%(ansify_if("
-       "  justify(scrub(display_total), 20,"
-       "          20 + int(prepend_width), true, color),"
+       "  justify(scrub(display_total), int(amount_width),"
+       "          int(amount_width) + int(prepend_width), true, color),"
        "            bold if should_bold))"
        "  %(!options.flat ? depth_spacer : \"\")"
        "%-(ansify_if("
@@ -428,7 +428,7 @@ public:
        "             bold if should_bold))\n%/"
        "%$1\n%/"
        "%(prepend_width ? \" \" * int(prepend_width) : \"\")"
-       "--------------------\n");
+       "%(\"-\" * int(amount_width))\n");
   });
 
   OPTION(report_t, base);


### PR DESCRIPTION
Hi, I've tried to make balance report more customisable by replacing hardcoded amount width 20 by `amount_width` option (discussion here https://groups.google.com/g/ledger-cli/c/IX8czQyAL20).

It changes old behaviour because default `amount_width` seems to be equal to 23. This sounds acceptable for me.

However a lot of unit tests failed. E.g.:
```
FAILURE in output from .../ledger/test/manual/transaction-notes-4.test:
--
$ledger -f ".../ledger/test/manual/transaction-notes-4.test" bal food and tag type --account='"Tags:" + tag("Type")'

--
  @@ -1,5 +1,5 @@
  -               $9.00  Tags
  -               $4.50    Coffee:Expenses:Food
  -               $4.50    Dining:Expenses:Food
  ---------------------
  -               $9.00
  +       $9.00  Tags
  +       $4.50    Coffee:Expenses:Food
  +       $4.50    Dining:Expenses:Food
  +------------
  +       $9.00
```

What is the proper way to fix this? Update tests? Moreover they use some custom `amount_width` value (12?).