### PR TITLE
Clean up class list

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,11 +30,12 @@
               then [ python3 (boost.override { enablePython = true; python = python3; }) ]
               else [ boost ]);
 
-        nativeBuildInputs = [ cmake texinfo tzdata ];
+        nativeBuildInputs = [ cmake texinfo tzdata doxygen graphviz ninja ];
 
         enableParallelBuilding = true;
 
         cmakeFlags = [
+          "-GNinja"
           "-DCMAKE_INSTALL_LIBDIR=lib"
           "-DBUILD_DOCS:BOOL=ON"
           "-DUSE_PYTHON:BOOL=${if usePython then "ON" else "OFF"}"

--- a/flake.nix
+++ b/flake.nix
@@ -30,12 +30,11 @@
               then [ python3 (boost.override { enablePython = true; python = python3; }) ]
               else [ boost ]);
 
-        nativeBuildInputs = [ cmake texinfo tzdata doxygen graphviz ninja ];
+        nativeBuildInputs = [ cmake texinfo tzdata ];
 
         enableParallelBuilding = true;
 
         cmakeFlags = [
-          "-GNinja"
           "-DCMAKE_INSTALL_LIBDIR=lib"
           "-DBUILD_DOCS:BOOL=ON"
           "-DUSE_PYTHON:BOOL=${if usePython then "ON" else "OFF"}"

--- a/src/account.h
+++ b/src/account.h
@@ -53,7 +53,7 @@ typedef std::list<post_t *> posts_list;
 typedef std::map<string, account_t *> accounts_map;
 typedef std::map<string, posts_list> deferred_posts_map_t;
 
-class account_t : public supports_flags<>, public scope_t
+class account_t : public flags::supports_flags<>, public scope_t
 {
 #define ACCOUNT_NORMAL    0x00  // no flags at all, a basic account
 #define ACCOUNT_KNOWN     0x01

--- a/src/amount.cc
+++ b/src/amount.cc
@@ -52,7 +52,7 @@ static mpfr_t tempfnum;
 static mpfr_t tempfden;
 #endif
 
-struct amount_t::bigint_t : public supports_flags<>
+struct amount_t::bigint_t : public flags::supports_flags<>
 {
 #define BIGINT_BULK_ALLOC 0x01
 #define BIGINT_KEEP_PREC  0x02

--- a/src/amount.h
+++ b/src/amount.h
@@ -76,7 +76,7 @@ enum parse_flags_enum_t {
   PARSE_SOFT_FAIL  = 0x80
 };
 
-typedef ledger::basic_flags_t<parse_flags_enum_t, uint_least8_t> parse_flags_t;
+typedef flags::basic_t<parse_flags_enum_t, uint_least8_t> parse_flags_t;
 
 /**
  * @brief Encapsulate infinite-precision commoditized amounts

--- a/src/amount.h
+++ b/src/amount.h
@@ -76,7 +76,7 @@ enum parse_flags_enum_t {
   PARSE_SOFT_FAIL  = 0x80
 };
 
-typedef basic_flags_t<parse_flags_enum_t, uint_least8_t> parse_flags_t;
+typedef ledger::basic_flags_t<parse_flags_enum_t, uint_least8_t> parse_flags_t;
 
 /**
  * @brief Encapsulate infinite-precision commoditized amounts

--- a/src/annotate.h
+++ b/src/annotate.h
@@ -49,7 +49,7 @@
 
 namespace ledger {
 
-struct annotation_t : public supports_flags<>,
+struct annotation_t : public flags::supports_flags<>,
                       public equality_comparable<annotation_t>
 {
 #define ANNOTATION_PRICE_CALCULATED      0x01

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -70,14 +70,14 @@ struct price_point_t
 };
 
 class commodity_t
-  : public delegates_flags<uint_least16_t>,
+  : public flags::delegates_flags<uint_least16_t>,
     public equality_comparable1<commodity_t, noncopyable>
 {
 protected:
   friend class commodity_pool_t;
   friend class annotated_commodity_t;
 
-  class base_t : public noncopyable, public supports_flags<uint_least16_t>
+  class base_t : public noncopyable, public flags::supports_flags<uint_least16_t>
   {
   public:
 #define COMMODITY_STYLE_DEFAULTS         0x000

--- a/src/flags.h
+++ b/src/flags.h
@@ -41,6 +41,7 @@
  */
 #pragma once
 
+namespace ledger {
 
 template <typename T = boost::uint_least8_t, typename U = T>
 class supports_flags
@@ -182,3 +183,5 @@ public:
     _flags.drop_flags(arg);
   }
 };
+
+} // namespace ledger

--- a/src/flags.h
+++ b/src/flags.h
@@ -41,7 +41,7 @@
  */
 #pragma once
 
-namespace ledger {
+namespace ledger { namespace flags {
 
 template <typename T = boost::uint_least8_t, typename U = T>
 class supports_flags
@@ -93,33 +93,33 @@ public:
 };
 
 template <typename T = boost::uint_least8_t, typename U = T>
-class basic_flags_t : public supports_flags<T, U>
+class basic_t : public supports_flags<T, U>
 {
 public:
-  basic_flags_t() {
-    TRACE_CTOR(basic_flags_t, "");
+  basic_t() {
+    TRACE_CTOR(basic_t, "");
   }
-  basic_flags_t(const T& bits) {
-    TRACE_CTOR(basic_flags_t, "const T&");
+  basic_t(const T& bits) {
+    TRACE_CTOR(basic_t, "const T&");
     supports_flags<T, U>::set_flags(bits);
   }
-  basic_flags_t(const U& bits) {
-    TRACE_CTOR(basic_flags_t, "const U&");
+  basic_t(const U& bits) {
+    TRACE_CTOR(basic_t, "const U&");
     supports_flags<T, U>::set_flags(static_cast<T>(bits));
   }
-  ~basic_flags_t() throw() {
-    TRACE_DTOR(basic_flags_t);
+  ~basic_t() throw() {
+    TRACE_DTOR(basic_t);
   }
 
-  basic_flags_t(const basic_flags_t& other)
+  basic_t(const basic_t& other)
     : supports_flags<T, U>(other) {
-    TRACE_CTOR(basic_flags_t, "copy");
+    TRACE_CTOR(basic_t, "copy");
   }
-  basic_flags_t& operator=(const basic_flags_t& other) {
+  basic_t& operator=(const basic_t& other) {
     set_flags(other.flags());
     return *this;
   }
-  basic_flags_t& operator=(const T& bits) {
+  basic_t& operator=(const T& bits) {
     set_flags(bits);
     return *this;
   }
@@ -131,13 +131,13 @@ public:
     return supports_flags<T, U>::flags();
   }
 
-  basic_flags_t plus_flags(const T& arg) const {
-    basic_flags_t temp(*this);
+  basic_t plus_flags(const T& arg) const {
+    basic_t temp(*this);
     temp.add_flags(arg);
     return temp;
   }
-  basic_flags_t minus_flags(const T& arg) const {
-    basic_flags_t temp(*this);
+  basic_t minus_flags(const T& arg) const {
+    basic_t temp(*this);
     temp.drop_flags(arg);
     return temp;
   }
@@ -184,4 +184,4 @@ public:
   }
 };
 
-} // namespace ledger
+} } // namespace ledger::flags

--- a/src/format.h
+++ b/src/format.h
@@ -56,7 +56,7 @@ class format_t : public expr_base_t<string>, public noncopyable
 {
   typedef expr_base_t<string> base_type;
 
-  struct element_t : public supports_flags<>, public noncopyable
+  struct element_t : public flags::supports_flags<>, public noncopyable
   {
 #define ELEMENT_ALIGN_LEFT 0x01
 

--- a/src/item.h
+++ b/src/item.h
@@ -79,7 +79,7 @@ struct position_t
   }
 };
 
-class item_t : public supports_flags<uint_least16_t>, public scope_t
+class item_t : public flags::supports_flags<uint_least16_t>, public scope_t
 {
 public:
 #define ITEM_NORMAL            0x00 // no flags at all, a basic posting

--- a/src/pstream.h
+++ b/src/pstream.h
@@ -44,6 +44,8 @@
 //#include <istream>
 //#include <streambuf>
 
+namespace ledger {
+
 class ptristream : public std::istream
 {
   class ptrinbuf : public std::streambuf
@@ -109,3 +111,5 @@ public:
     rdbuf(&buf);
   }
 };
+
+} // namespace ledger

--- a/src/py_account.cc
+++ b/src/py_account.cc
@@ -39,6 +39,7 @@
 
 namespace ledger {
 
+using namespace flags;
 using namespace boost::python;
 
 namespace {

--- a/src/py_account.cc
+++ b/src/py_account.cc
@@ -40,6 +40,7 @@
 namespace ledger {
 
 using namespace flags;
+using namespace python;
 using namespace boost::python;
 
 namespace {
@@ -232,11 +233,11 @@ void export_account()
     .def("__len__", accounts_len)
     .def("__getitem__", accounts_getitem, return_internal_reference<>())
 
-    .def("__iter__", python::range<return_internal_reference<> >
+    .def("__iter__", boost::python::range<return_internal_reference<> >
          (&account_t::accounts_begin, &account_t::accounts_end))
-    .def("accounts", python::range<return_internal_reference<> >
+    .def("accounts", boost::python::range<return_internal_reference<> >
          (&account_t::accounts_begin, &account_t::accounts_end))
-    .def("posts", python::range<return_internal_reference<> >
+    .def("posts", boost::python::range<return_internal_reference<> >
          (&account_t::posts_begin, &account_t::posts_end))
 
     .def("has_xdata", &account_t::has_xdata)

--- a/src/py_amount.cc
+++ b/src/py_amount.cc
@@ -39,6 +39,7 @@
 
 namespace ledger {
 
+using namespace python;
 using namespace boost::python;
 
 namespace {

--- a/src/py_balance.cc
+++ b/src/py_balance.cc
@@ -39,6 +39,7 @@
 
 namespace ledger {
 
+using namespace python;
 using namespace boost::python;
 
 namespace {

--- a/src/py_commodity.cc
+++ b/src/py_commodity.cc
@@ -39,6 +39,7 @@
 
 namespace ledger {
 
+using namespace flags;
 using namespace boost::python;
 
 namespace {

--- a/src/py_commodity.cc
+++ b/src/py_commodity.cc
@@ -40,6 +40,7 @@
 namespace ledger {
 
 using namespace flags;
+using namespace python;
 using namespace boost::python;
 
 namespace {
@@ -120,8 +121,8 @@ namespace {
     return (*i).second.get();
   }
 
-  python::list py_pool_keys(commodity_pool_t& pool) {
-    python::list keys;
+  list py_pool_keys(commodity_pool_t& pool) {
+    list keys;
     BOOST_REVERSE_FOREACH
       (const commodity_pool_t::commodities_map::value_type& pair,
        pool.commodities) {
@@ -296,15 +297,15 @@ void export_commodity()
     .def("has_key", py_pool_contains)
     .def("__contains__", py_pool_contains)
     .def("__iter__",
-         python::range<return_internal_reference<> >
+         boost::python::range<return_internal_reference<> >
          (py_pool_commodities_begin, py_pool_commodities_end))
     .def("iteritems",
-         python::range<return_internal_reference<> >
+         boost::python::range<return_internal_reference<> >
          (py_pool_commodities_begin, py_pool_commodities_end))
-    .def("iterkeys", python::range<>(py_pool_commodities_keys_begin,
+    .def("iterkeys", boost::python::range<>(py_pool_commodities_keys_begin,
                                      py_pool_commodities_keys_end))
     .def("itervalues",
-         python::range<return_internal_reference<> >
+         boost::python::range<return_internal_reference<> >
          (py_pool_commodities_values_begin, py_pool_commodities_values_end))
     ;
 

--- a/src/py_item.cc
+++ b/src/py_item.cc
@@ -39,6 +39,7 @@
 
 namespace ledger {
 
+using namespace flags;
 using namespace boost::python;
 
 namespace {

--- a/src/py_item.cc
+++ b/src/py_item.cc
@@ -40,6 +40,7 @@
 namespace ledger {
 
 using namespace flags;
+using namespace python;
 using namespace boost::python;
 
 namespace {

--- a/src/py_journal.cc
+++ b/src/py_journal.cc
@@ -241,7 +241,7 @@ void export_journal()
           boost::noncopyable >("PostCollectorWrapper", no_init)
     .def("__len__", &collector_wrapper::length)
     .def("__getitem__", posts_getitem, return_internal_reference<>())
-    .def("__iter__", python::range<return_internal_reference<> >
+    .def("__iter__", boost::python::range<return_internal_reference<> >
          (&collector_wrapper::begin, &collector_wrapper::end))
     ;
 
@@ -306,15 +306,15 @@ void export_journal()
              with_custodian_and_ward_postcall<1, 0> >())
 #endif
 
-    .def("__iter__", python::range<return_internal_reference<> >
+    .def("__iter__", boost::python::range<return_internal_reference<> >
          (&journal_t::xacts_begin, &journal_t::xacts_end))
-    .def("xacts", python::range<return_internal_reference<> >
+    .def("xacts", boost::python::range<return_internal_reference<> >
          (&journal_t::xacts_begin, &journal_t::xacts_end))
-    .def("auto_xacts", python::range<return_internal_reference<> >
+    .def("auto_xacts", boost::python::range<return_internal_reference<> >
          (&journal_t::auto_xacts_begin, &journal_t::auto_xacts_end))
-    .def("period_xacts", python::range<return_internal_reference<> >
+    .def("period_xacts", boost::python::range<return_internal_reference<> >
          (&journal_t::period_xacts_begin, &journal_t::period_xacts_end))
-    .def("sources", python::range<return_internal_reference<> >
+    .def("sources", boost::python::range<return_internal_reference<> >
          (&journal_t::sources_begin, &journal_t::sources_end))
 #if 0
     .def("read", py_read)

--- a/src/py_post.cc
+++ b/src/py_post.cc
@@ -37,6 +37,7 @@
 
 namespace ledger {
 
+using namespace flags;
 using namespace boost::python;
 
 namespace {

--- a/src/py_session.cc
+++ b/src/py_session.cc
@@ -38,6 +38,7 @@
 
 namespace ledger {
 
+using namespace python;
 using namespace boost::python;
 
 namespace {
@@ -78,12 +79,12 @@ void export_session()
   scope().attr("session") =
     object(ptr(static_cast<session_t *>(python_session.get())));
   scope().attr("close_journal_files") =
-    python::make_function(&py_close_journal_files);
+    boost::python::make_function(&py_close_journal_files);
   scope().attr("read_journal") =
-    python::make_function(&py_read_journal,
+    boost::python::make_function(&py_read_journal,
                           return_internal_reference<>());
   scope().attr("read_journal_from_string") =
-    python::make_function(&py_read_journal_from_string,
+    boost::python::make_function(&py_read_journal_from_string,
                           return_internal_reference<>());
 }
 

--- a/src/py_times.cc
+++ b/src/py_times.cc
@@ -40,6 +40,7 @@
 
 namespace ledger {
 
+using namespace python;
 using namespace boost::python;
 
 struct date_to_python
@@ -80,7 +81,6 @@ struct date_from_python
 
 typedef register_python_conversion<date_t, date_to_python, date_from_python>
   date_python_conversion;
-
 
 struct datetime_to_python
 {
@@ -145,7 +145,6 @@ typedef register_python_conversion<datetime_t,
                                    datetime_to_python, datetime_from_python>
   datetime_python_conversion;
 
-
 /* Convert time_duration to/from python */
 struct duration_to_python
 {
@@ -185,7 +184,7 @@ struct duration_from_python
   }
 
   static void construct(PyObject* obj_ptr,
-                        python::converter::rvalue_from_python_stage1_data * data)
+                        converter::rvalue_from_python_stage1_data * data)
   {
     PyDateTime_Delta const* pydelta
       = reinterpret_cast<PyDateTime_Delta*>(obj_ptr);
@@ -216,7 +215,6 @@ struct duration_from_python
 typedef register_python_conversion<time_duration_t,
                                    duration_to_python, duration_from_python>
   duration_python_conversion;
-
 
 datetime_t py_parse_datetime(const string& str) {
   return parse_datetime(str);

--- a/src/py_utils.cc
+++ b/src/py_utils.cc
@@ -36,6 +36,7 @@
 
 namespace ledger {
 
+using namespace flags;
 using namespace boost::python;
 
 struct bool_to_python

--- a/src/py_utils.cc
+++ b/src/py_utils.cc
@@ -37,6 +37,7 @@
 namespace ledger {
 
 using namespace flags;
+using namespace python;
 using namespace boost::python;
 
 struct bool_to_python
@@ -73,7 +74,6 @@ struct bool_from_python
 
 typedef register_python_conversion<bool, bool_to_python, bool_from_python>
   bool_python_conversion;
-
 
 struct string_to_python
 {

--- a/src/py_value.cc
+++ b/src/py_value.cc
@@ -38,6 +38,7 @@
 
 namespace ledger {
 
+using namespace python;
 using namespace boost::python;
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(value_overloads, value, 0, 2)

--- a/src/py_xact.cc
+++ b/src/py_xact.cc
@@ -38,6 +38,7 @@
 
 namespace ledger {
 
+using namespace python;
 using namespace boost::python;
 
 namespace {
@@ -104,9 +105,9 @@ void export_xact()
 
     .def("finalize", &xact_base_t::finalize)
 
-    .def("__iter__", python::range<return_internal_reference<> >
+    .def("__iter__", boost::python::range<return_internal_reference<> >
          (&xact_t::posts_begin, &xact_t::posts_end))
-    .def("posts", python::range<return_internal_reference<> >
+    .def("posts", boost::python::range<return_internal_reference<> >
          (&xact_t::posts_begin, &xact_t::posts_end))
 
     .def("valid", &xact_base_t::valid)

--- a/src/pyinterp.h
+++ b/src/pyinterp.h
@@ -52,19 +52,19 @@ namespace ledger {
 class python_module_t : public scope_t, public noncopyable
 {
 public:
-  string         module_name;
-  python::object module_object;
-  python::dict   module_globals;
+  string                module_name;
+  boost::python::object module_object;
+  boost::python::dict   module_globals;
 
   explicit python_module_t(const string& name);
-  explicit python_module_t(const string& name, python::object obj);
+  explicit python_module_t(const string& name, boost::python::object obj);
 
   void import_module(const string& name, bool import_direct = false);
 
   virtual expr_t::ptr_op_t lookup(const symbol_t::kind_t kind,
                                   const string& name);
 
-  void define_global(const string& name, python::object obj) {
+  void define_global(const string& name, boost::python::object obj) {
     module_globals[name] = obj;
   }
 
@@ -102,7 +102,7 @@ public:
   void initialize();
   void hack_system_paths();
 
-  python::object import_option(const string& name);
+  boost::python::object import_option(const string& name);
 
   enum py_eval_mode_t {
     PY_EVAL_EXPR,
@@ -110,9 +110,9 @@ public:
     PY_EVAL_MULTI
   };
 
-  python::object eval(std::istream& in, py_eval_mode_t mode = PY_EVAL_EXPR);
-  python::object eval(const string& str, py_eval_mode_t mode = PY_EVAL_EXPR);
-  python::object eval(const char * c_str, py_eval_mode_t mode = PY_EVAL_EXPR) {
+  boost::python::object eval(std::istream& in, py_eval_mode_t mode = PY_EVAL_EXPR);
+  boost::python::object eval(const string& str, py_eval_mode_t mode = PY_EVAL_EXPR);
+  boost::python::object eval(const char * c_str, py_eval_mode_t mode = PY_EVAL_EXPR) {
     return eval(string(c_str), mode);
   }
 
@@ -122,14 +122,14 @@ public:
     functor_t();
 
   protected:
-    python::object func;
+    boost::python::object func;
 
   public:
     string name;
 
-    functor_t(python::object _func, const string& _name)
+    functor_t(boost::python::object _func, const string& _name)
       : func(_func), name(_name) {
-      TRACE_CTOR(functor_t, "python::object, const string&");
+      TRACE_CTOR(functor_t, "boost::python::object, const string&");
     }
     functor_t(const functor_t& other)
       : func(other.func), name(other.name) {

--- a/src/pyutils.h
+++ b/src/pyutils.h
@@ -39,6 +39,8 @@
  */
 #pragma once
 
+namespace ledger { namespace python {
+
 template <typename T, typename TfromPy>
 struct object_from_python
 {
@@ -142,6 +144,8 @@ PyObject * str_to_py_unicode(const T& str)
   return object(handle<>(borrowed(uni))).ptr();
 }
 
+} } // namespace ledger::python
+
 namespace boost { namespace python {
 
 // Use expr to create the PyObject corresponding to x
@@ -178,7 +182,7 @@ namespace boost { namespace python {
         : handle<>                                      \
       {                                                 \
           arg_to_python(T const& x)                     \
-            : python::handle<>(expr) {}                 \
+            : boost::python::handle<>(expr) {}                 \
       };                                                \
     }
 

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1257,7 +1257,7 @@ void instance_t::python_directive(char * line)
     python_session->initialize();
 
   python_session->main_module->define_global
-    ("journal", python::object(python::ptr(context.journal)));
+    ("journal", boost::python::object(boost::python::ptr(context.journal)));
   python_session->eval(script.str(), python_interpreter_t::PY_EVAL_MULTI);
 }
 


### PR DESCRIPTION
Looking at the [Ledger class list in the API documentation](https://ledger-cli.org/doc/api/annotated.html) I noticed a few unexpected top-level types related to handling command-line flags and the Python API:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/16507/231558513-23b0a433-f374-42d8-b0e5-8c6bcddbd8e2.png">

This PR refactors these top-level types into the `ledger`, `ledger::flags`, and `ledger::python` namespaces.

These changes, especially refactoring `basic_flags_t` into `ledger::flags::base_t` may break ledger's API contract. If we believe that it does it might be worthwhile to learn how folks use ledger's API.

I thought it might be helpful to organize ledger's code further into sub-namespaces, i.e. `ledger::flags` and `ledger::python`, but I'm open to having these reside just in `ledger` too.