### PR TITLE
Fix regression in Python/C++ unicode string introduced with #2123

### DIFF
--- a/python/demo.py
+++ b/python/demo.py
@@ -55,11 +55,11 @@ def assertEqual(pat, candidate):
 comms = ledger.commodities
 
 usd = comms.find_or_create('$')
-eur = comms.find_or_create('EUR')
 xcd = comms.find_or_create('XCD')
 
-# Tests currency symbols encoded with UCS-1. For details see #2132.
-xxx = comms.find_or_create('¤')
+# Tests currency symbols encoded using UCS. For details see #2132.
+eur = comms.find_or_create('€') # UCS-2 / UCS-4
+xxx = comms.find_or_create('¤') # UCS-1
 
 assert not comms.find('CAD')
 assert not comms.has_key('CAD')
@@ -82,7 +82,7 @@ comms.european_by_default = True
 # don't need to worry about them, but they'll show up if you examine all the
 # keys in the commodities dict.
 
-assertEqual([u'', u'$', u'%', u'EUR', u'XCD', u'h', u'm', u's', u'¤'],
+assertEqual([u'', u'$', u'%', u'XCD', u'h', u'm', u's', u'¤', u'€'],
             sorted(comms.keys()))
 
 # All the styles of dict iteration are supported:
@@ -101,7 +101,7 @@ for commodity in comms.itervalues():
 # that date.  You can record specific conversion rates for any date using the
 # `exchange' method.
 
-comms.exchange(eur, ledger.Amount('$0.77')) # Trade 1 EUR for $0.77
+comms.exchange(eur, ledger.Amount('$0.77')) # Trade 1 € for $0.77
 comms.exchange(eur, ledger.Amount('$0.66'), datetime.now())
 
 # For the most part, however, you won't be interacting with commodities
@@ -136,7 +136,7 @@ assert one > zero
 
 # For addition and subtraction, only amounts of the same commodity may be
 # used, unless one of the amounts has no commodity at all -- in which case the
-# result uses the commodity of the other value.  Adding $10 to 10 EUR, for
+# result uses the commodity of the other value.  Adding $10 to 10 €, for
 # example, causes an ArithmeticError exception, but adding 10 to $10 gives
 # $20.
 
@@ -146,7 +146,7 @@ assertEqual(four, two + two)
 assertEqual(zero, one - one)
 
 try:
-    two += ledger.Amount("20 EUR")
+    two += ledger.Amount("20 €")
     assert False
 except ArithmeticError:
     pass
@@ -196,7 +196,7 @@ assertEqual(2, amt.display_precision)
 # There are several other supported math operations:
 
 amt    = ledger.Amount('$100.12')
-market = ((ledger.Amount('1 EUR') / ledger.Amount('$0.77')) * amt)
+market = ((ledger.Amount('1 €') / ledger.Amount('$0.77')) * amt)
 
 assertEqual(market, amt.value(eur))            # find present market value
 
@@ -225,19 +225,19 @@ assertEqual(100, amt.to_long())
 
 # Finally, amounts can be annotated to provide additional information about
 # "lots" of a given commodity.  This example shows $100.12 that was purchased
-# on 2009/10/01 for 140 EUR.  Lot information can be accessed through via the
+# on 2009/10/01 for 140 €.  Lot information can be accessed through via the
 # Amount's `annotation' property.  You can also strip away lot details to get
 # the underlying amount.  If you want the total price of any Amount, by
 # multiplying by its per-unit lot price, call the `Amount.price' method
 # instead of the `Annotation.price' property.
 
-amt2 = ledger.Amount('$100.12 {140 EUR} [2009/10/01]')
+amt2 = ledger.Amount('$100.12 {140 €} [2009/10/01]')
 
 assert amt2.has_annotation()
 assertEqual(amt, amt2.strip_annotations())
 
-assertEqual(ledger.Amount('140 EUR'), amt2.annotation.price)
-assertEqual(ledger.Amount('14016,8 EUR'), amt2.price()) # european amount!
+assertEqual(ledger.Amount('140 €'), amt2.annotation.price)
+assertEqual(ledger.Amount('14016,8 €'), amt2.price()) # european amount!
 
 ###############################################################################
 #

--- a/python/demo.py
+++ b/python/demo.py
@@ -58,6 +58,9 @@ usd = comms.find_or_create('$')
 eur = comms.find_or_create('EUR')
 xcd = comms.find_or_create('XCD')
 
+# Tests currency symbols encoded with UCS-1. For details see #2132.
+xxx = comms.find_or_create('¤')
+
 assert not comms.find('CAD')
 assert not comms.has_key('CAD')
 assert not 'CAD' in comms
@@ -79,7 +82,7 @@ comms.european_by_default = True
 # don't need to worry about them, but they'll show up if you examine all the
 # keys in the commodities dict.
 
-assertEqual([u'', u'$', u'%', u'EUR', u'XCD', u'h', u'm', u's'],
+assertEqual([u'', u'$', u'%', u'EUR', u'XCD', u'h', u'm', u's', u'¤'],
             sorted(comms.keys()))
 
 # All the styles of dict iteration are supported:

--- a/src/py_utils.cc
+++ b/src/py_utils.cc
@@ -134,7 +134,8 @@ struct string_from_python
       PyUnicode_GET_SIZE(obj_ptr);
 #endif
 #if PY_MINOR_VERSION < 12
-    PyUnicode_READY(obj_ptr);
+    if (PyUnicode_READY(obj_ptr))
+      return;
 #endif
     switch (PyUnicode_KIND(obj_ptr)) {
       case PyUnicode_1BYTE_KIND: {

--- a/src/py_utils.cc
+++ b/src/py_utils.cc
@@ -136,32 +136,33 @@ struct string_from_python
 #if PY_MINOR_VERSION < 12
     PyUnicode_READY(obj_ptr);
 #endif
-    const char* value;
     switch (PyUnicode_KIND(obj_ptr)) {
-      case PyUnicode_1BYTE_KIND:
-        value = (const char*)PyUnicode_1BYTE_DATA(obj_ptr);
+      case PyUnicode_1BYTE_KIND: {
+        Py_UCS1* value = PyUnicode_1BYTE_DATA(obj_ptr);
+        if (value == 0) throw_error_already_set();
         str = std::string(value);
-        break;
+        } break;
 #if PY_MINOR_VERSION < 12 && Py_UNICODE_SIZE == 2
       case PyUnicode_WCHAR_KIND:
 #endif
-      case PyUnicode_2BYTE_KIND:
-        value = (const char*)PyUnicode_2BYTE_DATA(obj_ptr);
+      case PyUnicode_2BYTE_KIND: {
+        Py_UCS2* value = PyUnicode_2BYTE_DATA(obj_ptr);
+        if (value == 0) throw_error_already_set();
         utf8::unchecked::utf16to8(value, value + size, std::back_inserter(str));
-        break;
+        } break;
 #if PY_MINOR_VERSION < 12 && Py_UNICODE_SIZE == 4
       case PyUnicode_WCHAR_KIND:
 #endif
-      case PyUnicode_4BYTE_KIND:
-        value = (const char*)PyUnicode_4BYTE_DATA(obj_ptr);
+      case PyUnicode_4BYTE_KIND: {
+        Py_UCS4* value = PyUnicode_4BYTE_DATA(obj_ptr);
+        if (value == 0) throw_error_already_set();
         utf8::unchecked::utf32to8(value, value + size, std::back_inserter(str));
-        break;
+        } break;
       default:
         assert("PyUnicode_KIND returned an unexpected kind" == NULL);
     }
 #endif // PY_MAJOR_VERSION
 
-    if (value == 0) throw_error_already_set();
     void* storage =
       reinterpret_cast<converter::rvalue_from_python_storage<string> *>
                       (data)->storage.bytes;

--- a/src/py_utils.cc
+++ b/src/py_utils.cc
@@ -140,7 +140,7 @@ struct string_from_python
       case PyUnicode_1BYTE_KIND: {
         Py_UCS1* value = PyUnicode_1BYTE_DATA(obj_ptr);
         if (value == 0) throw_error_already_set();
-        str = std::string(value);
+        utf8::unchecked::utf16to8(value, value + size, std::back_inserter(str));
         } break;
 #if PY_MINOR_VERSION < 12 && Py_UNICODE_SIZE == 2
       case PyUnicode_WCHAR_KIND:


### PR DESCRIPTION
The changes in this PR address #2132.

The regression was introduced by casting the return value of the different string access macros (e.g. `PyUnicode_1BYTE_DATA`) to `const char*` instead of using the proper typealias (e.g. `Py_UCS1`), which can be an 8, 16, or 32 bit type (see [`python/cpython/Include/unicodeobject.h`](https://github.com/python/cpython/blob/7546914e3f8157d8bad2998677e0ea3ed4cb7939/Include/unicodeobject.h#L100-L104)).

To properly handle the [Euro sign `€`)](https://en.wikipedia.org/wiki/Euro_sign) 16 bits are needed (UCS-2 codepath), yet ledger only allowed for 8, which truncated upper bits of the character for the Euro sign from `U+20AC` to to `U+FFAC`, i.e. `ﾬ`.

While working on this fix to address #2132 I noticed that certain strings (e.g. `¤ 12.34`) are not properly handled and result a `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa4 in position 0: invalid start byte` is thrown at runtime.
The [generic currency sign `¤`](https://en.wikipedia.org/wiki/Currency_sign_(typography)) can be encoded with 8 bits (UCS-1 codepath) yet directly creating a string from the `PyUnicode_1BYTE_DATA` return value does not result in a proper UTF-8 string.

I decided to replace the `EUR` currency in the `python/demo.py` with `€`, so that this fix for the regression is tested. The `XCD` and `EUR` commodities test the same codepath and seem to provide less value. Let me know if you believe that is too drastic of a change, @tbm…
