### PR TITLE
Refactor Ledger version info into cmake/LedgerVersion.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,11 @@
 cmake_minimum_required(VERSION 3.0)
 
-PROJECT(ledger)
-
-set(Ledger_VERSION_MAJOR 3)
-set(Ledger_VERSION_MINOR 3)
-set(Ledger_VERSION_PATCH 1)
-set(Ledger_VERSION_PRERELEASE "")
-set(Ledger_VERSION_DATE  20230303)
+# Point CMake at any custom modules we may ship
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(LedgerVersion)
 
 set(Ledger_TEST_TIMEZONE "America/Chicago")
 
-# Point CMake at any custom modules we may ship
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 if ((${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.7.0") AND (${CMAKE_VERSION} VERSION_LESS "3.16.0"))
   # use backported module from 3.15 (introduced 3.12) to support older versions of cmake.
   # this only works with cmake 3.7 or higher.

--- a/cmake/LedgerVersion.cmake
+++ b/cmake/LedgerVersion.cmake
@@ -1,0 +1,5 @@
+set(Ledger_VERSION_MAJOR 3)
+set(Ledger_VERSION_MINOR 3)
+set(Ledger_VERSION_PATCH 1)
+set(Ledger_VERSION_PRERELEASE "")
+set(Ledger_VERSION_DATE  20230303)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -5,8 +5,14 @@
 
 ########################################################################
 
+cmake_minimum_required(VERSION 3.0)
+
+# Point CMake at any custom modules we may ship
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+include(LedgerVersion)
+
 configure_file(
-  ${PROJECT_SOURCE_DIR}/doc/version.texi.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/version.texi.in
   ${PROJECT_BINARY_DIR}/doc/version.texi)
 
 if (USE_DOXYGEN)


### PR DESCRIPTION
so it can be re-used when generating the version.texi for ledger-website builds.

@tbm I'm working on generating `version.texi` for ledger-website builds, for this the changes in this PR are necessary, so that there is only a single source of truth. A PR for ledger-website ~~will follow shortly~~ is available, see [ledger/ledger-website#53](https://github.com/ledger/ledger-website/pull/53/commits/e6b2f3aa8032d5bdb3bcc554dc5cc57637dbd2eb).