### PR TITLE
Add python support for error_context

### DIFF
--- a/src/py_session.cc
+++ b/src/py_session.cc
@@ -33,6 +33,7 @@
 
 #include "pyinterp.h"
 #include "pyutils.h"
+#include "error.h"
 #include "session.h"
 
 namespace ledger {
@@ -49,6 +50,11 @@ namespace {
   {
     return python_session->read_journal_from_string(data);
   }
+
+  PyObject* py_error_context(const session_t& session)
+  {
+      return str_to_py_unicode(error_context());
+  }
 }
 
 void export_session()
@@ -63,6 +69,7 @@ void export_session()
     .def("close_journal_files", &session_t::close_journal_files)
     .def("journal", &session_t::get_journal,
          return_internal_reference<>())
+    .def("error_context", &py_error_context)
     ;
 
   scope().attr("session") =


### PR DESCRIPTION
Added ledger.session.error_context() to py_session.cc to get the error context message when exceptions are thrown.

This is needed for me as the ArithmeticError thrown when a transaction doesn't balance doesn't include the unbalanced remainder. So adding this allowed me to retrieve the amount that the transaction was off by.

First PR so let me know if anything else is needed. I looked at the python unit tests but looks like they were never updated for python 3.