### PR TITLE
Use #pragma once

### DIFF
--- a/src/account.h
+++ b/src/account.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_ACCOUNT_H
-#define INCLUDED_ACCOUNT_H
+#pragma once
 
 #include "scope.h"
 
@@ -304,5 +303,3 @@ struct account_compare {
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_ACCOUNT_H

--- a/src/amount.h
+++ b/src/amount.h
@@ -50,8 +50,7 @@
  * automatically expanded to include as many extra digits as necessary
  * to avoid losing information.
  */
-#ifndef INCLUDED_AMOUNT_H
-#define INCLUDED_AMOUNT_H
+#pragma once
 
 #include "utils.h"
 #include "times.h"
@@ -786,5 +785,3 @@ void put_amount(property_tree::ptree& pt, const amount_t& amt,
                 bool commodity_details = false);
 
 } // namespace ledger
-
-#endif // INCLUDED_AMOUNT_H

--- a/src/annotate.h
+++ b/src/annotate.h
@@ -43,8 +43,7 @@
  *
  * Long.
  */
-#ifndef INCLUDED_ANNOTATE_H
-#define INCLUDED_ANNOTATE_H
+#pragma once
 
 #include "expr.h"
 
@@ -232,5 +231,3 @@ as_annotated_commodity(const commodity_t& commodity) {
 }
 
 } // namespace ledger
-
-#endif // INCLUDED_ANNOTATE_H

--- a/src/balance.h
+++ b/src/balance.h
@@ -46,8 +46,7 @@
  * is designed to allow this, tracking the amounts of each component
  * commodity separately.
  */
-#ifndef INCLUDED_BALANCE_H
-#define INCLUDED_BALANCE_H
+#pragma once
 
 #include "amount.h"
 
@@ -609,5 +608,3 @@ void put_balance(property_tree::ptree& pt, const balance_t& bal);
 balance_t average_lot_prices(const balance_t& bal);
 
 } // namespace ledger
-
-#endif // INCLUDED_BALANCE_H

--- a/src/chain.h
+++ b/src/chain.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_CHAIN_H
-#define INCLUDED_CHAIN_H
+#pragma once
 
 #include "utils.h"
 
@@ -112,5 +111,3 @@ chain_handlers(post_handler_ptr handler,
 }
 
 } // namespace ledger
-
-#endif // INCLUDED_CHAIN_H

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -44,8 +44,7 @@
  * This file contains one of the most basic types in Ledger:
  * commodity_t, and its annotated cousin, annotated_commodity_t.
  */
-#ifndef INCLUDED_COMMODITY_H
-#define INCLUDED_COMMODITY_H
+#pragma once
 
 #include "expr.h"
 
@@ -299,5 +298,3 @@ struct commodity_compare {
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_COMMODITY_H

--- a/src/compare.h
+++ b/src/compare.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_COMPARE_H
-#define INCLUDED_COMPARE_H
+#pragma once
 
 #include "expr.h"
 
@@ -96,5 +95,3 @@ bool compare_items<account_t>::operator()(account_t * left,
                                           account_t * right);
 
 } // namespace ledger
-
-#endif // INCLUDED_COMPARE_H

--- a/src/context.h
+++ b/src/context.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_CONTEXT_H
-#define INCLUDED_CONTEXT_H
+#pragma once
 
 #include "utils.h"
 #include "times.h"
@@ -166,5 +165,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_CONTEXT_H

--- a/src/convert.h
+++ b/src/convert.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_CONVERT_H
-#define INCLUDED_CONVERT_H
+#pragma once
 
 #include "value.h"
 
@@ -51,5 +50,3 @@ class call_scope_t;
 value_t convert_command(call_scope_t& scope);
 
 } // namespace ledger
-
-#endif // INCLUDED_CONVERT_H

--- a/src/csv.h
+++ b/src/csv.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_CSV_H
-#define INCLUDED_CSV_H
+#pragma once
 
 #include "value.h"
 #include "context.h"
@@ -114,5 +113,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_CSV_H

--- a/src/draft.h
+++ b/src/draft.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_DRAFT_H
-#define INCLUDED_DRAFT_H
+#pragma once
 
 #include "exprbase.h"
 #include "value.h"
@@ -128,5 +127,3 @@ value_t xact_command(call_scope_t& args);
 value_t template_command(call_scope_t& args);
 
 } // namespace ledger
-
-#endif // INCLUDED_DRAFT_H

--- a/src/emacs.h
+++ b/src/emacs.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_EMACS_H
-#define INCLUDED_EMACS_H
+#pragma once
 
 #include "chain.h"
 
