### PR TITLE
Update flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "A double-entry accounting system with a command-line reporting interface";
 
   outputs = { self, nixpkgs }: let
+    useGpgme = true;
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
     nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
     systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
@@ -17,11 +18,16 @@
         src = self;
 
         nativeBuildInputs = with pkgs; [ cmake ];
-        buildInputs = with pkgs; [ boost gmp mpfr libedit python3 texinfo gnused gpgme ];
+        buildInputs = with pkgs; [
+          boost gmp mpfr libedit python3 texinfo gnused
+        ] ++ pkgs.lib.optional useGpgme gpgme;
 
         enableParallelBuilding = true;
 
-        cmakeFlags = [ "-DCMAKE_INSTALL_LIBDIR=lib" "-DUSE_GPGME=1" ];
+        cmakeFlags = [
+          "-DCMAKE_INSTALL_LIBDIR=lib"
+          (pkgs.lib.optionalString useGpgme "-DUSE_GPGME=1")
+        ];
 
         checkPhase = ''
           export LD_LIBRARY_PATH=$PWD

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "A double-entry accounting system with a command-line reporting interface";
 
   outputs = { self, nixpkgs }: let
+    usePython = false;
     useGpgme = true;
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
     nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
@@ -19,15 +20,26 @@
 
         nativeBuildInputs = with pkgs; [ cmake ];
         buildInputs = with pkgs; [
-          boost gmp mpfr libedit python3 texinfo gnused
-        ] ++ pkgs.lib.optional useGpgme gpgme;
+          (boost.override { enablePython = usePython; python = python3; })
+          gmp mpfr libedit texinfo gnused
+        ]
+        ++ pkgs.lib.optional usePython python3
+        ++ pkgs.lib.optional useGpgme gpgme;
 
         enableParallelBuilding = true;
 
         cmakeFlags = [
           "-DCMAKE_INSTALL_LIBDIR=lib"
-          (pkgs.lib.optionalString useGpgme "-DUSE_GPGME=1")
+          (pkgs.lib.optionalString usePython "-DUSE_PYTHON:BOOL=ON")
+          (pkgs.lib.optionalString useGpgme "-DUSE_GPGME:BOOL=ON")
         ];
+
+        # by default, it will query the python interpreter for it's sitepackages location
+        # however, that would write to a different nixstore path, pass our own sitePackages location
+        prePatch = pkgs.lib.optionalString usePython ''
+          substituteInPlace src/CMakeLists.txt \
+            --replace 'DESTINATION ''${Python_SITEARCH}' 'DESTINATION "lib/${pkgs.python3.sitePackages}"'
+        '';
 
         checkPhase = ''
           export LD_LIBRARY_PATH=$PWD


### PR DESCRIPTION
This PR brings ledger's `flake.nix` a bit closer to the [`default.nix` in nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/office/ledger/default.nix) by adding the `usePython` and `useGpgme` "options" allowing to specify whether support for Python bindings and gpg encrypted journal files should be built into ledger.