### PR TITLE
flake: Update to 23.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675153841,
-        "narHash": "sha256-EWvU3DLq+4dbJiukfhS7r6sWZyJikgXn6kNl7eHljW8=",
+        "lastModified": 1701484532,
+        "narHash": "sha256-zC6a3b7zw7+1DfQt1p+GZ/5Mk19mI1dxnjZHi+5hNiM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea692c2ad1afd6384e171eabef4f0887d2b882d3",
+        "rev": "21ee79ad8cff9638ec0edaa6d2f1574dd237e1df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The release of NixOS and Nixpkgs 23.11 seems like a good opportunity to update Ledger's flake.lock.