### PR TITLE
acprep: add support for arch linux

### DIFF
--- a/acprep
+++ b/acprep
@@ -539,7 +539,8 @@ class PrepareBuild(CommandLineApp):
         elif system == 'Linux':
             if exists('/etc/issue'):
                 issue = open('/etc/issue')
-                if issue.readline().startswith('Ubuntu'):
+                issue_name = issue.readline()
+                if issue_name.startswith('Ubuntu'):
                     info = dict([line.strip().split('=', 1)
                                  for line in open('/etc/lsb-release')])
                     release = info['DISTRIB_CODENAME']
@@ -673,6 +674,23 @@ class PrepareBuild(CommandLineApp):
                             BoostInfo().dependencies('ubuntu-' + release))
                         self.log.info('Executing: ' + ' '.join(packages))
                         self.execute(*packages)
+                elif issue_name.startswith('Arch Linux'):
+                    self.log.info('Looks like you are using Pacman on Arch Linux')
+                    packages = [
+                        'sudo', 'pacman', '-S', '--noconfirm',
+                        'base-devel',
+                        'boost',
+                        'doxygen',
+                        'gmp',
+                        'graphviz',
+                        'lcov',
+                        'libedit',
+                        'mpfr',
+                        'sloccount',
+                        'utf8cpp'
+                    ]
+                    self.log.info('Executing: ' + ' '.join(packages))
+                    self.execute(*packages)
 
             if exists('/etc/redhat-release'):
                 release = open('/etc/redhat-release').readline()


### PR DESCRIPTION
Hello folks,

I just tried to setup the Ledger codebase on Arch Linux and discovered that the `acprep` script does not handle it already.

So I extended it to also work on this distribution.

I followed existing setup for other distros such as Fedora to install all needed dependencies.

So hopefully this is fine.

Thanks.