### PR TITLE
Fix null posting causing error on balanced multi-commodity transaction

### DIFF
--- a/src/balance.cc
+++ b/src/balance.cc
@@ -273,7 +273,7 @@ balance_t::strip_annotations(const keep_details_t& what_to_keep) const
 void balance_t::sorted_amounts(amounts_array& sorted) const
 {
   foreach (const amounts_map::value_type& pair, amounts)
-    if (pair.second)
+    if (! pair.second.is_null())
       sorted.push_back(&pair.second);
   std::stable_sort(
     sorted.begin(), sorted.end(),
@@ -287,7 +287,7 @@ void balance_t::map_sorted_amounts(function<void(const amount_t&)> fn) const
   if (! amounts.empty()) {
     if (amounts.size() == 1) {
       const amount_t& amount((*amounts.begin()).second);
-      if (amount)
+      if (! amount.is_null())
         fn(amount);
     }
     else {
@@ -327,6 +327,8 @@ namespace {
     }
 
     void operator()(const amount_t& amount) {
+      if(amount.is_zero()) return;
+
       int width;
       if (! first) {
         out << std::endl;

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1082,6 +1082,7 @@ namespace {
     }
 
     void operator()(const amount_t& amount) {
+      if(amount.is_zero()) return;
       post_t& balance_post = temps.create_post(xact, &balance_account);
       balance_post.amount = - amount;
       (*handler)(balance_post);

--- a/test/regress/2270.test
+++ b/test/regress/2270.test
@@ -1,0 +1,13 @@
+2023-07-10 * tx
+  A   1 USD
+  B  -1 USD
+  C   1 BTC
+  D  -1 BTC
+  E
+
+test register --columns 80
+23-Jul-10 tx                    A                             1 USD        1 USD
+                                B                            -1 USD            0
+                                C                             1 BTC        1 BTC
+                                D                            -1 BTC            0
+end test


### PR DESCRIPTION
This fixes #2270 . The cause of the issue was balancing postings were not properly generated when the transaction balance was already zero.