### PR TITLE
Point licenses to lib.licenses

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -42,7 +42,7 @@ pkgs.stdenv.mkDerivation {
   meta = {
     homepage = "http://ledger-cli.org/";
     description = "A double-entry accounting system with a command-line reporting interface";
-    license = pkgs.stdenv.lib.licenses.bsd3;
+    license = pkgs.lib.licenses.bsd3;
 
     longDescription = ''
       Ledger is a powerful, double-entry accounting system that is accessed


### PR DESCRIPTION
`pkgs.stdenv.lib.licenses` is no longer available in recent versions of nixpkgs. Use `lib.licenses` instead.

I think this will fix the build failure in https://github.com/ledger/ledger-mode/pull/323.

Note that this change is already included in #2072, so you don't need this if you merge the PR that adds a flake.