### PR TITLE
Improve web docs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -160,6 +160,11 @@ if (BUILD_WEB_DOCS)
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1
       VERBATIM)
     list(APPEND ledger_doc_files ledger.1.html)
+    add_custom_command(OUTPUT ledger.1.pdf
+      COMMAND ${BASH} -c "${_cmd} -mandoc -Tpdf ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1 > ledger.1.pdf"
+      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1
+      VERBATIM)
+    list(APPEND ledger_doc_files ledger.1.pdf)
   else()
     message(FATAL_ERROR "Could not find man2html or groff. HTML version of man page cannot be built.")
   endif()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -108,7 +108,7 @@ foreach(file ${ledger_info_files})
 
   if (MAKEINFO)
     add_custom_command(OUTPUT ${file_base}.info
-      COMMAND makeinfo --force --no-split -o ${file_base}.info ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+      COMMAND ${MAKEINFO} --force --no-split -o ${file_base}.info ${CMAKE_CURRENT_SOURCE_DIR}/${file}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file}
       VERBATIM)
     list(APPEND ledger_doc_files ${file_base}.info)
@@ -116,7 +116,7 @@ foreach(file ${ledger_info_files})
 
   if (BUILD_WEB_DOCS AND MAKEINFO)
     add_custom_command(OUTPUT ${file_base}.html
-      COMMAND makeinfo --force --html --no-split -o ${file_base}.html ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+      COMMAND ${MAKEINFO} --force --html --no-split -o ${file_base}.html ${CMAKE_CURRENT_SOURCE_DIR}/${file}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file}
       VERBATIM)
     list(APPEND ledger_doc_files ${file_base}.html)
@@ -127,7 +127,7 @@ foreach(file ${ledger_info_files})
       set(papersize --texinfo=@afourpaper)
     endif()
     add_custom_command(OUTPUT ${file_base}.pdf
-      COMMAND texi2pdf ${papersize} -b -q -o ${file_base}.pdf ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+      COMMAND ${TEXI2PDF} ${papersize} -b -q -o ${file_base}.pdf ${CMAKE_CURRENT_SOURCE_DIR}/${file}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file}
       VERBATIM)
     list(APPEND ledger_doc_files ${file_base}.pdf)
@@ -143,13 +143,13 @@ if (BUILD_WEB_DOCS)
   endif()
   if (MAN2HTML)
     add_custom_command(OUTPUT ledger.1.html
-      COMMAND ${BASH} -c "man2html ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1 | tail -n+3 > ledger.1.html"
+      COMMAND ${BASH} -c "${MAN2HTML} ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1 | tail -n+3 > ledger.1.html"
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1
       VERBATIM)
     list(APPEND ledger_doc_files ledger.1.html)
   elseif(GROFF)
     add_custom_command(OUTPUT ledger.1.html
-      COMMAND ${BASH} -c "groff -mandoc -Thtml ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1 > ledger.1.html"
+      COMMAND ${BASH} -c "${GROFF} -mandoc -Thtml ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1 > ledger.1.html"
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1
       VERBATIM)
     list(APPEND ledger_doc_files ledger.1.html)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -89,6 +89,7 @@ if (BUILD_DOCS)
   find_program(TEXI2PDF texi2pdf)
   find_program(TEX tex)
   find_program(MAN2HTML man2html)
+  find_program(MANDOC mandoc)
   find_program(GROFF groff)
   set(ledger_info_files ledger3.texi)
 
@@ -147,9 +148,15 @@ if (BUILD_WEB_DOCS)
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1
       VERBATIM)
     list(APPEND ledger_doc_files ledger.1.html)
-  elseif(GROFF)
+  elseif (MANDOC OR GROFF)
+    set(_cmd ${MANDOC})
+    if (NOT _cmd)
+      # HTML produced by mandoc is much nicer looking, use groff only as a last resort.
+      message(WARNING "Using ${GROFF} to generate ledger1.html, as mandoc could not be found.")
+      set(_cmd ${GROFF})
+    endif()
     add_custom_command(OUTPUT ledger.1.html
-      COMMAND ${BASH} -c "${GROFF} -mandoc -Thtml ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1 > ledger.1.html"
+      COMMAND ${BASH} -c "${_cmd} -mandoc -Thtml ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1 > ledger.1.html"
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ledger.1
       VERBATIM)
     list(APPEND ledger_doc_files ledger.1.html)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -113,14 +113,18 @@ foreach(file ${ledger_info_files})
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file}
       VERBATIM)
     list(APPEND ledger_doc_files ${file_base}.info)
-  endif()
-
-  if (BUILD_WEB_DOCS AND MAKEINFO)
-    add_custom_command(OUTPUT ${file_base}.html
-      COMMAND ${MAKEINFO} --force --html --no-split -o ${file_base}.html ${CMAKE_CURRENT_SOURCE_DIR}/${file}
-      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file}
-      VERBATIM)
-    list(APPEND ledger_doc_files ${file_base}.html)
+    if (BUILD_WEB_DOCS)
+      add_custom_command(OUTPUT ${file_base}.html
+        COMMAND ${MAKEINFO} --force --html --no-split -o ${file_base}.html ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+        VERBATIM)
+      list(APPEND ledger_doc_files ${file_base}.html)
+      add_custom_command(OUTPUT ${file_base}.txt
+        COMMAND ${MAKEINFO} --force --plaintext --no-split -o ${file_base}.txt ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file}
+        VERBATIM)
+      list(APPEND ledger_doc_files ${file_base}.txt)
+    endif()
   endif()
 
   if (TEXI2PDF AND TEX)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -170,7 +170,17 @@ if (BUILD_WEB_DOCS)
       VERBATIM)
     list(APPEND ledger_doc_files ledger.1.pdf)
   else()
