### PR TITLE
doc: Fix texinfo invalid previous node reference

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -3112,7 +3112,7 @@ date.
 * Payee metadata::
 @end menu
 
-@node Payee metadata,  , Metadata payee, Metadata
+@node Payee metadata,  , Typed metadata, Metadata
 @subsection Payee metadata
 @cindex Payee metadata
 @findex register


### PR DESCRIPTION
When building the PDF documentation using texinfo, it complains about an incorrect previous node named `Metadata payee` for the `Payee metadata` node. This PR fixes this.