### PR TITLE
xml: Include posting-specific payee in output

### DIFF
--- a/src/post.cc
+++ b/src/post.cc
@@ -723,6 +723,9 @@ void put_post(property_tree::ptree& st, const post_t& post)
   if (post._date_aux)
     put_date(st.put("aux-date", ""), *post._date_aux);
 
+  if (post.payee_from_tag() != "")
+    st.put("payee", post.payee_from_tag());
+
   if (post.account) {
     property_tree::ptree& t(st.put("account", ""));
 


### PR DESCRIPTION
In `ledger xml` export, include the `<posting>`-specific payee (from the
`Payee:` tag) as `<payee>`. This data is already included under
`<metadata>` as `<value key="Payee">`, but that is more specific to
Ledger's implementation; if in the future there is another way to set
the payee (or perhaps an option to have the Payee tag in one's own
language), that field wouldn't be a reliable method of getting this
info.

Example:

    2022-01-01 Transaction-level payee
        a                                             10
        b  ; Payee: Posting-level payee

Relevant XML output:

    <transaction>
      <date>2022-01-01</date>
      <payee>Transaction-level payee</payee>
      <postings>
        <posting>
          <account ref="0000558defd6f260">
            <name>a</name>
          </account>
          <post-amount>
            <amount>
              <quantity>10</quantity>
            </amount>
          </post-amount>
          <total>
            <amount>
              <quantity>10</quantity>
            </amount>
          </total>
        </posting>
        <posting>
          <payee>Posting-level payee</payee>
          <account ref="0000558defd6f960">
            <name>b</name>
          </account>
          <post-amount>
            <amount>
              <quantity>-10</quantity>
            </amount>
          </post-amount>
          <note> Payee: Posting-level payee</note>
          <metadata>
            <value key="Payee">
              <string>Posting-level payee</string>
            </value>
          </metadata>
          <total>
            <amount>
              <quantity>0</quantity>
            </amount>
          </total>
        </posting>
      </postings>
    </transaction>