-    message(FATAL_ERROR "Could not find man2html or groff. HTML version of man page cannot be built.")
+    message(WARNING "Could not find man2html or groff. HTML version of man page will not be built.")
+  endif()
+
+  if (USE_PYTHON AND Python_EXECUTABLE)
+    add_custom_command(OUTPUT ledger.html
+      COMMAND ${CMAKE_COMMAND} -E env
+        PYTHONPATH=${CMAKE_BINARY_DIR}
+        ${Python_EXECUTABLE} -m pydoc -w ledger
+      DEPENDS ${CMAKE_BINARY_DIR}/${_ledger_python_module_name}
+      VERBATIM)
+    list(APPEND ledger_doc_files ledger.html)
   endif()
 endif(BUILD_WEB_DOCS)
 

--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -1449,7 +1449,7 @@ initializations.
 .Sh SEE ALSO
 .Xr beancount 1 ,
 .Xr hledger 1
-
+.Pp
 The full documentation for
 .Nm
 is maintained as a Texinfo manual.  If the

--- a/doc/mainpage.txt
+++ b/doc/mainpage.txt
@@ -1,9 +1,9 @@
 /**
-\mainpage API Documentation
+\mainpage C++ API Documentation
 
 \section intro_sec Introduction
 
-Documentation of the Ledger API is an ongoing process and you are invited
+Documentation of the Ledger C++ API is an ongoing process and you are invited
 to help out and contribute. In case you find this documentation incorrect,
 incomplete, unclear, or lacking please
 [open a pull request](https://git.ledger-cli.org/ledger/pulls).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,7 @@ set(LEDGER_INCLUDES
   value.h
   views.h
   xact.h
+  ${PROJECT_BINARY_DIR}/ledger.hh
   ${PROJECT_BINARY_DIR}/system.hh)
 
 # Windows provides no strptime(), so supply our own.

--- a/src/global.h
+++ b/src/global.h
@@ -125,7 +125,7 @@ public:
                 << Ledger_VERSION_PATCH;
     if (Ledger_VERSION_PRERELEASE != 0)
       out << Ledger_VERSION_PRERELEASE;
-    if (Ledger_VERSION_DATE != 0)
+    if (std::strlen(Ledger_VERSION_DATE) > 0)
       out << '-' << Ledger_VERSION_DATE;
     out << _(", the command-line accounting tool");
     out << _("\nwith");

--- a/src/ledger.hh.in
+++ b/src/ledger.hh.in
@@ -43,7 +43,8 @@
 #define Ledger_VERSION_MINOR     @Ledger_VERSION_MINOR@
 #define Ledger_VERSION_PATCH     @Ledger_VERSION_PATCH@
 #define Ledger_VERSION_PRERELEASE "@Ledger_VERSION_PRERELEASE@"
-#define Ledger_VERSION_DATE      @Ledger_VERSION_DATE@
+#define Ledger_VERSION_DATE      "@Ledger_VERSION_DATE@"
+#define Ledger_VERSION           "@Ledger_VERSION_MAJOR@.@Ledger_VERSION_MINOR@.@Ledger_VERSION_PATCH@"
 
 /**
  * @name Default values

--- a/src/pyledger.cc
+++ b/src/pyledger.cc
@@ -29,7 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <system.hh>
+#include <ledger.hh>
 
 #include "pyinterp.h"
 
@@ -42,6 +42,23 @@ namespace ledger {
 BOOST_PYTHON_MODULE(ledger)
 {
   using namespace ledger;
+
+  scope().attr("__author__") = "John Wiegley <jwiegley@gmail.com>";
+  scope().attr("__version__") = Ledger_VERSION;
+  scope().attr("__date__") = Ledger_VERSION_DATE;
+  scope().attr("__doc__") =
+    "Python API Documentation\n\n"
+    "Documentation of the Ledger Python API is an ongoing process and you are invited\n"
+    "to help out and contribute. In case you find this documentation incorrect,\n"
+    "incomplete, unclear, or lacking please open a pull request at\n"
+    "https://git.ledger-cli.org/ledger/pulls."
+    ;
+
+#if !DEBUG_MODE
+  docstring_options doc_options;
+  doc_options.disable_cpp_signatures();
+#endif
+
 
   if (! python_session.get())
     python_session.reset(new python_interpreter_t);


### PR DESCRIPTION
### Improve HTML rendition of Ledger's man page

Unfortunately groff's HTML output of the Ledger man page isn't too readable due to breaks on lines that belong on the same line and with much space between tabbed content. Use of [mandoc(1)](http://mandoc.bsd.lv) remedies that

| Before with `groff` | After with `mandoc`
| --- | ---
| ![Before](https://user-images.githubusercontent.com/16507/233979823-d0de4d88-61c4-40d1-a7ad-e3ef2107f6b3.png) | ![After](https://user-images.githubusercontent.com/16507/233979847-6dd02fad-5daf-473d-94df-8325db6c5a56.png)

### Generate documentation for Ledger Python module using pydoc

A live preview is available at http://projects.surryhill.net/ledger/ledger.html

Future the documentation of the Ledger Python module and package is probably better generated using [sphinx](http://sphinx-doc.org) and the [autodocs](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) extension. For now the result of pydoc is better than offering no documentation at all.

| Exhibit A | Exhibit B
| --- | ---
| ![image](https://user-images.githubusercontent.com/16507/234238981-30c376b1-c08c-41b0-b76a-bc0d244bba9b.png) | ![image](https://user-images.githubusercontent.com/16507/234239060-a89e33c7-8238-4807-bdca-36d6fc286d1d.png)

### ℹ️ For details on the other changes please see the individual commits 