### PR TITLE
cmake: Replace add_defitions with superseding alternatives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,10 @@ set(Ledger_TEST_TIMEZONE "America/Chicago")
 
 enable_testing()
 
-add_definitions(
-  -std=c++11
-  -DBOOST_FILESYSTEM_NO_DEPRECATED
-)
+add_compile_definitions(BOOST_FILESYSTEM_NO_DEPRECATED)
+add_compile_options(-std=c++11)
 if (CYGWIN)
-  add_definitions(-U__STRICT_ANSI__)
+  add_compile_options(-U__STRICT_ANSI__)
 endif()
 
 ########################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,7 +149,7 @@ endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_definitions(
+    add_compile_options(
       # -Weverything
       # -Wno-disabled-macro-expansion
       # -Wno-padded
@@ -223,7 +223,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
       -Wno-deprecated
       -Wno-strict-aliasing)
 
-    add_definitions(${GXX_WARNING_FLAGS})
+    add_compile_options(${GXX_WARNING_FLAGS})
 
     macro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
       set(_gch_filename "${_header_filename}.gch")
@@ -288,7 +288,7 @@ if (BUILD_LIBRARY)
     VERSION ${Ledger_VERSION_MAJOR}
     SOVERSION ${Ledger_VERSION_MAJOR})
 
-  add_executable(ledger main.cc global.cc)
+  add_executable(ledger ${LEDGER_CLI_SOURCES})
   target_link_libraries(ledger libledger)
   if (HAVE_GPGME)
     target_link_libraries(ledger Gpgmepp)


### PR DESCRIPTION
According to the CMake documentation [`add_definitions()`](https://cmake.org/cmake/help/v3.16/command/add_definitions.html?highlight=add_definitions) has been superseded by the alternatives: [`add_compile_definitions()`](https://cmake.org/cmake/help/v3.16/command/add_compile_definitions.html#command:add_compile_definitions), [`include_directories()`](https://cmake.org/cmake/help/v3.16/command/include_directories.html#command:include_directories), and [`add_compile_options()`](https://cmake.org/cmake/help/v3.16/command/add_compile_options.html#command:add_compile_options).