### PR TITLE
WIP: Signed costs

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -6877,6 +6877,10 @@ When generating a ledger transaction from a CSV file using the
 Set the random seed to @var{INT} for the @code{generate} command.
 Used as part of development testing.
 
+@item --signed-costs-out
+Show total costs as signed values, so that @code{AMOUNT} and @code{COST}
+are always output with the same sign in @code{AMOUNT@@@@ COST}.
+
 @item --sort @var{VEXPR}
 @itemx -S @var{VEXPR}
 Sort the @command{register} report based on the value expression given

--- a/src/print.cc
+++ b/src/print.cc
@@ -248,18 +248,21 @@ namespace {
         if (post->given_cost &&
             ! post->has_flags(POST_CALCULATED | POST_COST_CALCULATED)) {
           std::string cost_op;
-          if (post->has_flags(POST_COST_IN_FULL))
+	  amount_t cost_amt;
+          if (post->has_flags(POST_COST_IN_FULL)) {
             cost_op = "@@";
-          else
+	    cost_amt = *post->given_cost;
+          } else {
             cost_op = "@";
+	    cost_amt = *post->given_cost / post->amount;
+	  }
           if (post->has_flags(POST_COST_VIRTUAL))
             cost_op = "(" + cost_op + ")";
 
-          if (post->has_flags(POST_COST_IN_FULL))
-            amtbuf << " " << cost_op << " " << post->given_cost->abs();
+	  if (report.HANDLED(signed_costs_out))
+            amtbuf << " " << cost_op << " " << cost_amt.abs();
           else
-            amtbuf << " " << cost_op << " "
-                   << (*post->given_cost / post->amount).abs();
+            amtbuf << " " << cost_op << " " cost_amt;
         }
 
         if (post->assigned_amount)

--- a/src/print.cc
+++ b/src/print.cc
@@ -260,9 +260,9 @@ namespace {
             cost_op = "(" + cost_op + ")";
 
 	  if (report.HANDLED(signed_costs_out))
-            amtbuf << " " << cost_op << " " << cost_amt.abs();
+            amtbuf << " " << cost_op << " " << cost_amt;
           else
-            amtbuf << " " << cost_op << " " cost_amt;
+            amtbuf << " " << cost_op << " " << cost_amt.abs();
         }
 
         if (post->assigned_amount)

--- a/src/report.cc
+++ b/src/report.cc
@@ -1301,6 +1301,7 @@ option_t<report_t> * report_t::lookup_option(const char * p)
     else OPT_(subtotal);
     else OPT(start_of_week_);
     else OPT(seed_);
+    else OPT(signed_costs_out);
     break;
   case 't':
     OPT_CH(amount_);

--- a/src/report.h
+++ b/src/report.h
@@ -341,6 +341,7 @@ public:
     HANDLER(revalued_total_).report(out);
     HANDLER(rich_data).report(out);
     HANDLER(seed_).report(out);
+    HANDLER(signed_costs_out).report(out);
     HANDLER(sort_).report(out);
     HANDLER(sort_all_).report(out);
     HANDLER(sort_xacts_).report(out);
@@ -970,6 +971,8 @@ public:
   OPTION(report_t, rich_data);
 
   OPTION(report_t, seed_);
+
+  OPTION(report_t, signed_costs_out);
 
   OPTION_(report_t, sort_, DO_(str) { // -S
       OTHER(sort_xacts_).off();

--- a/test/baseline/opt-signed-costs-out.test
+++ b/test/baseline/opt-signed-costs-out.test
@@ -1,0 +1,18 @@
+2022-10-30 * Buy FOO
+    Assets:Cash              -100.00 EUR
+    Assets:Fubar                3.00 FOO @@ 100.00 EUR
+
+2022-10-31 * Sell FOO
+    Assets:Fubar              -3,00 FOO @@ 100.00 EUR
+    Assets:Cash              100,00 EUR
+
+test --signed-costs-out print
+2022/10/30 * Buy FOO
+    Assets:Cash                          -100,00 EUR
+    Assets:Fubar                            3,00 FOO @@ 100,00 EUR
+
+2022/10/31 * Sell FOO
+    Assets:Fubar                           -3,00 FOO @@ -100,00 EUR
+    Assets:Cash                           100,00 EUR
+end test
+

--- a/test/baseline/opt-signed-costs-out.test
+++ b/test/baseline/opt-signed-costs-out.test
@@ -3,16 +3,16 @@
     Assets:Fubar                3.00 FOO @@ 100.00 EUR
 
 2022-10-31 * Sell FOO
-    Assets:Fubar              -3,00 FOO @@ 100.00 EUR
-    Assets:Cash              100,00 EUR
+    Assets:Fubar              -3.00 FOO @@ 100.00 EUR
+    Assets:Cash              100.00 EUR
 
 test --signed-costs-out print
 2022/10/30 * Buy FOO
-    Assets:Cash                          -100,00 EUR
-    Assets:Fubar                            3,00 FOO @@ 100,00 EUR
+    Assets:Cash                          -100.00 EUR
+    Assets:Fubar                            3.00 FOO @@ 100.00 EUR
 
 2022/10/31 * Sell FOO
-    Assets:Fubar                           -3,00 FOO @@ -100,00 EUR
-    Assets:Cash                           100,00 EUR
+    Assets:Fubar                           -3.00 FOO @@ -100.00 EUR
+    Assets:Cash                           100.00 EUR
 end test
 


### PR DESCRIPTION
I have a feature request that might be somewhat idiosyncratic, so I'm prepared to do most of the work myself, mainly asking for feedback and guidance.
My brain insists that the total cost or price of a lot is really a signed quantity (positive when you buy, negative when you sell), just like Ledger does internally. I'd like to have command-line switches to expose the internal sign of a total cost, separately for input and output to let you easily transform a journal from one format to the other either way. Here's my proposal for the output switch, which seems to be more straightforward than the input one. It worked as expected when I ran a  couple of simple tests. I'll be happy to write some proper automated tests, document the new feature, and do whatever else is needed, but I'd like to first know if I'm going in the right direction at all.