@@ -76,5 +75,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_EMACS_H

--- a/src/error.h
+++ b/src/error.h
@@ -39,8 +39,7 @@
  *
  * @ingroup util
  */
-#ifndef INCLUDED_ERROR_H
-#define INCLUDED_ERROR_H
+#pragma once
 
 namespace ledger {
 
@@ -101,5 +100,3 @@ struct error_count {
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_ERROR_H

--- a/src/expr.h
+++ b/src/expr.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_EXPR_H
-#define INCLUDED_EXPR_H
+#pragma once
 
 #include "exprbase.h"
 #include "value.h"
@@ -184,5 +183,3 @@ class call_scope_t;
 value_t source_command(call_scope_t& scope);
 
 } // namespace ledger
-
-#endif // INCLUDED_EXPR_H

--- a/src/exprbase.h
+++ b/src/exprbase.h
@@ -51,8 +51,7 @@
  * | draft_t     | Partially filled xacts     | xact_t *        |             |
  * | format_t    | Format strings             | string          |             |
  */
-#ifndef INCLUDED_EXPRBASE_H
-#define INCLUDED_EXPRBASE_H
+#pragma once
 
 #include "utils.h"
 #include "amount.h"
@@ -241,5 +240,3 @@ std::ostream& operator<<(std::ostream& out,
 }
 
 } // namespace ledger
-
-#endif // INCLUDED_EXPRBASE_H

--- a/src/filters.h
+++ b/src/filters.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_FILTERS_H
-#define INCLUDED_FILTERS_H
+#pragma once
 
 #include "chain.h"
 #include "xact.h"
@@ -1083,5 +1082,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_FILTERS_H

--- a/src/flags.h
+++ b/src/flags.h
@@ -39,8 +39,7 @@
  *
  * @ingroup util
  */
-#ifndef INCLUDED_FLAGS_H
-#define INCLUDED_FLAGS_H
+#pragma once
 
 
 template <typename T = boost::uint_least8_t, typename U = T>
@@ -183,5 +182,3 @@ public:
     _flags.drop_flags(arg);
   }
 };
-
-#endif // INCLUDED_FLAGS_H

--- a/src/format.h
+++ b/src/format.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_FORMAT_H
-#define INCLUDED_FORMAT_H
+#pragma once
 
 #include "expr.h"
 #include "unistring.h"
@@ -165,5 +164,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_FORMAT_H

--- a/src/generate.h
+++ b/src/generate.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_GENERATE_H
-#define INCLUDED_GENERATE_H
+#pragma once
 
 #include "iterators.h"
 
@@ -126,5 +125,3 @@ protected:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_GENERATE_H

--- a/src/global.h
+++ b/src/global.h
@@ -35,8 +35,7 @@
  *
  * @brief Contains the top-level functions used by main.cc
  */
-#ifndef INCLUDED_GLOBAL_H
-#define INCLUDED_GLOBAL_H
+#pragma once
 
 #include "option.h"
 #include "report.h"
@@ -182,5 +181,3 @@ See LICENSE file included with the distribution for details and disclaimer.");
 void handle_debug_options(int argc, char * argv[]);
 
 } // namespace ledger
-
-#endif // INCLUDED_GLOBAL_H

--- a/src/history.h
+++ b/src/history.h
@@ -43,8 +43,7 @@
  *
  * Long.
  */
-#ifndef INCLUDED_HISTORY_H
-#define INCLUDED_HISTORY_H
+#pragma once
 
 #include "amount.h"
 #include "commodity.h"
@@ -92,5 +91,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_HISTORY_H

--- a/src/item.h
+++ b/src/item.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_ITEM_H
-#define INCLUDED_ITEM_H
+#pragma once
 
 #include "scope.h"
 
@@ -214,5 +213,3 @@ string  item_context(const item_t& item, const string& desc);
 void    put_metadata(property_tree::ptree& pt, const item_t::string_map& metadata);
 
 } // namespace ledger
-
-#endif // INCLUDED_ITEM_H

--- a/src/iterators.h
+++ b/src/iterators.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_ITERATORS_H
-#define INCLUDED_ITERATORS_H
+#pragma once
 
 #include "xact.h"
 #include "post.h"
@@ -325,5 +324,3 @@ private:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_ITERATORS_H

--- a/src/journal.h
+++ b/src/journal.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_JOURNAL_H
-#define INCLUDED_JOURNAL_H
+#pragma once
 
 #include "utils.h"
 #include "times.h"
