### PR TITLE
Fix use of deprecated Python legacy Unicode API

### DIFF
--- a/src/py_utils.cc
+++ b/src/py_utils.cc
@@ -110,31 +110,65 @@ struct string_from_python
                         (data)->storage.bytes;
       new (storage) string(value);
       data->convertible = storage;
-    } else {
-#endif
-      VERIFY(PyUnicode_Check(obj_ptr));
-
-      Py_ssize_t size = PyUnicode_GET_SIZE(obj_ptr);
-      const Py_UNICODE* value = PyUnicode_AS_UNICODE(obj_ptr);
-
-      string str;
-#if Py_UNICODE_SIZE == 2 // UTF-16
-        utf8::unchecked::utf16to8(value, value + size, std::back_inserter(str));
-#elif Py_UNICODE_SIZE == 4 // UTF-32
-        utf8::unchecked::utf32to8(value, value + size, std::back_inserter(str));
-#else
-        assert("Py_UNICODE has an unexpected size" == NULL);
-#endif
-
-      if (value == 0) throw_error_already_set();
-      void* storage =
-        reinterpret_cast<converter::rvalue_from_python_storage<string> *>
-                        (data)->storage.bytes;
-      new (storage) string(str);
-      data->convertible = storage;
-#if PY_MAJOR_VERSION < 3
+      return;
     }
 #endif
+    VERIFY(PyUnicode_Check(obj_ptr));
+
+    string str;
+#if PY_MAJOR_VERSION < 3
+    Py_ssize_t size = PyUnicode_GET_SIZE(obj_ptr);
+    const Py_UNICODE* value = PyUnicode_AS_UNICODE(obj_ptr);
+#if Py_UNICODE_SIZE == 2 // UTF-16
+    utf8::unchecked::utf16to8(value, value + size, std::back_inserter(str));
+#elif Py_UNICODE_SIZE == 4 // UTF-32
+    utf8::unchecked::utf32to8(value, value + size, std::back_inserter(str));
+#else
+    assert("Py_UNICODE has an unexpected size" == NULL);
+#endif // Py_UNICODE_SIZE
+#else // PY_MAJOR_VERSION >= 3
+    Py_ssize_t size =
+#if PY_MINOR_VERSION >= 3
+      PyUnicode_GET_LENGTH(obj_ptr);
+#else
+      PyUnicode_GET_SIZE(obj_ptr);
+#endif
+#if PY_MINOR_VERSION < 12
+    PyUnicode_READY(obj_ptr);
+#endif
+    const char* value;
+    switch (PyUnicode_KIND(obj_ptr)) {
+      case PyUnicode_1BYTE_KIND:
+        value = (const char*)PyUnicode_1BYTE_DATA(obj_ptr);
+        // FIXME: It seems wrong to use `utf16to8` on 1BYTE_DATA, yet without this call
+        // the tests fail with: libc++abi: terminating with uncaught exception of type int
+        utf8::unchecked::utf16to8(value, value + size, std::back_inserter(str));
+        break;
+#if PY_MINOR_VERSION < 12 && Py_UNICODE_SIZE == 2
+      case PyUnicode_WCHAR_KIND:
+#endif
+      case PyUnicode_2BYTE_KIND:
+        value = (const char*)PyUnicode_2BYTE_DATA(obj_ptr);
+        utf8::unchecked::utf16to8(value, value + size, std::back_inserter(str));
+        break;
+#if PY_MINOR_VERSION < 12 && Py_UNICODE_SIZE == 4
+      case PyUnicode_WCHAR_KIND:
+#endif
+      case PyUnicode_4BYTE_KIND:
+        value = (const char*)PyUnicode_4BYTE_DATA(obj_ptr);
+        utf8::unchecked::utf32to8(value, value + size, std::back_inserter(str));
+        break;
+      default:
+        assert("PyUnicode_KIND returned an unexpected kind" == NULL);
+    }
+#endif // PY_MAJOR_VERSION
+
+    if (value == 0) throw_error_already_set();
+    void* storage =
+      reinterpret_cast<converter::rvalue_from_python_storage<string> *>
+                      (data)->storage.bytes;
+    new (storage) string(str);
+    data->convertible = storage;
   }
 };
 

