### PR TITLE
Fix Python version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if (USE_PYTHON)
 
   find_package(Python
     COMPONENTS Interpreter Development)
-  if (PYTHON_FOUND AND ${Python_VERSION} VERSION_LESS ${Required_Python_Version})
+  if (PYTHON_FOUND AND ${Python_VERSION} VERSION_GREATER_EQUAL ${Required_Python_Version})
     set(BOOST_PYTHON "python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}")
     set(HAVE_BOOST_PYTHON 1)
     include_directories(SYSTEM ${Python_INCLUDE_DIRS})


### PR DESCRIPTION
I got the version check for Python wrong when updating ledger's dependencies and starting to require Python 3.9.

We want cmake to check that the available Python version is greater than or equal to ledger's minimun required Python version.