### PR TITLE
Fix bucket transactions with reg --related

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 - Include contrib files in distribution
 
+- Fix related reports when using bucket transactions (ledger/ledger#2220)
+
 ## 3.3.2 (2023-03-30)
 
 - Fix divide by zero (ledger/ledger#777, ledger/ledger#2207)

--- a/src/item.h
+++ b/src/item.h
@@ -86,6 +86,7 @@ public:
 #define ITEM_GENERATED         0x01 // posting was not found in a journal
 #define ITEM_TEMP              0x02 // posting is a managed temporary
 #define ITEM_NOTE_ON_NEXT_LINE 0x04 // did we see a note on the next line?
+#define ITEM_INFERRED          0x08 // bucketed item
 
   enum state_t { UNCLEARED = 0, CLEARED, PENDING };
 

--- a/src/xact.cc
+++ b/src/xact.cc
@@ -210,7 +210,7 @@ bool xact_base_t::finalize()
   // been set.
 
   if (journal && journal->bucket && posts.size() == 1 && ! balance.is_null()) {
-    null_post = new post_t(journal->bucket, ITEM_GENERATED);
+    null_post = new post_t(journal->bucket, ITEM_INFERRED);
     null_post->_state = (*posts.begin())->_state;
     add_post(null_post);
   }

--- a/test/regress/issue2220.test
+++ b/test/regress/issue2220.test
@@ -1,0 +1,8 @@
+bucket Liabilities:CreditCard
+
+2023/01/01 * Payment
+    Assets:Checking     $-34.86
+
+test reg --monthly --related ^Assets:Checking
+23-Jan-01 - 23-Jan-31           Liabilities:CreditCard       $34.86       $34.86
+end test


### PR DESCRIPTION
This adds a new item flag, `ITEM_INFERRED`, that differentiates generated items from bucket items.

This makes them show up as related items in reports. This is ledger bug #2220.

 I've also added a regression test.