### PR TITLE
README.md: Fix for Homebrew and Conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,14 @@ Dependency | Version (or greater)
 
 ### macOS
 
-You can use [Homebrew] or [MacPorts] to install Ledger easily on macOS.
+You can use [Homebrew] or [MacPorts] to install build dependencies for Ledger
+easily on macOS.
 
 #### 1. Homebrew
 
-You can see the parameters you can pass while installing with brew by the command `brew options ledger`. To install ledger, simply type the following command:
+If you use Homebrew, to install the dependencies you would run:
 
-    $ brew install ledger
-
-If you to want to startup python, use the following command:
-
-    $ ledger python
-
+    $ brew install cmake boost boost-python3 gmp mpfr
 
 #### 2. MacPorts
 
@@ -99,10 +95,13 @@ run:
 
 ### Conda
 
-Ledger is also available through [Conda](https://conda.io) from the
-[conda-forge](https://conda-forge.org) channel:
+The dependencies for building Ledger are available from [conda-forge] on certain
+platforms (for example, `linux-64`), which can be used with [Conda] or [mamba].
 
-    $ conda install -c conda-forge ledger
+With Conda you could run:
+
+    $ conda install -c conda-forge python=3 cmake boost gmp mpfr \
+         gettext libedit texinfo doxygen graphviz
 
 ### Ubuntu
 
@@ -198,3 +197,6 @@ hack as much as you like, then send me a pull request via GitHub.
 [expat]: http://www.libexpat.org
 [libxml2]: http://xmlsoft.org
 [openhub]: https://www.openhub.net/p/ledger
+[conda-forge]: https://conda-forge.org
+[Conda]: https://conda.io
+[mamba]: https://github.com/mamba-org/mamba


### PR DESCRIPTION
Hi!

If I understand it correctly, the README file in this repo is for developers who want to build Ledger. So we have instructions for installing *build dependencies* on Ubuntu, Fedora, and macOS with MacPorts. However, for Homebrew and Conda the instructions are actually on installing the *compiled Ledger cli itself*. That looks a bit confusing and inconsistent. So I update them to give instructions about installing build dependencies.

For conda-forge, I have tested it on a Linux x64 machine. I did not try the Homebrew instructions but the packages are copied from the CI workflow (with `git` and `gpgme` omitted):

https://github.com/ledger/ledger/blob/f3fd025a35b7328f66e21db1eccfe774cae4cf70/.github/workflows/cmake.yml#L47

Thanks!