--- a/src/py_utils.cc
+++ b/src/py_utils.cc
@@ -140,9 +140,7 @@ struct string_from_python
     switch (PyUnicode_KIND(obj_ptr)) {
       case PyUnicode_1BYTE_KIND:
         value = (const char*)PyUnicode_1BYTE_DATA(obj_ptr);
-        // FIXME: It seems wrong to use `utf16to8` on 1BYTE_DATA, yet without this call
-        // the tests fail with: libc++abi: terminating with uncaught exception of type int
-        utf8::unchecked::utf16to8(value, value + size, std::back_inserter(str));
+        str = std::string(value);
         break;
 #if PY_MINOR_VERSION < 12 && Py_UNICODE_SIZE == 2
       case PyUnicode_WCHAR_KIND:


### PR DESCRIPTION
replacing it with APIs introduced in Python 3.3 to ensure ledger's Python bindings continue to function when the legacy Unicode API is removed in Python 3.12.

For details see ["Unicode Objects and Codecs" in the Python/C API Reference Manual](https://docs.python.org/3.10/c-api/unicode.html).

<details><summary>Python C/API Deprecation Warnings Emitted During Compilation of Ledger's Python Bindings</summary>

```
~/Developer/ledger/src/py_utils.cc:117:25: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
      Py_ssize_t size = PyUnicode_GET_SIZE(obj_ptr);
                        ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:261:7: note: expanded from macro 'PyUnicode_GET_SIZE'
      PyUnicode_WSTR_LENGTH(op) :                    \
      ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
#define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                  ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
Py_DEPRECATED(3.3)
^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
#define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                     ^
~/Developer/ledger/src/py_utils.cc:117:25: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
      Py_ssize_t size = PyUnicode_GET_SIZE(obj_ptr);
                        ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:262:14: note: expanded from macro 'PyUnicode_GET_SIZE'
      ((void)PyUnicode_AsUnicode(_PyObject_CAST(op)),\
             ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
#define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                     ^
~/Developer/ledger/src/py_utils.cc:117:25: warning: '_PyUnicode_get_wstr_length' is deprecated [-Wdeprecated-declarations]
      Py_ssize_t size = PyUnicode_GET_SIZE(obj_ptr);
                        ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:264:8: note: expanded from macro 'PyUnicode_GET_SIZE'
       PyUnicode_WSTR_LENGTH(op)))
       ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:451:35: note: expanded from macro 'PyUnicode_WSTR_LENGTH'
#define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
                                  ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:445:1: note: '_PyUnicode_get_wstr_length' has been explicitly marked deprecated here
Py_DEPRECATED(3.3)
^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
#define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                     ^
~/Developer/ledger/src/py_utils.cc:118:33: warning: 'PyUnicode_AsUnicode' is deprecated [-Wdeprecated-declarations]
      const Py_UNICODE* value = PyUnicode_AS_UNICODE(obj_ptr);
                                ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:279:7: note: expanded from macro 'PyUnicode_AS_UNICODE'
      PyUnicode_AsUnicode(_PyObject_CAST(op)))
      ^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/cpython/unicodeobject.h:580:1: note: 'PyUnicode_AsUnicode' has been explicitly marked deprecated here
Py_DEPRECATED(3.3) PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
^
/nix/store/6a94sw6yyc412y3a0qjnjdyljx3p1b7n-python3-3.10.5/include/python3.10/pyport.h:513:54: note: expanded from macro 'Py_DEPRECATED'
#define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                     ^
4 warnings generated.
```

</details>

---

✅ ~~Until [this FIXME](https://github.com/ledger/ledger/pull/2123/files#r913784951) is addressed this PR should continue to be a draft and should not be merged!~~