### PR TITLE
Clean-up doxygen modules

### DIFF
--- a/src/generate.h
+++ b/src/generate.h
@@ -30,7 +30,7 @@
  */
 
 /**
- * @addtogroup generate
+ * @addtogroup report
  */
 
 /**

--- a/src/gpgme.h
+++ b/src/gpgme.h
@@ -30,7 +30,7 @@
  */
 
 /**
- * @addtogroup extra
+ * @defgroup extra Extra functionality
  */
 
 /**

--- a/src/pyutils.h
+++ b/src/pyutils.h
@@ -29,6 +29,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * @addtogroup python
+ */
+
 /**
  * @file   pyutils.h
  * @author John Wiegley

--- a/src/select.h
+++ b/src/select.h
@@ -30,14 +30,14 @@
  */
 
 /**
- * @addtogroup select
+ * @addtogroup util
  */
 
 /**
  * @file   select.h
  * @author John Wiegley
  *
- * @ingroup select
+ * @ingroup util
  */
 #pragma once
 

--- a/src/stats.h
+++ b/src/stats.h
@@ -30,7 +30,7 @@
  */
 
 /**
- * @addtogroup stats
+ * @addtogroup report
  */
 
 /**

--- a/src/unistring.h
+++ b/src/unistring.h
@@ -30,7 +30,7 @@
  */
 
 /**
- * @addtogroup utils
+ * @addtogroup util
  */
 
 /**

--- a/src/views.h
+++ b/src/views.h
@@ -30,7 +30,7 @@
  */
 
 /**
- * @addtogroup views
+ * @defgroup views Views
  */
 
 /**


### PR DESCRIPTION
Looking at the [Modules in Ledger's API documentation](http://ledger-cli.org/doc/api/modules.html) there appear to be some inconsistencies, e.g. there is a "General utilities" and a "Utils" module, `generate.h` declares `@addotgroup generate` although it later specifies `@ingroup resport`, etc.

This PR tries to clean this up.

@jwiegley do you agree with the proposed changes and could you possibly provide a brief description for the following modules:

- [ ] **Mathematical objects:** _TBA_
- [ ] **Extra Functionality:** _TBA_
- [ ] **Data representation:** _TBA_
- [ ] **Python API:** _TBA_
- [ ] **Reporting:** _TBA_
- [ ] **Value expressions:** _TBA_
- [ ] **General utilities:** _TBA_
- [ ] **Views:** _TBA_
