### PR TITLE
Fix --time-colon for negative time amounts

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -733,13 +733,9 @@ void amount_t::in_place_unreduce()
 
   if (shifted) {
     if (("h" == comm->symbol() || "m" == comm->symbol()) && commodity_t::time_colon_by_default) {
-      amount_t floored = tmp.floored();
-      amount_t precision = tmp - floored;
-      if (precision < 0.0) {
-        precision += 1.0;
-        floored -= 1.0;
-      }
-      tmp = floored + (precision * (comm->smaller()->number() / 100.0));
+      double truncated = trunc(tmp.to_double());
+      double precision = tmp.to_double() - truncated;
+      tmp = truncated + (precision * (comm->smaller()->number() / 100.0));
     }
 
     *this      = tmp;

--- a/test/regress/1176.test
+++ b/test/regress/1176.test
@@ -1,0 +1,23 @@
+2016-01-01 Employer
+        Me   -5400s
+        Them  5400s
+2016-01-01 Employer
+        Me   -3600s
+        Them  3600s
+2016-01-02 Employer
+        Me   -1800s
+        Them  1800s
+2016-01-02 Employer
+        Me   -30s
+        Them  30s
+
+test reg --time-colon
+16-Jan-01 Employer              Me                           -1:30h       -1:30h
+                                Them                          1:30h            0
+16-Jan-01 Employer              Me                           -1:00h       -1:00h
+                                Them                          1:00h            0
+16-Jan-02 Employer              Me                           -30:0m       -30:0m
+                                Them                          30:0m            0
+16-Jan-02 Employer              Me                             -30s         -30s
+                                Them                            30s            0
+end test


### PR DESCRIPTION
While the current formula works for positive numbers, negative numbers
are incorrectly represented.

One of the issues comes from the fact that floor(x) < x for every x.
`amount_t precision` will always be a non negative number and the code
that attempts to fix the issue for negative number will never run.

If we truncate the number instead, the current formula works for both
positive and negative numbers without making negative numbers a corner
case. So let's do that.