### PR TITLE
Fix silent errors when reading lines from input files.

### DIFF
--- a/test/input/parsing.dat
+++ b/test/input/parsing.dat
@@ -1,0 +1,6 @@
+
+;NOTE: this file should NOT end in a new line
+;See https://github.com/ledger/ledger/issues/516
+2021/07/14 test
+	Assets  $30
+	Income  -$30

--- a/test/regress/516.test
+++ b/test/regress/516.test
@@ -1,0 +1,4 @@
+test cleared --file test/input/parsing.dat --cleared-format "%-30(account) %15(get_at(total_expr, 0)) %15(get_at(total_expr, 1))\n%/"
+Assets                                     $30               0
+Income                                    $-30               0
+end test


### PR DESCRIPTION
Handle files that don't end with a new line. Throw an error when the buffer
size is exceeded.

Fixes #516
Contributes to #1149