### PR TITLE
Revert to build without Python

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   nixConfig.bash-prompt = "ledger$ ";
   outputs = { self, nixpkgs }: let
-    usePython = true;
+    usePython = false;
     gpgmeSupport = true;
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
     nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });


### PR DESCRIPTION
Since I'm _always_ building ledger with Python support I accidentally flipped the default in the flake.nix. Mea culpa :/