### PR TITLE
Use OpenBSD readline instead of editline

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -40,7 +40,12 @@
 #endif
 
 #if HAVE_EDIT
-#include <editline/readline.h>
+  #ifdef __OpenBSD__
+    #include <readline/readline.h>
+    #include <readline/history.h>
+  #else
+    #include <editline/readline.h>
+  #endif
 #endif
 
 using namespace ledger;


### PR DESCRIPTION
OpenBSD ships with GNU readline in its base system. There is no port for NetBSD editline. Nevertheless ledger's configure system recognises the GNU readline library and sets `HAVE_EDIT`.
The OpenBSD ledger port deals with this by explicitely disabeling libedit support:
``` make
# libedit support requires readline headers that aren't installed on OpenBSD
CONFIGURE_ARGS +=	-DHAVE_EDIT:=Off
```
I did not test it, but ledger links fine against OpenBSD's libedit when `main.cc` knows the right headers, as done in this PR. This is a hack, because I don't test for the feature, but for the OS.