### PR TITLE
Bump required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 3.0)
 
 PROJECT(ledger)
 


### PR DESCRIPTION
CMake 3.21.4 reports that compatibility with CMake < 2.8.12 will be removed from a future version of CMake.

CMake 3.0 has new defaults for MACOSX_RPATH. It seems ledger works fine with them. See CMake Policy CMP0042 for the details.

Fixes #1721.