### PR TITLE
Add support for Ubuntu 22.04 Jammy in ./acprep

### DIFF
--- a/acprep
+++ b/acprep
@@ -63,7 +63,7 @@ class BoostInfo(object):
         if system in ['centos']:
             return [ 'boost-devel' ]
 
-        elif system in ['ubuntu-focal', 'ubuntu-bionic', 'ubuntu-xenial',
+        elif system in ['ubuntu-jammy', 'ubuntu-focal', 'ubuntu-bionic', 'ubuntu-xenial',
                         'ubuntu-eoan', 'ubuntu-trusty', 'ubuntu-cosmic']:
             return [ 'libboost-dev',
                      'libboost-date-time-dev',
@@ -549,7 +549,24 @@ class PrepareBuild(CommandLineApp):
                         'sudo', 'apt-get', 'install',
                         'build-essential',
                     ]
-                    if release == 'focal':
+                    if release == 'jammy':
+                        packages.extend([
+                            'doxygen',
+                            'cmake',
+                            'ninja-build',
+                            'zlib1g-dev',
+                            'libbz2-dev',
+                            'python-dev',
+                            'libgmp3-dev',
+                            'libmpfr-dev',
+                            'gettext',
+                            'libedit-dev',
+                            'texinfo',
+                            'lcov',
+                            'libutfcpp-dev',
+                            'sloccount'
+                        ])
+                    elif release == 'focal':
                         packages.extend([
                             'doxygen',
                             'cmake',


### PR DESCRIPTION
Running `./acprep dependencies` in Ubuntu 22.04 Jammy while building ledger from source returns:

    acprep: INFO: Invoking primary phase: dependencies
    acprep: INFO: Executing phase: dependencies
    acprep: INFO: Installing Ledger's build dependencies ...
    acprep: INFO: Looks like you are using APT on Ubuntu jammy
    acprep: INFO: I do not recognize your version of Ubuntu!

This error was also present when installing on Ubuntu 20.04 Focal. The solution for Focal is the same for Jammy, which is to add `ubuntu-jammy` to `BoostInfo` and `jammy` as another `release`.