### PR TITLE
typo and column alignment

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -499,7 +499,7 @@ public:
       fits_in_long() returns true if to_long() would not lose
       precision.
 
-      to_string() returns an amount'ss "display value" as a string --
+      to_string() returns an amount's "display value" as a string --
       after rounding the value according to the commodity's default
       precision.  It is equivalent to: `round().to_fullstring()'.
 

--- a/test/regress/25A099C9.dat
+++ b/test/regress/25A099C9.dat
@@ -492,7 +492,7 @@ public:
       fits_in_long() returns true if to_long() would not lose
       precision.
 
-      to_string() returns an amount'ss "display value" as a string --
+      to_string() returns an amount's "display value" as a string --
       after rounding the value according to the commodity's default
       precision.  It is equivalent to: `round().to_fullstring()'.
 

--- a/test/regress/89233B6D-a.dat
+++ b/test/regress/89233B6D-a.dat
@@ -1,4 +1,4 @@
 1994/01/02 * Salary
-    Assets:Bank:Checking               200.00
+    Assets:Bank:Checking                200.00
     Income:Salary                      -200.00
 

--- a/test/regress/89233B6D-b.dat
+++ b/test/regress/89233B6D-b.dat
@@ -1,4 +1,4 @@
 1994/01/02 * Rent
     Expenses:Rent                       100.00
-    Assets:Bank:Checking              -100.00
+    Assets:Bank:Checking               -100.00
 


### PR DESCRIPTION
https://github.com/ledger/ledger/issues/2159

missed a typo in https://github.com/ledger/ledger/pull/2160/commits/0540ef19dbbdea127f824eba2f8fe8f1bb04b046

src/amount.h
test/regress/25A099C9.dat

```
$ ed -s ledger/test/regress/25A099C9.dat <<<'495p'
      to_string() returns an amount'ss "display value" as a string --
$ grep -n amount\'ss ledger/src/amount.h
502:      to_string() returns an amount'ss "display value" as a string --
$ 
```

should have added blank spaces to align columns

test/regress/89233B6D-a.dat

```diff
  1994/01/02 * Salary
-     Assets:Bank:Checking               200.00
+     Assets:Bank:Checking                200.00
      Income:Salary                      -200.00
```

test/regress/89233B6D-b.dat

```diff
      Expenses:Rent                       100.00
-     Assets:Bank:Checking              -100.00
+     Assets:Bank:Checking               -100.00
```
