### PR TITLE
Update git clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and easy to use.
 I know, you just want to build and play.  If you have all the [dependencies](#dependencies)
 installed, then simply do this:
 
-    $ git clone git://github.com/ledger/ledger.git
+    $ git clone git@github.com:ledger/ledger.git
     $ cd ledger && ./acprep update  # Update to the latest, configure, make
 
 Now try your first ledger command:


### PR DESCRIPTION
Github deprecated this way of clone recently.

When trying to clone like that, git throws:

```
➜ git clone git://github.com/ledger/ledger.git
Cloning into 'ledger'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

The proposed change properly clones the repository: 
```
➜ git clone git@github.com:ledger/ledger.git
Cloning into 'ledger'...
remote: Enumerating objects: 38173, done.        
remote: Counting objects: 100% (331/331), done.        
remote: Compressing objects: 100% (230/230), done.        
remote: Total 38173 (delta 164), reused 193 (delta 97), pack-reused 37842        
Receiving objects: 100% (38173/38173), 18.20 MiB | 957.00 KiB/s, done.
Resolving deltas: 100% (28670/28670), done.

```