### PR TITLE
Replace os.path.abspath with os.path.realpath in tests

### DIFF
--- a/test/CheckOptions.py
+++ b/test/CheckOptions.py
@@ -19,8 +19,8 @@ class CheckOptions (object):
     self.source_file = None
     self.sep = "\n  --"
 
-    self.ledger     = os.path.abspath(args.ledger)
-    self.source     = os.path.abspath(args.source)
+    self.ledger     = os.path.realpath(args.ledger)
+    self.source     = os.path.realpath(args.source)
 
     self.missing_options = set()
     self.unknown_options = set()

--- a/test/DocTests.py
+++ b/test/DocTests.py
@@ -18,8 +18,8 @@ from difflib import unified_diff
 class DocTests:
   def __init__(self, args):
     scriptpath      = os.path.dirname(os.path.realpath(__file__))
-    self.ledger     = os.path.abspath(args.ledger)
-    self.sourcepath = os.path.abspath(args.file)
+    self.ledger     = os.path.realpath(args.ledger)
+    self.sourcepath = os.path.realpath(args.file)
     self.verbose    = args.verbose
     self.tests      = args.examples
 

--- a/test/LedgerHarness.py
+++ b/test/LedgerHarness.py
@@ -50,8 +50,8 @@ class LedgerHarness:
             print("Cannot find source path at '%s'" % argv[2])
             sys.exit(1)
 
-        self.ledger     = os.path.abspath(argv[1])
-        self.sourcepath = os.path.abspath(argv[2])
+        self.ledger     = os.path.realpath(argv[1])
+        self.sourcepath = os.path.realpath(argv[2])
         self.succeeded  = 0
         self.failed     = 0
         self.verify     = '--verify' in argv

--- a/test/RegressTests.py
+++ b/test/RegressTests.py
@@ -45,7 +45,7 @@ class RegressFile(object):
 
     def transform_line(self, line):
         line = line.replace('$sourcepath', harness.sourcepath)
-        line = line.replace('$FILE', os.path.abspath(self.filename))
+        line = line.replace('$FILE', os.path.realpath(self.filename))
         return line
 
     def read_test(self):
@@ -117,7 +117,7 @@ class RegressFile(object):
                 use_stdin = True
         else:
             test['command'] = (('$ledger -f "%s" ' % 
-                                os.path.abspath(self.filename)) +
+                                os.path.realpath(self.filename)) +
                                test['command'])
 
         p = harness.run(test['command'],

--- a/test/convert.py
+++ b/test/convert.py
@@ -36,9 +36,9 @@ import re
 import sys
 import os
 
-source = os.path.abspath(sys.argv[1])
+source = os.path.realpath(sys.argv[1])
 base   = os.path.splitext(source)[0]
-target = os.path.abspath(sys.argv[2])
+target = os.path.realpath(sys.argv[2])
 
 dirname = os.path.dirname(target)
 if not os.path.isdir(dirname):


### PR DESCRIPTION
to fix failing tests on Darwin, where `/tmp` is a symlink to `/private/tmp` and the tests fail as ledger reports filenames with the symlink resolved to `/private/tmp`, but the tests expect absolute filenames starting with `/tmp`.

Tested using:

<details><summary><code>% nix build</code></summary>

```
% nix build                                                                                      ~src/ledger
error: builder for '/nix/store/479q7ifg9qgxfqwmb4qy9daja1jnkqqz-ledger-3.2.1-dirty.drv' failed with exit code 8;
       last 10 log lines:
       > 99% tests passed, 4 tests failed out of 400
       >
       > Total Test time (real) =   5.20 sec
       >
       > The following tests FAILED:
       >         20 - BaselineTest_cmd-convert (Failed)
       >        118 - BaselineTest_opt-file (Failed)
       >        280 - RegressTest_25A099C9 (Failed)
       >        363 - RegressTest_BF3C1F82-2 (Failed)
       > Errors while running CTest
       For full logs, run 'nix log /nix/store/479q7ifg9qgxfqwmb4qy9daja1jnkqqz-ledger-3.2.1-dirty.drv'.

```

</details>

<details><summary>Excerpt of <code>% nix log /nix/store/479q7ifg9qgxfqwmb4qy9daja1jnkqqz-ledger-3.2.1-dirty.drv'</code> showing a failed test</summary>

```
   22/400 Test  #20: BaselineTest_cmd-convert ..............................***Failed    0.16 sec
  ..FAILURE in error output from /tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert.test:
  --
  $ledger -f /dev/null --input-date-format "%m/%d/%Y" convert test/baseline/cmd-convert3.dat
  --
    @@ -1,4 +1,4 @@

    -While parsing file "/tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert3.dat", line 1  :

    +While parsing file "/private/tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert3.dat"  , line 1:

     While parsing CSV line:

       01/01/2011,,



  E[cmd-convert.test]STDERR:
  b''
  FAILURE in error output from /tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert.test:
  --
  $ledger -f /dev/null convert test/baseline/cmd-convert4.dat
  --
    @@ -1,4 +1,4 @@

    -While parsing file "/tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert4.dat", line 1  :

    +While parsing file "/private/tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert4.dat"  , line 1:

     While parsing CSV line:

       bogus,$10,



  E[cmd-convert.test]STDERR:
  b''
  .FAILURE in error output from /tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert.test:
  --
  $ledger -f /dev/null --input-date-format "%m/%d/%Y" convert test/baseline/cmd-convert6.dat
  --
    @@ -1,4 +1,4 @@

    -While parsing file "/tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert6.dat", line 1  :

    +While parsing file "/private/tmp/nix-build-ledger-3.2.1-dirty.drv-0/source/test/baseline/cmd-convert6.dat"  , line 1:

     While parsing CSV line:

       01/01/2011,20.00 EUR,10.00 EUR,test1,



  E[cmd-convert.test]STDERR:
  b''

  OK (3)
  FAILED (3)
```

</details>

[Full output of `nix log /nix/store/479q7ifg9qgxfqwmb4qy9daja1jnkqqz-ledger-3.2.1-dirty.drv`](https://github.com/ledger/ledger/files/9019894/nix-log.txt)


<details><summary>Example showing difference in behaviour of <a href="https://docs.python.org/3/library/os.path.html#os.path.abspath"><code>abspath</code></a> and <a href="https://docs.python.org/3/library/os.path.html#os.path.realpath"><code>realpath</code></a></summary>

```
% ls -lsa /tmp;python -c "import os; print(f'abs: {os.path.abspath(\"/tmp\")}\nreal: {os.path.realpath(\"/tmp\")}')"
0 lrwxr-xr-x 1 root wheel 11 May  9 23:30 /tmp -> private/tmp
abs: /tmp
real: /private/tmp
```

</details>

<details><summary>system info</summary>

```
% sw_vers
ProductName:    macOS
ProductVersion: 12.4
BuildVersion:   21F79
% uname -a
Darwin kei.local 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:37 PDT 2022; root:xnu-8020.121.3~4/RELEASE_ARM64_T6000 arm64 arm Darwin
% nix --version
nix (Nix) 2.8.0
```

</details>


ℹ️  Note that I had to `nix flake update` in order to be able to create a usable ledger build as with the current `flake.nix` in the repo ledger errs with the following otherwise:


```
% ./result/ledger --args-only --file test/input/drewr.dat bal                                     
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 4:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 6:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 10:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 14:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 23:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 29:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 33:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 37:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 42:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 46:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 52:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 57:
Error: boost::bad_get: failed value get using boost::get
While parsing file "~/Developer/ledger/test/input/drewr.dat", line 61:
Error: boost::bad_get: failed value get using boost::get
```

