### PR TITLE
update CONTRIBUTING.md for multiple output directories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ or `g++` as follows:
 
     mkdir build
     ./acprep --compiler=clang++
-    cd build
+    cd build/ledger/debug
     make
 
 This will set up a debug build using clang++ (and pre-compiled headers, which
@@ -111,7 +111,7 @@ cores:
 
     mkdir build
     ./acprep --compiler=clang++ --ninja
-    cd build
+    cd build/ledger/debug
     ninja
 
 [Boost]: http://boost.org


### PR DESCRIPTION
The `CONTRIBUTING.md` instructions currently imply you should run `acprep` then `cd` into `build` and run `make`/`ninja`, but `acprep` doesn't generate the make file in `build` but in a subdirectory depending on the configuration selected,`build/ledger/debug` by default or `build/ledger/opt` if you pass `opt`.

```
$ git clone https://github.com/ledger/ledger.git
Cloning into 'ledger'...
remote: Enumerating objects: 39563, done.
remote: Counting objects: 100% (636/636), done.
remote: Compressing objects: 100% (279/279), done.
remote: Total 39563 (delta 390), reused 546 (delta 357), pack-reused 38927
Receiving objects: 100% (39563/39563), 18.94 MiB | 19.41 MiB/s, done.
Resolving deltas: 100% (29716/29716), done.
$ cd ledger/
$ mkdir build
$ python3 ./acprep --compiler=clang++
[...]
-- Build files have been written to: [...]/ledger/build/ledger/debug
$ cd build
$ make
make: *** No targets specified and no makefile found.  Stop.
```

I was thinking maybe the instructions should be updated to take this into account so people aren't confused the first time they try to build the project. 😃 