@@ -202,5 +201,3 @@ private:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_JOURNAL_H

--- a/src/lookup.h
+++ b/src/lookup.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_LOOKUP_H
-#define INCLUDED_LOOKUP_H
+#pragma once
 
 #include "iterators.h"
 
@@ -53,5 +52,3 @@ lookup_probable_account(const string& ident,
                         account_t * ref_account = NULL);
 
 } // namespace ledger
-
-#endif // INCLUDED_LOOKUP_H

--- a/src/mask.h
+++ b/src/mask.h
@@ -41,8 +41,7 @@
  *
  * @brief Regular expression masking.
  */
-#ifndef INCLUDED_MASK_H
-#define INCLUDED_MASK_H
+#pragma once
 
 #include "utils.h"
 #if HAVE_BOOST_REGEX_UNICODE
@@ -136,5 +135,3 @@ inline void put_mask(property_tree::ptree& pt, const mask_t& mask) {
 }
 
 } // namespace ledger
-
-#endif // INCLUDED_MASK_H

--- a/src/op.h
+++ b/src/op.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_OP_H
-#define INCLUDED_OP_H
+#pragma once
 
 #include "expr.h"
 
@@ -347,5 +346,3 @@ string op_context(const expr_t::ptr_op_t op,
 value_t split_cons_expr(expr_t::ptr_op_t op);
 
 } // namespace ledger
-
-#endif // INCLUDED_OP_H

--- a/src/option.h
+++ b/src/option.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_OPTION_H
-#define INCLUDED_OPTION_H
+#pragma once
 
 #include "scope.h"
 
@@ -297,5 +296,3 @@ strings_list process_arguments(strings_list args, scope_t& scope);
 DECLARE_EXCEPTION(option_error, std::runtime_error);
 
 } // namespace ledger
-
-#endif // INCLUDED_OPTION_H

--- a/src/output.h
+++ b/src/output.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_OUTPUT_H
-#define INCLUDED_OUTPUT_H
+#pragma once
 
 #include "chain.h"
 #include "predicate.h"
@@ -247,5 +246,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_OUTPUT_H

--- a/src/parser.h
+++ b/src/parser.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_PARSER_H
-#define INCLUDED_PARSER_H
+#pragma once
 
 #include "token.h"
 #include "op.h"
@@ -122,5 +121,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_PARSER_H

--- a/src/pool.h
+++ b/src/pool.h
@@ -43,8 +43,7 @@
  *
  * Long.
  */
-#ifndef INCLUDED_POOL_H
-#define INCLUDED_POOL_H
+#pragma once
 
 #include "history.h"
 #include "annotate.h"
@@ -135,5 +134,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_POOL_H

--- a/src/post.h
+++ b/src/post.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_POST_H
-#define INCLUDED_POST_H
+#pragma once
 
 #include "item.h"
 
@@ -268,5 +267,3 @@ void extend_post(post_t& post, journal_t& journal);
 void put_post(property_tree::ptree& pt, const post_t& post);
 
 } // namespace ledger
-
-#endif // INCLUDED_POST_H

--- a/src/precmd.h
+++ b/src/precmd.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_PRECMD_H
-#define INCLUDED_PRECMD_H
+#pragma once
 
 #include "value.h"
 
@@ -55,5 +54,3 @@ value_t period_command(call_scope_t& args);
 value_t query_command(call_scope_t& args);
 
 } // namespace ledger
-
-#endif // INCLUDED_PRECMD_H

--- a/src/predicate.h
+++ b/src/predicate.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_PREDICATE_H
-#define INCLUDED_PREDICATE_H
+#pragma once
 
 #include "expr.h"
 #include "commodity.h"
@@ -93,5 +92,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_PREDICATE_H

--- a/src/print.h
+++ b/src/print.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_PRINT_H
-#define INCLUDED_PRINT_H
+#pragma once
 
 #include "chain.h"
 #include "predicate.h"
@@ -87,5 +86,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_PRINT_H

--- a/src/pstream.h
+++ b/src/pstream.h
@@ -39,8 +39,7 @@
  *
  * @ingroup util
  */
-#ifndef INCLUDED_PSTREAM_H
-#define INCLUDED_PSTREAM_H
+#pragma once
 
 //#include <istream>
 //#include <streambuf>
@@ -110,5 +109,3 @@ public:
     rdbuf(&buf);
   }
 };
-
-#endif // INCLUDED_PSTREAM_H

