### PR TITLE
Update required CMake version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Ledger
   VERSION 3.3.0
   DESCRIPTION "A double-entry accounting system with a command-line reporting interface and Python module"
   HOMEPAGE_URL https://www.ledger-cli.org
-  LANGUAGES CXX
+  LANGUAGES CXX C
   )
 
 set(Ledger_VERSION_PRERELEASE "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,21 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
-PROJECT(ledger)
+project(Ledger
+  VERSION 3.3.0
+  DESCRIPTION "A double-entry accounting system with a command-line reporting interface and Python module"
+  HOMEPAGE_URL https://www.ledger-cli.org
+  LANGUAGES CXX
+  )
 
-set(Ledger_VERSION_MAJOR 3)
-set(Ledger_VERSION_MINOR 3)
-set(Ledger_VERSION_PATCH 0)
 set(Ledger_VERSION_PRERELEASE "")
-set(Ledger_VERSION_DATE  20230208)
+set(Ledger_VERSION_DATE "20230208")
 
 set(Ledger_TEST_TIMEZONE "America/Chicago")
 
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-if ((${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.7.0") AND (${CMAKE_VERSION} VERSION_LESS "3.16.0"))
-  # use backported module from 3.15 (introduced 3.12) to support older versions of cmake.
-  # this only works with cmake 3.7 or higher.
+if (${CMAKE_VERSION} VERSION_LESS "3.16.0")
+  # Use backported module from 3.15 (introduced 3.12) to support older versions of cmake.
   list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/python-backport")
 endif()
 
@@ -37,6 +38,7 @@ option(PRECOMPILE_SYSTEM_HH "Precompile system.hh" ON)
 option(USE_GPGME "Build with support for encrypted journals" OFF)
 option(BUILD_LIBRARY "Build and install Ledger as a library" ON)
 option(BUILD_DOCS "Build and install documentation" OFF)
+option(BUILD_A4_PDF "Build documentation for A4 papersize" OFF)
 option(BUILD_WEB_DOCS "Build version of documentation suitable for viewing online" OFF)
 
 if (BUILD_DEBUG)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ current `master` branch:
 
 Dependency  | Version (or greater)
 ------------|---------------------
+[CMake]     | 3.12
 [Boost]     | 1.49
 [GMP]       | 4.2.2
 [MPFR]      | 2.4.0


### PR DESCRIPTION
While this specific PR only adds little value I'd like to start a conversation about how far back older version of Ledger dependencies we'd like to support.

My first proposal would be to support versions that were released 4 years ago or more recent, any version released before that are unconsidered as unsupported from this project's point of view.
This would allow for a codebase modernisation once a year.

What are your thoughts on this?