### PR TITLE
Fix SIGABRT when python subcommand raises an exception

### DIFF
--- a/src/pyinterp.cc
+++ b/src/pyinterp.cc
@@ -376,8 +376,9 @@ value_t python_interpreter_t::python_command(call_scope_t& args)
     delete[] argv[i];
   delete[] argv;
 
-  if (status != 0)
-    throw status;
+  if (status != 0) {
+    throw_(std::runtime_error, _("Failed to execute Python module"));
+  }
 
   return NULL_VALUE;
 }


### PR DESCRIPTION
Before, `ledger python -- -c 'raise RuntimeError'` would terminate
messily via SIGABRT, printing the following:

    terminate called after throwing an instance of 'int'
    [1]    2151711 abort (core dumped)  ledger python -c 'raise RuntimeError'

This change makes the python subcommand throw a standard C++ exception
rather than just a plain int, which is never caught and triggers the
SIGABRT.  Now, the process prints the uncaught Python exception as
usual and then exits with exit code 1.

I tried to make a test case in test/regress but was not able to make it trigger a SIGABRT the same way it did on the command line.  I'm not sure why this is the case, but here is the test case for reference, in case a maintainer wants to fix and add it:

```
test python -- -c 'raise RuntimeError("raising from python script")' -> 1
__ERROR__
Traceback (most recent call last):
  File "<string>", line 1, in <module>
RuntimeError: raising from python script
end test
```