### PR TITLE
Remove unused server related code

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -257,12 +257,6 @@ The synonyms
 and
 .Ic r
 are also accepted.
-.It Ic server
-This command requires that Python support be active.  If so, it starts up an
-.Tn HTTP
-server listening for requests on port 9000.  This provides an alternate
-interface to creating and viewing reports.  Note that this is very much a
-work-in-progress, and will not be fully functional until a later version.
 .It Ic select Oo Ar sql-query Oc
 List all postings matching the
 .Ar sql-query .

--- a/src/pyinterp.cc
+++ b/src/pyinterp.cc
@@ -362,44 +362,6 @@ value_t python_interpreter_t::python_command(call_scope_t& args)
   return NULL_VALUE;
 }
 
-value_t python_interpreter_t::server_command(call_scope_t& args)
-{
-  if (! is_initialized)
-    initialize();
-
-  python::object server_module;
-
-  try {
-    server_module = python::import("ledger.server");
-    if (! server_module)
-      throw_(std::runtime_error,
-             _("Could not import ledger.server; please check your PYTHONPATH"));
-  }
-  catch (const error_already_set&) {
-    PyErr_Print();
-    throw_(std::runtime_error,
-           _("Could not import ledger.server; please check your PYTHONPATH"));
-  }
-
-  if (python::object main_function = server_module.attr("main")) {
-    functor_t func(main_function, "main");
-    try {
-      func(args);
-      return true;
-    }
-    catch (const error_already_set&) {
-      PyErr_Print();
-      throw_(std::runtime_error,
-             _("Error while invoking ledger.server's main() function"));
-    }
-  } else {
-      throw_(std::runtime_error,
-             _("The ledger.server module is missing its main() function!"));
-  }
-
-  return false;
-}
-
 option_t<python_interpreter_t> *
 python_interpreter_t::lookup_option(const char * p)
 {
@@ -473,11 +435,6 @@ expr_t::ptr_op_t python_interpreter_t::lookup(const symbol_t::kind_t kind,
     case 'p':
       if (is_eq(p, "python"))
         return MAKE_FUNCTOR(python_interpreter_t::python_command);
-      break;
-
-    case 's':
-      if (is_eq(p, "server"))
-        return MAKE_FUNCTOR(python_interpreter_t::server_command);
       break;
     }
   }

--- a/src/pyinterp.h
+++ b/src/pyinterp.h
@@ -106,7 +106,6 @@ public:
   }
 
   value_t python_command(call_scope_t& scope);
-  value_t server_command(call_scope_t& args);
 
   class functor_t {
     functor_t();


### PR DESCRIPTION
Other `server` related code was removed in `013965d0ce1b20e3f8814f65a0d3593c6789bcd7` it seems logical to remove any related left-overs.