### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638407071,
-        "narHash": "sha256-xbveILjgtBVh6B5F6i2k3T0IrE8lZp1vsqfDY+Df/cg=",
+        "lastModified": 1675153841,
+        "narHash": "sha256-EWvU3DLq+4dbJiukfhS7r6sWZyJikgXn6kNl7eHljW8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "971b383a28f4baee8ea3931af4840fa221929fd6",
+        "rev": "ea692c2ad1afd6384e171eabef4f0887d2b882d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Building ledger with the following commands

```console
% nix develop
bash-5.1$ rm -rf build; (cmakeConfigurePhase && buildPhase && checkPhase)
```

form the current state of master fails all tests due to the following issue:

```console
bash-5.1$ ./build/ledger --version
dyld[95849]: Library not loaded: libledger.3.dylib
  Referenced from: <no uuid> /Users/afh/Developer/ledger/build/ledger
  Reason: tried: 'libledger.3.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibledger.3.dylib' (no such file), 'libledger.3.dylib' (no such file), '/usr/local/lib/libledger.3.dylib' (no such file), '/usr/lib/libledger.3.dylib' (no such file, not in dyld cache), '/Users/afh/Developer/ledger/libledger.3.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/afh/Developer/ledger/libledger.3.dylib' (no such file), '/Users/afh/Developer/ledger/libledger.3.dylib' (no such file), '/usr/local/lib/libledger.3.dylib' (no such file), '/usr/lib/libledger.3.dylib' (no such file, not in dyld cache)
Abort trap: 6
```

After a `nix flake update` all tests pass and ledger works as expected.