### PR TITLE
Rename quoted_rfc4180 to quoted_rfc; disallow numbers in function names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,11 @@
   to include for stdin (`-f -`). Also for `-f -` when `include` cannot find the
   file it reports the error with full path now. (bug #2057 & bug #2092)
 
+- Rename `quoted_rfc4180` to `quoted_rfc`, as numbers used in function names
+  confuses the parser.
+
+- Numbers are no longer permitted in value expression function names.
+
 - Various documentation improvements
 
 ## 3.2.1 (2020-05-18)

--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -1,4 +1,4 @@
-.Dd March 15, 2019
+.Dd January 23, 2023
 .Dt LEDGER 1
 .Os
 .Sh NAME
@@ -1285,7 +1285,7 @@ for values that have a per-unit cost.
 Surround
 .Ar expression
 with double-quotes.
-.It Fn quoted_rfc4180 expression
+.It Fn quoted_rfc expression
 Surround
 .Ar expression
 with double-quotes, compatible with rfc 4180.

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -8528,10 +8528,10 @@ $ ledger -f expr.dat --format "%(quoted(account)) %(quoted(amount))\n" reg
 @end smallexample
 @end defun
 
-@c @defun quoted_rfc4180 expression
+@c @defun quoted_rfc expression
 @c Surround @var{expression} with double-quotes, compliant with RFC 4180.  If expression contains a double-quote, it will be represented with two double-quotes.
 @c @smallexample @c command:EAD8AA7,with_input:3406FC1
-@c $ ledger -f expr.dat --format "%(quoted_rfc4180(account)) %(quoted_rfc4180(amount))\n" reg
+@c $ ledger -f expr.dat --format "%(quoted_rfc(account)) %(quoted_rfc(amount))\n" reg
 @c @end smallexample
 @c @smallexample @c output:EAD8AA7
 @c "Assets:Cash" "¤ -123,45"

--- a/src/report.cc
+++ b/src/report.cc
@@ -765,7 +765,7 @@ value_t report_t::fn_quoted(call_scope_t& args)
   return string_value(out.str());
 }
 
-value_t report_t::fn_quoted_rfc4180(call_scope_t& args)
+value_t report_t::fn_quoted_rfc(call_scope_t& args)
 {
   std::ostringstream out;
 
@@ -1498,8 +1498,8 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind,
     case 'q':
       if (is_eq(p, "quoted"))
         return MAKE_FUNCTOR(report_t::fn_quoted);
-      else if (is_eq(p, "quoted_rfc4180"))
-        return MAKE_FUNCTOR(report_t::fn_quoted_rfc4180);
+      else if (is_eq(p, "quoted_rfc"))
+        return MAKE_FUNCTOR(report_t::fn_quoted_rfc);
       else if (is_eq(p, "quantity"))
         return MAKE_FUNCTOR(report_t::fn_quantity);
       break;

--- a/src/report.h
+++ b/src/report.h
@@ -182,7 +182,7 @@ public:
   value_t fn_abs(call_scope_t& scope);
   value_t fn_justify(call_scope_t& scope);
   value_t fn_quoted(call_scope_t& scope);
-  value_t fn_quoted_rfc4180(call_scope_t& scope);
+  value_t fn_quoted_rfc(call_scope_t& scope);
   value_t fn_join(call_scope_t& scope);
   value_t fn_format_date(call_scope_t& scope);
   value_t fn_format_datetime(call_scope_t& scope);

--- a/src/token.cc
+++ b/src/token.cc
@@ -133,7 +133,7 @@ void expr_t::token_t::parse_ident(std::istream& in)
 
   int c;
   char buf[256];
-  READ_INTO_(in, buf, 255, c, length, std::isalnum(c) || c == '_');
+  READ_INTO_(in, buf, 255, c, length, std::isalpha(c) || c == '_');
 
   value.set_string(buf);
 }


### PR DESCRIPTION
Fixes https://github.com/ledger/ledger/issues/2007.