### PR TITLE
acprep update for Python 3

### DIFF
--- a/acprep
+++ b/acprep
@@ -195,8 +195,7 @@ class CommandLineApp(object):
             # the argument count ourself.
 
             # argspec = inspect.getargspec(self.main)
-            # Since Python 3.3:
-            # argspec = inspect.signature(self.main)
+            # Since Python 3.2:
             argspec = inspect.getfullargspec(self.main)
 
             expected_arg_count = len(argspec[0]) - 1

--- a/acprep
+++ b/acprep
@@ -193,7 +193,12 @@ class CommandLineApp(object):
             # not let us differentiate between application errors and a case
             # where the user has not passed us enough arguments.  So, we check
             # the argument count ourself.
+
+            # argspec = inspect.getargspec(self.main)
+            # Since Python 3.3:
+            # argspec = inspect.signature(self.main)
             argspec = inspect.getfullargspec(self.main)
+
             expected_arg_count = len(argspec[0]) - 1
 
             if len(main_args) >= expected_arg_count:


### PR DESCRIPTION
`acprep` fails with Python 3.

>inspect.getargspec() is deprecated in Python 3 (in favor of inspect.getfullargspec until 3.2 and in favor of inspect.signature since 3.3).

More info in https://github.com/pytorch/pytorch/issues/15344