### PR TITLE
docs: Specify regex dialect used by ledger

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -1060,9 +1060,9 @@ query terms with an implicit OR operator between them.  The following terms
 are accepted:
 .Bl -tag -width "term and term"
 .It Ar regex
-A bare string is taken as a regular expression matching the full account name.
-Thus, to report the current balance for all assets and liabilities, you would
-use:
+A bare string is taken as a regular expression (PCRE) matching the full account
+name. Thus, to report the current balance for all assets and liabilities, you
+would use:
 .Pp
 .Dl ledger bal asset liab
 .It Ic payee Ar regex Pq Ic \&@ Ns Ar regex

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -4264,7 +4264,7 @@ $ ledger balance -f drewr3.dat Income
          $ -2,030.00
 @end smallexample
 
-You can use general regular expressions in nearly any place Ledger
+You can use general regular expressions (PCRE) in nearly any place Ledger
 needs a string:
 
 @smallexample @c command:EAE389F


### PR DESCRIPTION
I'm a bit uncertain on how to best integrate links to the documentation for [Boost's default regex dialect](https://www.boost.org/doc/libs/1_81_0/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html) and possibly https://www.pcre.org.

Any ideas or suggestions?


Closes #2145