### PR TITLE
copy cost from automatic transaction postings

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -782,6 +782,8 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context)
         // the automated xact's one.
         post_t * new_post = new post_t(account, amt);
         new_post->copy_details(*post);
+        if(post->cost)
+          new_post->cost = post->cost;
 
         // A Cleared transaction implies all of its automatic posting are cleared
         // CPR 2012/10/23

--- a/src/xact.cc
+++ b/src/xact.cc
@@ -782,7 +782,7 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context)
         // the automated xact's one.
         post_t * new_post = new post_t(account, amt);
         new_post->copy_details(*post);
-        if(! post->cost.is_null())
+        if(post->cost)
           new_post->cost = post->cost;
 
         // A Cleared transaction implies all of its automatic posting are cleared

--- a/src/xact.cc
+++ b/src/xact.cc
@@ -782,7 +782,7 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context)
         // the automated xact's one.
         post_t * new_post = new post_t(account, amt);
         new_post->copy_details(*post);
-        if(post->cost)
+        if(! post->cost.is_null())
           new_post->cost = post->cost;
 
         // A Cleared transaction implies all of its automatic posting are cleared

--- a/test/regress/2268.test
+++ b/test/regress/2268.test
@@ -1,0 +1,13 @@
+= expr 'has_tag("FOO")'
+  A  1 BTC @ $30000
+  A  $-30000
+
+2010/05/31 tx
+  A  1 BTC @ $30000
+  A  $-30000
+  ; :FOO:
+
+test balance
+             $-60000
+               2 BTC  A
+end test


### PR DESCRIPTION
This fixes #2268 by preserving the cost from automatic transactions and reflecting it in target transactions.