### PR TITLE
fix brew link error on mac CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,6 +43,15 @@ jobs:
       - if: runner.os == 'macOS'
         name: Mac Dependencies
         run: |
+          # Unlink and re-link to prevent errors when github mac runner images
+          # install python outside of brew, for example:
+          # https://github.com/orgs/Homebrew/discussions/3895
+          # https://github.com/actions/setup-python/issues/577
+          # https://github.com/actions/runner-images/issues/6459
+          # https://github.com/actions/runner-images/issues/6507
+          # https://github.com/actions/runner-images/issues/2322
+          brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+
           brew update
           brew install boost boost-python3 gmp mpfr gpgme
 


### PR DESCRIPTION
The github mac runner images added python 3.11 but, unlike 3.10, not via brew. This causes `brew install` to fail with link conflict errors now that `boost-python3` switched over to 3.11. Workaround this, and future python brew link errors, by overwriting all links for python packages.

There are a variety of possible solutions here. I went with re-linking all python packages to try to prevent this problem from reoccurring with future python versions; similar issues have been previously reported with the mac github runner images.

I did look into `install --force` as mentioned in #2157. It turns out that still does not overwrite symlinks. From https://docs.brew.sh/Manpage: `-f, --force: [...] When installing casks, overwrite existing files (binaries and symlinks are excluded, unless originally from the same cask)`. The brew maintainers declined to provide an overwrite option for `install`: https://github.com/Homebrew/brew/issues/1742.

https://github.com/Homebrew/homebrew-core/commit/8c79089ae410bcd38065dfa3748bbcdb64b228d2
https://github.com/orgs/Homebrew/discussions/3895
https://github.com/actions/setup-python/issues/577
https://github.com/actions/runner-images/issues/6459
https://github.com/actions/runner-images/issues/6507
https://github.com/actions/runner-images/issues/2322

Fixes #2157 