### PR TITLE
WIP: fileinfo_t: remove size member

### DIFF
--- a/src/journal.h
+++ b/src/journal.h
@@ -78,21 +78,19 @@ public:
   struct fileinfo_t
   {
     optional<path>   filename;
-    boost::uintmax_t size;
     datetime_t       modtime;
     bool             from_stream;
 
-    fileinfo_t() : size(0), from_stream(true) {
+    fileinfo_t() : from_stream(true) {
       TRACE_CTOR(journal_t::fileinfo_t, "");
     }
     fileinfo_t(const path& _filename)
       : filename(_filename), from_stream(false) {
-      size    = file_size(*filename);
       modtime = posix_time::from_time_t(last_write_time(*filename));
       TRACE_CTOR(journal_t::fileinfo_t, "const path&");
     }
     fileinfo_t(const fileinfo_t& info)
-      : filename(info.filename), size(info.size),
+      : filename(info.filename),
         modtime(info.modtime), from_stream(info.from_stream)
     {
       TRACE_CTOR(journal_t::fileinfo_t, "copy");

--- a/src/py_journal.cc
+++ b/src/py_journal.cc
@@ -251,9 +251,6 @@ void export_journal()
     .add_property("filename",
                   make_getter(&journal_t::fileinfo_t::filename),
                   make_setter(&journal_t::fileinfo_t::filename))
-    .add_property("size",
-                  make_getter(&journal_t::fileinfo_t::size),
-                  make_setter(&journal_t::fileinfo_t::size))
     .add_property("modtime",
                   make_getter(&journal_t::fileinfo_t::modtime),
                   make_setter(&journal_t::fileinfo_t::modtime))


### PR DESCRIPTION
it is currently not required but set. Incidentally, calling file_size()
on a bash pipe e.g. /proc/self/fd/11 fails with:

Error: boost::filesystem::file_size: Operation not permitted: "/proc/self/fd/11"

when executing ledger as

ledger -f <(cat journal)