### PR TITLE
gpgme: Remove code handling versions prior to required version

### DIFF
--- a/src/gpgme.cc
+++ b/src/gpgme.cc
@@ -136,15 +136,9 @@ shared_ptr<Data> decrypted_stream_t::decrypt(shared_ptr<Data> enc_d) {
     ctx = nullptr;
     dec_d = enc_d;
   } else {
-#if GPGME_VERSION_NUMBER < 0x010d00
-    ctx = unique_ptr<Context>(Context::createForProtocol(enc_d->type() == Data::PGPEncrypted
-                                                          ? Protocol::OpenPGP
-                                                          : Protocol::CMS));
-#else
     ctx = Context::create(enc_d->type() == Data::PGPEncrypted
                           ? Protocol::OpenPGP
                           : Protocol::CMS);
-#endif
     if (!ctx)
       throw runtime_error("Unable to establish decryption context");
 
@@ -167,11 +161,7 @@ static inline void init_lib() {
 }
 
 static inline void rewind(Data * d) {
-#if GPGME_VERSION_NUMBER < 0x010c00
-  d->seek(0, SEEK_SET);
-#else
   d->rewind();
-#endif
 }
 
 istream* decrypted_stream_t::open_stream(const path& filename) {

--- a/src/gpgme.cc
+++ b/src/gpgme.cc
@@ -160,10 +160,6 @@ static inline void init_lib() {
     throw_(runtime_error, _f("%1%: %2%") % err.source() % err.asString());
 }
 
-static inline void rewind(Data * d) {
-  d->rewind();
-}
-
 istream* decrypted_stream_t::open_stream(const path& filename) {
   init_lib();
 
@@ -171,7 +167,7 @@ istream* decrypted_stream_t::open_stream(const path& filename) {
   auto enc_d = setup_cipher_buffer(file.get());
   if (is_encrypted(enc_d)) {
     auto dec_d = decrypt(enc_d);
-    rewind(dec_d.get());
+    dec_d.get()->rewind();
     return new decrypted_stream_t(dec_d);
   }
   return new ifstream(filename);
@@ -184,7 +180,7 @@ decrypted_stream_t::decrypted_stream_t(path& filename)
   file = open_file(filename);
   auto enc_d = setup_cipher_buffer(file);
   dec_d = decrypt(enc_d);
-  rewind(dec_d.get());
+  dec_d.get()->rewind();
 
   if (is_encrypted(enc_d)) {
     fclose(file);


### PR DESCRIPTION
Since ledger now required Gpgme >= 1.13.1 (see #2222 for details) code handling prior versions can be removed.

/cc @spacefrogg