### PR TITLE
Re-add accidentially deleted PROJECT in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
+PROJECT(ledger)
+
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(LedgerVersion)


### PR DESCRIPTION
Apologies @tbm, the `PROJECT` cmake statement should not have been removed from CMakeLists.txt, my bad.