### PR TITLE
Fix CI job on macOS

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -44,7 +44,7 @@ jobs:
         name: Mac Dependencies
         run: |
           brew update
-          brew install boost boost-python3 gmp mpfr gpgme git
+          brew install boost boost-python3 gmp mpfr gpgme
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
`brew install git` [fails on macOS CI job](https://github.com/ledger/ledger/runs/6301580650?check_suite_focus=true)

```
==> Pouring git--2.36.0.big_sur.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink etc/bash_completion.d/git-completion.bash
Target /usr/local/etc/bash_completion.d/git-completion.bash
is a symlink belonging to git@2.35.1. You can unlink it:
  brew unlink git@2.35.1
```

I don't think ledger needs the latest git for its tests, so I removed it from `brew install`.

See also:

* https://github.community/t/unable-to-update-homebrews-git-on-macos-runner-without-removing-prebuilt-git-package/246983