### PR TITLE
Do not perform commodity reduction when parsing a format directive

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1132,10 +1132,12 @@ void instance_t::commodity_format_directive(commodity_t& comm, string format)
   // observational formatting.
   trim(format);
   amount_t amt;
-  amt.parse(format);
+  amt.parse(format, PARSE_NO_REDUCE);
   if (amt.commodity() != comm)
-    throw_(parse_error, _f("commodity directive symbol %1% and format directive symbol %2% should be the same") %
-	comm.symbol() % amt.commodity().symbol());
+    throw_(parse_error,
+           _f("commodity directive symbol %1% and format directive symbol %2% should be the same")
+             % comm.symbol()
+             % amt.commodity().symbol());
   amt.commodity().add_flags(COMMODITY_STYLE_NO_MIGRATE);
   VERIFY(amt.valid());
 }


### PR DESCRIPTION
Fixes #2205 