### PR TITLE
print: Align amounts even when account names are long

### DIFF
--- a/test/regress/align-amounts.test
+++ b/test/regress/align-amounts.test
@@ -1,0 +1,24 @@
+; Amounts should still align even though the account names are much longer than
+; the default --account-width.
+
+2023/01/01 Transaction with short account names
+    Assets:Short  -10 ABC
+    Assets:Short  -10 ABC
+    Expenses:Short  20 ABC
+
+2023/01/01 Transaction with long account names
+    Assets:Very:Long:Account:Name:That:Will:Push:The:Amount   -10 ABC
+    Assets:Another:Long:Account:Name:That:Will:Push:The:Amount   -10 ABC
+    Expenses:Short  20 ABC
+
+test print
+2023/01/01 Transaction with short account names
+    Assets:Short                             -10 ABC
+    Assets:Short                             -10 ABC
+    Expenses:Short                            20 ABC
+
+2023/01/01 Transaction with long account names
+    Assets:Very:Long:Account:Name:That:Will:Push:The:Amount        -10 ABC
+    Assets:Another:Long:Account:Name:That:Will:Push:The:Amount     -10 ABC
+    Expenses:Short                                                  20 ABC
+end test


### PR DESCRIPTION
When the account name is longer than the --account-width (default 36), the amounts stop aligning:

    2023/01/01 Transaction with long account names
        Assets:Very:Long:Account:Name:That:Will:Push:The:Amount     -10 ABC
        Assets:Another:Long:Account:Name:That:Will:Push:The:Amount     -10 ABC
        Expenses:Short                            20 ABC

One can set a larger --account-width, but that is not a great solution for cases where you have only a few accounts with problematically long names. Instead, keep the current account width wherever possible, but when an account name is longer than the account width, account for that and still align the values:

    2023/01/01 Transaction with short account names
        Assets:Short                             -10 ABC
        Assets:Short                             -10 ABC
        Expenses:Short                            20 ABC

    2023/01/01 Transaction with long account names
        Assets:Very:Long:Account:Name:That:Will:Push:The:Amount        -10 ABC
        Assets:Another:Long:Account:Name:That:Will:Push:The:Amount     -10 ABC
        Expenses:Short                                                  20 ABC

This is similar to hledger's behavior.