### PR TITLE
Support for `NO_COLOR` environment variable

### DIFF
--- a/src/report.cc
+++ b/src/report.cc
@@ -816,7 +816,7 @@ value_t report_t::fn_format_datetime(call_scope_t& args)
 
 value_t report_t::fn_ansify_if(call_scope_t& args)
 {
-  if (args.has<string>(1)) {
+  if (args.has<string>(1) && !getenv("NO_COLOR")) {
     string color = args.get<string>(1);
     std::ostringstream buf;
     if (color == "black")          buf << "\033[30m";

--- a/src/unistring.h
+++ b/src/unistring.h
@@ -184,9 +184,9 @@ inline void justify(std::ostream&      out,
                     bool               redden = false)
 {
   if (! right) {
-    if (redden) out << "\033[31m";
+    if (redden && !getenv("NO_COLOR")) out << "\033[31m";
     out << str;
-    if (redden) out << "\033[0m";
+    if (redden && !getenv("NO_COLOR")) out << "\033[0m";
   }
 
   unistring temp(str);
@@ -196,9 +196,9 @@ inline void justify(std::ostream&      out,
     out << ' ';
 
   if (right) {
-    if (redden) out << "\033[31m";
+    if (redden && !getenv("NO_COLOR")) out << "\033[31m";
     out << str;
-    if (redden) out << "\033[0m";
+    if (redden && !getenv("NO_COLOR")) out << "\033[0m";
   }
 }
 


### PR DESCRIPTION
See https://no-color.org/ for more information about the variable.