### PR TITLE
Add compatability for Python 3.10 and later to acprep

### DIFF
--- a/acprep
+++ b/acprep
@@ -193,7 +193,10 @@ class CommandLineApp(object):
             # not let us differentiate between application errors and a case
             # where the user has not passed us enough arguments.  So, we check
             # the argument count ourself.
-            argspec = inspect.getargspec(self.main)
+            if sys.version_info < (3, 10):
+                argspec = inspect.getargspec(self.main)
+            else:
+                argspec = inspect.getfullargspec(self.main)
             expected_arg_count = len(argspec[0]) - 1
 
             if len(main_args) >= expected_arg_count:


### PR DESCRIPTION
This PR calls the appropriate `inspect.get(full)argspec` method depending on the Python version being used to run acprep.

This is necessary as `inspect.getargspec` was renamed to `inspect.getfullargspec` in [Python 3.10](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec)