### PR TITLE
Update checkout action to Node.js 16

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
             cmake_args: -DUSE_PYTHON=ON -DUSE_GPGME=ON
           }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Check out repository code
 
       - if: runner.os == 'Linux'


### PR DESCRIPTION
as suggested by action warning

For more information see:
https://github.com/ledger/ledger/actions

and

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/