### PR TITLE
Rename quoted_rfc4180 to quoted_rfc, to avoid parser quirk

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -1284,11 +1284,11 @@ for values that have a per-unit cost.
 .It Fn quoted expression
 Surround
 .Ar expression
-with double-quotes.
-.It Fn quoted_rfc4180 expression
+with double quotes.
+.It Fn quoted_rfc expression
 Surround
 .Ar expression
-with double-quotes, compatible with rfc 4180.
+with double quotes, compliant with rfc 4180.
 .It Sy real
 .\" Is there a difference between real and actual?
 Return true if the transaction is real, i.e not an automated or virtual

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -8518,7 +8518,8 @@ Return the quantity of @var{value} for values that have a per-unit cost.
 @end defun
 
 @defun quoted expression
-Surround @var{expression} with double-quotes.  If expression contains a double-quote, it will be escaped with a backslash.
+Surround @var{expression} with double quotes.  If expression contains
+a double quote, it will be escaped with a backslash.
 @smallexample @c command:EAD8AA7,with_input:3406FC1
 $ ledger -f expr.dat --format "%(quoted(account)) %(quoted(amount))\n" reg
 @end smallexample
@@ -8528,16 +8529,10 @@ $ ledger -f expr.dat --format "%(quoted(account)) %(quoted(amount))\n" reg
 @end smallexample
 @end defun
 
-@c @defun quoted_rfc4180 expression
-@c Surround @var{expression} with double-quotes, compliant with RFC 4180.  If expression contains a double-quote, it will be represented with two double-quotes.
-@c @smallexample @c command:EAD8AA7,with_input:3406FC1
-@c $ ledger -f expr.dat --format "%(quoted_rfc4180(account)) %(quoted_rfc4180(amount))\n" reg
-@c @end smallexample
-@c @smallexample @c output:EAD8AA7
-@c "Assets:Cash" "¤ -123,45"
-@c "Expenses:Office Supplies" "¤ 123,45"
-@c @end smallexample
-@c @end defun
+@defun quoted_rfc expression
+Similar, except an embedded double quote would be escaped by
+preceding it with another double quote, as prescribed by RFC 4180.
+@end defun
 
 @defun round
 @value{FIXME:UNDOCUMENTED}

--- a/src/report.cc
+++ b/src/report.cc
@@ -765,7 +765,7 @@ value_t report_t::fn_quoted(call_scope_t& args)
   return string_value(out.str());
 }
 
-value_t report_t::fn_quoted_rfc4180(call_scope_t& args)
+value_t report_t::fn_quoted_rfc(call_scope_t& args)
 {
   std::ostringstream out;
 
@@ -1498,8 +1498,8 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind,
     case 'q':
       if (is_eq(p, "quoted"))
         return MAKE_FUNCTOR(report_t::fn_quoted);
-      else if (is_eq(p, "quoted_rfc4180"))
-        return MAKE_FUNCTOR(report_t::fn_quoted_rfc4180);
+      else if (is_eq(p, "quoted_rfc"))
+        return MAKE_FUNCTOR(report_t::fn_quoted_rfc);
       else if (is_eq(p, "quantity"))
         return MAKE_FUNCTOR(report_t::fn_quantity);
       break;

--- a/src/report.h
+++ b/src/report.h
@@ -182,7 +182,7 @@ public:
   value_t fn_abs(call_scope_t& scope);
   value_t fn_justify(call_scope_t& scope);
   value_t fn_quoted(call_scope_t& scope);
-  value_t fn_quoted_rfc4180(call_scope_t& scope);
+  value_t fn_quoted_rfc(call_scope_t& scope);
   value_t fn_join(call_scope_t& scope);
   value_t fn_format_date(call_scope_t& scope);
   value_t fn_format_datetime(call_scope_t& scope);

--- a/test/baseline/opt-csv-format4180.test
+++ b/test/baseline/opt-csv-format4180.test
@@ -1,0 +1,7 @@
+2023/01/09   John's Hardware - 2" rubber nails
+    Expenses:DIY    $1.00
+    Assets:Cash
+
+test csv --csv-format='%(quoted_rfc(payee))\n' expenses
+"John's Hardware - 2"" rubber nails"
+end test

--- a/test/baseline/opt-csv-formatq.test
+++ b/test/baseline/opt-csv-formatq.test
@@ -1,0 +1,7 @@
+2023/01/09   John's Hardware - 2" rubber nails
+    Expenses:DIY    $1.00
+    Assets:Cash
+
+test csv --csv-format='%(quoted(payee))\n' expenses
+"John's Hardware - 2\" rubber nails"
+end test


### PR DESCRIPTION
Ledger's expression parser considers quoted_rfc4180 to be an amount (quantity 4180 of commodity "quoted_rfc").

Fixes #2007.