--- a/src/ptree.h
+++ b/src/ptree.h
@@ -43,8 +43,7 @@
  *
  * Long.
  */
-#ifndef INCLUDED_PTREE_H
-#define INCLUDED_PTREE_H
+#pragma once
 
 #include "chain.h"
 
@@ -99,5 +98,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_PTREE_H

--- a/src/pyinterp.h
+++ b/src/pyinterp.h
@@ -29,8 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef INCLUDED_PYINTERP_H
-#define INCLUDED_PYINTERP_H
+#pragma once
 
 #include "session.h"
 
@@ -145,5 +144,3 @@ extern shared_ptr<python_interpreter_t> python_session;
 } // namespace ledger
 
 #endif // HAVE_BOOST_PYTHON
-
-#endif // INCLUDED_PYINTERP_H

--- a/src/pyutils.h
+++ b/src/pyutils.h
@@ -29,8 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef INCLUDED_PYUTILS_H
-#define INCLUDED_PYUTILS_H
+#pragma once
 
 template <typename T, typename TfromPy>
 struct object_from_python
@@ -183,5 +182,3 @@ namespace boost { namespace python {
 } } // namespace boost::python
 
 //boost::python::register_ptr_to_python< boost::shared_ptr<Base> >();
-
-#endif // INCLUDED_PYUTILS_H

--- a/src/query.h
+++ b/src/query.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_QUERY_H
-#define INCLUDED_QUERY_H
+#pragma once
 
 #include "predicate.h"
 
@@ -348,5 +347,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_QUERY_H

--- a/src/quotes.h
+++ b/src/quotes.h
@@ -39,8 +39,7 @@
  *
  * @ingroup extra
  */
-#ifndef INCLUDED_QUOTES_H
-#define INCLUDED_QUOTES_H
+#pragma once
 
 namespace ledger {
 
@@ -49,5 +48,3 @@ commodity_quote_from_script(commodity_t& commodity,
                             const commodity_t * exchange_commodity);
 
 } // namespace ledger
-
-#endif // INCLUDED_QUOTES_H

--- a/src/report.h
+++ b/src/report.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_REPORT_H
-#define INCLUDED_REPORT_H
+#pragma once
 
 #include "expr.h"
 #include "query.h"
@@ -1110,5 +1109,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_REPORT_H

--- a/src/scope.h
+++ b/src/scope.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_SCOPE_H
-#define INCLUDED_SCOPE_H
+#pragma once
 
 #include "op.h"
 
@@ -616,5 +615,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_SCOPE_H

--- a/src/select.h
+++ b/src/select.h
@@ -39,8 +39,7 @@
  *
  * @ingroup select
  */
-#ifndef INCLUDED_SELECT_H
-#define INCLUDED_SELECT_H
+#pragma once
 
 #include "utils.h"
 #include "value.h"
@@ -51,5 +50,3 @@ class call_scope_t;
 value_t select_command(call_scope_t& args);
 
 } // namespace ledger
-
-#endif // INCLUDED_SELECT_H

--- a/src/session.h
+++ b/src/session.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_SESSION_H
-#define INCLUDED_SESSION_H
+#pragma once
 
 #include "account.h"
 #include "journal.h"
@@ -191,5 +190,3 @@ public:
 void set_session_context(session_t * session);
 
 } // namespace ledger
-
-#endif // INCLUDED_SESSION_H

--- a/src/stats.h
+++ b/src/stats.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_STATS_H
-#define INCLUDED_STATS_H
+#pragma once
 
 #include "value.h"
 
@@ -51,5 +50,3 @@ class call_scope_t;
 value_t report_statistics(call_scope_t& scope);
 
 } // namespace ledger
-
-#endif // INCLUDED_STATS_H

--- a/src/stream.h
+++ b/src/stream.h
@@ -45,8 +45,7 @@
  * child process, different cleanup is needed for each scenario.  This
  * file abstracts those various needs.
  */
-#ifndef INCLUDED_STREAM_H
-#define INCLUDED_STREAM_H
+#pragma once
 
 #include "utils.h"
 
@@ -138,5 +137,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_STREAM_H

--- a/src/strptime.h
+++ b/src/strptime.h
@@ -1,6 +1,3 @@
-#ifndef INCLUDED_STRPTIME_H
-#define INCLUDED_STRPTIME_H
+#pragma once
 
 char* strptime(const char *buf, const char *fmt, struct tm *tm);
-
-#endif // INCLUDED_STRPTIME_H

--- a/src/temps.h
+++ b/src/temps.h
@@ -39,8 +39,7 @@
  *
  * @ingroup report
  */
