### PR TITLE
acprep: Replace deprecated getargspec with getfullargspec

### DIFF
--- a/acprep
+++ b/acprep
@@ -193,10 +193,7 @@ class CommandLineApp(object):
             # not let us differentiate between application errors and a case
             # where the user has not passed us enough arguments.  So, we check
             # the argument count ourself.
-            if sys.version_info < (3, 10):
-                argspec = inspect.getargspec(self.main)
-            else:
-                argspec = inspect.getfullargspec(self.main)
+            argspec = inspect.getfullargspec(self.main)
             expected_arg_count = len(argspec[0]) - 1
 
             if len(main_args) >= expected_arg_count:


### PR DESCRIPTION
Adressing latest comment in #2154.

According to the Python documentation [`getargspec`](https://docs.python.org/3.9/library/inspect.html#inspect.getargspec) is
> [d]eprecated since version 3.0: Use [getfullargspec()](https://docs.python.org/3.9/library/inspect.html#inspect.getfullargspec) for an updated API that is usually a drop-in replacement, but also correctly handles function annotations and keyword-only parameters.

Given that support for Python 2 has been dropped in ledger and [getfullargspec()](https://docs.python.org/3.9/library/inspect.html#inspect.getfullargspec) is available in Python 3 this change seems a good solution forward.