### PR TITLE
Ensure absolute path for include

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -743,7 +743,7 @@ void instance_t::include_directive(char * line)
     DEBUG("textual.include", "parent file path: " << context.pathname);
     path parent_path = context.pathname.parent_path();
     if (parent_path.empty()) {
-      filename = path(string(".")) / line;
+      filename = context.current_directory / line;
     } else {
       filename = parent_path / line;
       DEBUG("textual.include", "normalized path: " << filename.string());

--- a/test/regress/BF3C1F82-2.test
+++ b/test/regress/BF3C1F82-2.test
@@ -4,11 +4,11 @@ include non-existent-ledger-file-BF3C1F82
 test -f - reg -> 1
 __ERROR__
 While parsing file "", line 2:
-Error: File to include was not found: "non-existent-ledger-file-BF3C1F82"
+Error: File to include was not found: "$sourcepath/non-existent-ledger-file-BF3C1F82"
 end test
 
 test -f /dev/stdin reg -> 1
 __ERROR__
 While parsing file "", line 2:
-Error: File to include was not found: "non-existent-ledger-file-BF3C1F82"
+Error: File to include was not found: "$sourcepath/non-existent-ledger-file-BF3C1F82"
 end test


### PR DESCRIPTION
Ensure the path of file to include in `instance_t::include_directive`
is always an absolute path.

Previously when the journal file is given through stdin, we prepend a
"./" to the filename to include. However, in Boost >= 1.77,
`path::normalize` strips the leading "./" [1]. Our `resolve_path`
function calls `normalize` and thus now it returns "file" for "./file"
instead of the previous "./file".

This change causes a failing test regress/BF3C1F82-2 [2], and also
breaks the `include` directive for stdin input:

    $ touch file-to-include
    $ echo "include file-to-include" | ledger -f - reg

gives

    While parsing file "", line 1:
    Error: File to include was not found: "file-to-include"

Therefore, we change to prepend the `context.current_directory` to
make the filename absolute in this case as well. The test
regress/BF3C1F82-2 is also updated to match the new output.

Fixes #2075.

[1] https://github.com/boostorg/filesystem/commit/16bd89b7c0398d0dc5904148a865ef3fc3ece7ec
[2] https://github.com/ledger/ledger/issues/2075