### PR TITLE
Fix the other occurrences of stdenv.lib

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,7 @@ pkgs.stdenv.mkDerivation {
       their data, there really is no alternative.
     '';
 
-    platforms = pkgs.stdenv.lib.platforms.all;
-    maintainers = with pkgs.stdenv.lib.maintainers; [ jwiegley ];
+    platforms = pkgs.lib.platforms.all;
+    maintainers = with pkgs.lib.maintainers; [ jwiegley ];
   };
 }


### PR DESCRIPTION
@purcell This is a follow-up to the latest PR. #2082 didn't completely fix the error on ledger-mode. I hope this PR will finally fix it.

(I grepped `stdenv.lib`, so there is no other occurrence of the pattern.)