### PR TITLE
do not enforce GNU C++, allow using c++ (clang)

### DIFF
--- a/acprep
+++ b/acprep
@@ -239,7 +239,7 @@ class PrepareBuild(CommandLineApp):
         self.LDFLAGS         = []
 
         self.envvars = {
-            'CXX':      'g++',
+            'CXX':      '',
             'CXXFLAGS': '',
             'LDFLAGS':  '',
         }


### PR DESCRIPTION
I don't know why this is prefilled with `g++`. I was annoyed by it, because my OpenBSD uses clang `c++`. Maybe others, too.