### PR TITLE
Add info about compile features to --version

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -128,6 +128,15 @@ public:
     if (Ledger_VERSION_DATE != 0)
       out << '-' << Ledger_VERSION_DATE;
     out << _(", the command-line accounting tool");
+    out << _("\nwith");
+#if !HAVE_GPGME
+    out << _("out");
+#endif
+    out << _(" support for gpg encrypted journals and with");
+#if !HAVE_BOOST_PYTHON
+    out <<_("out");
+#endif
+    out << _(" Python support");
     out <<
       _("\n\nCopyright (c) 2003-2023, John Wiegley.  All rights reserved.\n\n\
 This program is made available under the terms of the BSD Public License.\n\


### PR DESCRIPTION
What is people's opinion about adding a line to the output of the `--version` option that shows which features have been compiled into Ledger?

**Before**

```console
% ledger --version
Ledger 3.3.0-20230208, the command-line accounting tool

Copyright (c) 2003-2023, John Wiegley.  All rights reserved.

This program is made available under the terms of the BSD Public License.
See LICENSE file included with the distribution for details and disclaimer.
```

**Before**

```console
% ./build/ledger --version
Ledger 3.3.0-20230208, the command-line accounting tool
with support for gpg encrypted journals and with Python support

Copyright (c) 2003-2023, John Wiegley.  All rights reserved.

This program is made available under the terms of the BSD Public License.
See LICENSE file included with the distribution for details and disclaimer.
```

