### PR TITLE
Fix unrounding for equity

### DIFF
--- a/src/chain.cc
+++ b/src/chain.cc
@@ -213,7 +213,7 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler,
     // day_of_week_posts is like period_posts, except that it reports
     // all the posts that fall on each subsequent day of the week.
     if (report.HANDLED(equity))
-      handler.reset(new posts_as_equity(handler, report, expr));
+      handler.reset(new posts_as_equity(handler, report, expr, report.HANDLED(unround)));
     else if (report.HANDLED(subtotal))
       handler.reset(new subtotal_posts(handler, expr));
   }

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1106,6 +1106,8 @@ void posts_as_equity::report_subtotal()
   value_t total = 0L;
   foreach (values_map::value_type& pair, values) {
     value_t value(pair.second.value.strip_annotations(report.what_to_keep()));
+    if (unround)
+      value.in_place_unround();
     if (! value.is_zero()) {
       if (value.is_balance()) {
         value.as_balance_lval().map_sorted_amounts

--- a/src/filters.h
+++ b/src/filters.h
@@ -790,13 +790,14 @@ class posts_as_equity : public subtotal_posts
   post_t *    last_post;
   account_t * equity_account;
   account_t * balance_account;
+  bool        unround;
 
   posts_as_equity();
 
 public:
   posts_as_equity(post_handler_ptr _handler, report_t& _report,
-                  expr_t& amount_expr)
-    : subtotal_posts(_handler, amount_expr), report(_report) {
+                  expr_t& amount_expr, bool _unround)
+    : subtotal_posts(_handler, amount_expr), report(_report), unround(_unround) {
     create_accounts();
     TRACE_CTOR(posts_as_equity, "post_handler_ptr, expr_t&");
   }

--- a/test/regress/equity-unround.test
+++ b/test/regress/equity-unround.test
@@ -1,0 +1,30 @@
+commodity EUR
+    note Euro
+    format 1,000.00 EUR
+
+2022/05/04 * Test 1
+   Assets:Foo  1.0001 EUR
+   Income
+
+2022/05/04 * Test 2
+   Assets:Bar  0.0002 EUR
+   Income
+
+2022/05/04 * Test 3
+   Assets:Baz  3 EUR
+   Income
+
+test equity ^Assets: --unround
+2022/05/04 Opening Balances
+    Assets:Bar                            0.0002 EUR
+    Assets:Baz                              3.00 EUR
+    Assets:Foo                            1.0001 EUR
+    Equity:Opening Balances              -4.0003 EUR
+end test
+
+test reg --equity ^Assets: --unround
+22-May-04 Opening Balances      Assets:Bar               0.0002 EUR   0.0002 EUR
+                                Assets:Baz                 3.00 EUR   3.0002 EUR
+                                Assets:Foo               1.0001 EUR   4.0003 EUR
+                                Equit:Opening Balances  -4.0003 EUR            0
+end test


### PR DESCRIPTION
A naive fix that makes `reg --equity --unround` and `equity --unround` work. Today `equity` ignores `--unround` and `reg --equity --unround` doesn't display amounts that are zero when they are rounded. Perhaps we need a more sophisticated fix as it doesn't fix `reg --equity --amount 'unround(amount_expr)'`