### PR TITLE
Use correct int return type for stream input operations

### DIFF
--- a/src/query.cc
+++ b/src/query.cc
@@ -220,37 +220,9 @@ test_ident:
   return token_t(token_t::UNKNOWN);
 }
 
-void query_t::lexer_t::token_t::unexpected()
+void query_t::lexer_t::token_t::expected(char wanted)
 {
-  kind_t prev_kind = kind;
-
-  kind = UNKNOWN;
-
-  switch (prev_kind) {
-  case END_REACHED:
-    throw_(parse_error, _("Unexpected end of expression"));
-  case TERM:
-    throw_(parse_error, _f("Unexpected string '%1%'") % *value);
-  default:
-    throw_(parse_error, _f("Unexpected token '%1%'") % symbol());
-  }
-}
-
-void query_t::lexer_t::token_t::expected(char wanted, char c)
-{
-  kind = UNKNOWN;
-
-  if (c == '\0' || c == -1) {
-    if (wanted == '\0' || wanted == -1)
-      throw_(parse_error, _("Unexpected end"));
-    else
-      throw_(parse_error, _f("Missing '%1%'") % wanted);
-  } else {
-    if (wanted == '\0' || wanted == -1)
-      throw_(parse_error, _f("Invalid char '%1%'") % c);
-    else
-      throw_(parse_error, _f("Invalid char '%1%' (wanted '%2%')") % c % wanted);
-  }
+  throw_(parse_error, _f("Missing '%1%'") % wanted);
 }
 
 expr_t::ptr_op_t

--- a/src/query.h
+++ b/src/query.h
@@ -191,8 +191,7 @@ public:
 #endif
       }
 
-      void unexpected();
-      void expected(char wanted, char c = '\0');
+      void expected(char wanted);
     };
 
     token_t token_cache;

--- a/src/times.cc
+++ b/src/times.cc
@@ -1621,17 +1621,10 @@ void date_parser_t::lexer_t::token_t::unexpected()
 
 void date_parser_t::lexer_t::token_t::expected(char wanted, char c)
 {
-  if (c == '\0' || c == -1) {
-    if (wanted == '\0' || wanted == -1)
-      throw_(date_error, _("Unexpected end"));
-    else
-      throw_(date_error, _f("Missing '%1%'") % wanted);
-  } else {
-    if (wanted == '\0' || wanted == -1)
-      throw_(date_error, _f("Invalid char '%1%'") % c);
-    else
-      throw_(date_error, _f("Invalid char '%1%' (wanted '%2%')") % c % wanted);
-  }
+  if (wanted == '\0')
+    throw_(date_error, _f("Invalid char '%1%'") % c);
+  else
+    throw_(date_error, _f("Invalid char '%1%' (wanted '%2%')") % c % wanted);
 }
 
 namespace {

--- a/src/token.h
+++ b/src/token.h
@@ -126,7 +126,7 @@ struct expr_t::token_t : public noncopyable
   void next(std::istream& in, const parse_flags_t& flags);
   void rewind(std::istream& in);
   void unexpected(const char wanted = '\0');
-  void expected(const char wanted, const char c = '\0');
+  void expected(const char wanted, const int c);
   void expected(const kind_t wanted);
 };
 

--- a/test/regress/2058.test
+++ b/test/regress/2058.test
@@ -1,0 +1,8 @@
+2021/1/2 Test
+    A  $1.00
+    B
+
+test -p 'last %^@' bal -> 1
+__ERROR__
+Error: Invalid char '%'
+end test


### PR DESCRIPTION
This makes it safe to compare results to -1 to indicate EOF,
regardless of whether char is considered signed or unsigned;
and so eliminates compiler warnings on platforms such as ARM.

Fixes bug #2058.