### PR TITLE
Fix python/c++ conversion for boost::optional<T>

### DIFF
--- a/src/pyutils.h
+++ b/src/pyutils.h
@@ -88,13 +88,14 @@ struct register_optional_to_python : public boost::noncopyable
     {
       using namespace boost::python::converter;
 
-      void * const storage =
-        reinterpret_cast<rvalue_from_python_storage<T> *>(data)->storage.bytes;
+      const T value = typename boost::python::extract<T>(source);
 
-      if (data->convertible == source)      // == None
+      void * storage = ((rvalue_from_python_storage<boost::optional<T>>*) data)->storage.bytes;
+
+      if (source == Py_None)      // == None
         new (storage) boost::optional<T>(); // A Boost uninitialized value
       else
-        new (storage) boost::optional<T>(*reinterpret_cast<T *>(data->convertible));
+        new (storage) boost::optional<T>(value);
 
       data->convertible = storage;
     }

--- a/test/python/TransactionTest.py
+++ b/test/python/TransactionTest.py
@@ -10,6 +10,7 @@ class TransactionTestCase(unittest.TestCase):
     def setUp(self):
         self.journal = read_journal_from_string("""
 2012-03-01 KFC
+    ;this is a note
     Expenses:Food      $21.34
     Assets:Cash
 2012-03-02 MJT
@@ -30,6 +31,14 @@ class TransactionTestCase(unittest.TestCase):
         x1_posts = [post for post in xacts[1]]
         self.assertEqual(len(x0_posts), 4)
         self.assertEqual(len(x1_posts), 0)
+
+    def testSetNote(self):
+        xacts = [xact for xact in self.journal]
+        self.assertEqual(xacts[0].note, 'this is a note')
+        xacts[0].note = 'this is also a note'
+        self.assertEqual(xacts[0].note, 'this is also a note')
+        xacts[0].note += 'so is this'
+        self.assertEqual(xacts[0].note, 'this is also a noteso is this')
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(TransactionTestCase)


### PR DESCRIPTION
Setters for types wrapped in `boost::optional`, such as `item_t::note` were broken, e.g. setting a note on a transaction resulted in garbled data that would cause Python to throw utf-8 errors when retrieving the note.

(But setters that accessed strings directly, e.g. "payee" on a transaction worked fine.)

This change alters the from-python conversion for optional-wrapped types based on the example at
https://stackoverflow.com/questions/36485840/wrap-boostoptional-using-boostpython and a test case to verify the behavior.