### PR TITLE
Python: test cleanups

### DIFF
--- a/src/py_session.cc
+++ b/src/py_session.cc
@@ -55,6 +55,9 @@ namespace {
   {
       return str_to_py_unicode(error_context());
   }
+  void py_close_journal_files() {
+    python_session->close_journal_files();
+  }
 }
 
 void export_session()
@@ -74,6 +77,8 @@ void export_session()
 
   scope().attr("session") =
     object(ptr(static_cast<session_t *>(python_session.get())));
+  scope().attr("close_journal_files") =
+    python::make_function(&py_close_journal_files);
   scope().attr("read_journal") =
     python::make_function(&py_read_journal,
                           return_internal_reference<>());

--- a/test/python/JournalTest.py
+++ b/test/python/JournalTest.py
@@ -6,7 +6,7 @@ from ledger import *
 
 class JournalTestCase(unittest.TestCase):
     def tearDown(self):
-        session.close_journal_files()
+        close_journal_files()
 
     def testBasicRead(self):
         journal = read_journal_from_string("""
@@ -37,7 +37,7 @@ class JournalTestCase(unittest.TestCase):
         try:
             fun()
         except RuntimeError as e:
-            self.assertEquals(str(e).splitlines()[-1],
+            self.assertEqual(str(e).splitlines()[-1],
                               "No quantity specified for amount")
 
  

--- a/test/python/PostingTest.py
+++ b/test/python/PostingTest.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import exceptions
 import operator
 
 from ledger import *
-from StringIO import *
 from datetime import *
 
 class PostingTestCase(unittest.TestCase):
@@ -13,7 +11,7 @@ class PostingTestCase(unittest.TestCase):
         pass
 
     def tearDown(self):
-        pass
+        close_journal_files()
 
     def test_(self):
         pass

--- a/test/python/TransactionTest.py
+++ b/test/python/TransactionTest.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import exceptions
 import operator
 
 from ledger import *
-from StringIO import *
 from datetime import *
 
 class JournalTestCase(unittest.TestCase):
@@ -13,7 +11,7 @@ class JournalTestCase(unittest.TestCase):
         pass
 
     def tearDown(self):
-        pass
+        close_journal_files()
 
     def test_(self):
         pass


### PR DESCRIPTION
1. Remove references to modules (exceptions, StringIO) no longer needed for Pythn3

2. Use assertEqual instead of assertEquals

3. Clear journal files with a close_journal_files() function that uses the then-current underlying python_session pointer. Calling session.close_journal_files() sometimes leads to segfaults because python_session has changed after it was injected into the python module (as "session") on module startup.