### PR TITLE
Add __version__ attribute to Python module

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -119,14 +119,17 @@ public:
     return true;
   }
 
-  void show_version_info(std::ostream& out) {
-    out <<
-      "Ledger " << Ledger_VERSION_MAJOR << '.' << Ledger_VERSION_MINOR << '.'
+  static void show_version(std::ostream& out) {
+    out << Ledger_VERSION_MAJOR << '.' << Ledger_VERSION_MINOR << '.'
                 << Ledger_VERSION_PATCH;
     if (Ledger_VERSION_PRERELEASE != 0)
       out << Ledger_VERSION_PRERELEASE;
     if (Ledger_VERSION_DATE != 0)
       out << '-' << Ledger_VERSION_DATE;
+  }
+
+  void show_version_info(std::ostream& out) {
+    show_version(out);
     out << _(", the command-line accounting tool");
     out <<
       _("\n\nCopyright (c) 2003-2023, John Wiegley.  All rights reserved.\n\n\

--- a/src/pyledger.cc
+++ b/src/pyledger.cc
@@ -32,12 +32,23 @@
 #include <system.hh>
 
 #include "pyinterp.h"
+#include "global.h"
 
 using namespace boost::python;
 
 namespace ledger {
   extern void initialize_for_python();
 }
+
+struct PyLedger
+{
+  static std::string version()
+  {
+    std::stringstream out;
+    ledger::global_scope_t::show_version(out);
+    return out.str();
+  }
+};
 
 BOOST_PYTHON_MODULE(ledger)
 {
@@ -49,4 +60,5 @@ BOOST_PYTHON_MODULE(ledger)
   set_session_context(python_session.get());
 
   initialize_for_python();
+  scope().attr("__version__") = PyLedger::version();
 }


### PR DESCRIPTION
this helps folks using the Ledger Python module to ensure they are using a version that provides the features they rely on.

```
% PYTHONPATH=build python -c 'import ledger; print(ledger.__version__)'
3.3.0-20230208
```