-#ifndef INCLUDED_TEMPS_H
-#define INCLUDED_TEMPS_H
+#pragma once
 
 namespace ledger {
 
@@ -81,5 +80,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_TEMPS_H

--- a/src/timelog.h
+++ b/src/timelog.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_TIMELOG_H
-#define INCLUDED_TIMELOG_H
+#pragma once
 
 #include "utils.h"
 #include "times.h"
@@ -107,5 +106,3 @@ public:
 };
 
 } // namespace ledger
-
-#endif // INCLUDED_TIMELOG_H

--- a/src/times.h
+++ b/src/times.h
@@ -41,8 +41,7 @@
  *
  * @brief datetime_t and date_t objects
  */
-#ifndef INCLUDED_TIMES_H
-#define INCLUDED_TIMES_H
+#pragma once
 
 #include "utils.h"
 
@@ -532,5 +531,3 @@ void show_period_tokens(std::ostream& out, const string& arg);
 std::ostream& operator<<(std::ostream& out, const date_duration_t& duration);
 
 } // namespace ledger
-
-#endif // INCLUDED_TIMES_H

--- a/src/token.h
+++ b/src/token.h
@@ -39,8 +39,7 @@
  *
  * @ingroup expr
  */
-#ifndef INCLUDED_TOKEN_H
-#define INCLUDED_TOKEN_H
+#pragma once
 
 #include "expr.h"
 
@@ -134,5 +133,3 @@ std::ostream& operator<<(std::ostream& out, const expr_t::token_t::kind_t& kind)
 std::ostream& operator<<(std::ostream& out, const expr_t::token_t& token);
 
 } // namespace ledger
-
-#endif // INCLUDED_TOKEN_H

--- a/src/unistring.h
+++ b/src/unistring.h
@@ -39,8 +39,7 @@
  *
  * @ingroup utils
  */
-#ifndef INCLUDED_UNISTRING_H
-#define INCLUDED_UNISTRING_H
+#pragma once
 
 namespace ledger {
 
@@ -204,5 +203,3 @@ inline void justify(std::ostream&      out,
 }
 
 } // namespace ledger
-
-#endif // INCLUDED_UNISTRING_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -41,8 +41,7 @@
  *
  * @brief General utility facilities used by Ledger
  */
-#ifndef INCLUDED_UTILS_H
-#define INCLUDED_UTILS_H
+#pragma once
 
 #include <boost/uuid/detail/sha1.hpp>
 
@@ -633,5 +632,3 @@ extern const string version;
 } // namespace ledger
 
 /*@}*/
-
-#endif // INCLUDED_UTILS_H

--- a/src/value.h
+++ b/src/value.h
@@ -46,8 +46,7 @@
  * the number 10 to a value object, it's internal type will be
  * INTEGER.
  */
-#ifndef INCLUDED_VALUE_H
-#define INCLUDED_VALUE_H
+#pragma once
 
 #include "balance.h"            // includes amount.h
 #include "mask.h"
@@ -997,5 +996,3 @@ bool sort_value_is_less_than(const std::list<sort_value_t>& left_values,
 void put_value(property_tree::ptree& pt, const value_t& value);
 
 } // namespace ledger
-
-#endif // INCLUDED_VALUE_H

--- a/src/views.h
+++ b/src/views.h
@@ -39,8 +39,7 @@
  *
  * @ingroup views
  */
-#ifndef INCLUDED_VIEWS_H
-#define INCLUDED_VIEWS_H
+#pragma once
 
 #include "utils.h"
 
@@ -453,5 +452,3 @@ void populate_journal(r_journal_ptr journal, report_t& report,
 } // namespace ledger
 
 #endif /* DOCUMENT_MODEL */
-
-#endif // INCLUDED_VIEWS_H

--- a/src/xact.h
+++ b/src/xact.h
@@ -39,8 +39,7 @@
  *
  * @ingroup data
  */
-#ifndef INCLUDED_XACT_H
-#define INCLUDED_XACT_H
+#pragma once
 
 #include "item.h"
 #include "predicate.h"
@@ -235,5 +234,3 @@ typedef std::list<period_xact_t *> period_xacts_list;
 void put_xact(property_tree::ptree& pt, const xact_t& xact);
 
 } // namespace ledger
-
-#endif // INCLUDED_XACT_H


### PR DESCRIPTION
I saw that `gpgme.h` used `#pragma once` instead of `#ifndef …\n#define…`, so I thought it would be a nice clean-up for all headers.