### PR TITLE
Fix =regex note query syntax

### DIFF
--- a/src/query.cc
+++ b/src/query.cc
@@ -126,6 +126,10 @@ query_t::lexer_t::next_token(query_t::lexer_t::token_t::kind_t tok_context)
   case '#': ++arg_i; return token_t(token_t::TOK_CODE);
   case '%': ++arg_i; return token_t(token_t::TOK_META);
   case '=':
+    if (arg_i == (*begin).as_string().begin()) {
+      ++arg_i;
+      return token_t(token_t::TOK_NOTE);
+    }
     ++arg_i;
     consume_next = true;
     return token_t(token_t::TOK_EQ);

--- a/test/manual/transaction-notes-1.test
+++ b/test/manual/transaction-notes-1.test
@@ -2,14 +2,14 @@
     Expenses:Food               $4.50
     Assets:Checking
 
-2009/11/01 Panera Bread
+2009/11/02 Panera Bread
     ; Type: Coffee
     ; Let’s see, I ate a whole bunch of stuff, drank some coffee,
     ; pondered a bagel, then decided against the donut.
     Expenses:Food               $4.50
     Assets:Checking
 
-2009/11/01 Panera Bread
+2009/11/03 Panera Bread
     ; Type: Dining
     ; :Eating:
     ; This is another long note, after the metadata.
@@ -18,5 +18,10 @@
 
 test reg --columns=60 food and note eat
 09-Nov-01 Panera Bread   Expenses:Food       $4.50     $4.50
-09-Nov-01 Panera Bread   Expenses:Food       $4.50     $9.00
+09-Nov-03 Panera Bread   Expenses:Food       $4.50     $9.00
+end test
+
+test reg --columns=60 food and =eat
+09-Nov-01 Panera Bread   Expenses:Food       $4.50     $4.50
+09-Nov-03 Panera Bread   Expenses:Food       $4.50     $9.00
 end test

--- a/test/regress/1182_2.test
+++ b/test/regress/1182_2.test
@@ -13,5 +13,5 @@ __ERROR__
 While parsing file "$FILE", line 5:
 While parsing automated transaction:
 > ============
-Error: Expected predicate after '='
+Error: note operator not followed by argument
 end test

--- a/test/unit/t_expr.cc
+++ b/test/unit/t_expr.cc
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(testPredicateTokenizer6)
 #ifndef NOT_FOR_PYTHON
   query_t::lexer_t tokens(args.begin(), args.end());
 
-  BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::TOK_EQ, tokens.next_token().kind);
+  BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::TOK_NOTE, tokens.next_token().kind);
   BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::TERM, tokens.next_token().kind);
   BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::TOK_AND, tokens.next_token().kind);
   BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::TERM, tokens.next_token().kind);
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(testPredicateTokenizer7)
 #ifndef NOT_FOR_PYTHON
   query_t::lexer_t tokens(args.begin(), args.end());
 
-  BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::TOK_EQ, tokens.next_token().kind);
+  BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::TOK_NOTE, tokens.next_token().kind);
   BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::TERM, tokens.next_token().kind);
   BOOST_CHECK_EQUAL(query_t::lexer_t::token_t::END_REACHED, tokens.next_token().kind);
 #endif


### PR DESCRIPTION
The manpage documents `=regex` as equivalent to the `note regex` query syntax, but the former does not actually work as the parser only handles an equals sign in the case of `tag type=dining` syntax, and doesn't handle the case where an equals sign starts a note query.

Fixing this does break queries like `tag type = dining` with spaces around the equals sign, but that syntax was not intended or documented.

Closes: #2275