### PR TITLE
test: Include CheckManpage and CheckTexinfo in tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,7 +55,12 @@ if (Python_EXECUTABLE)
 
   # CheckManpage and CheckTexinfo are disabled, since they do not work
   # reliably yet
-  list(APPEND CheckOptions CheckBaselineTests) #CheckManpage CheckTexinfo
+  list(APPEND CheckOptions CheckBaselineTests)
+  if (BUILD_DEBUG)
+    # CheckManpage and CheckTexinfo require ledger to have been
+    # built with debug support
+    list(APPEND CheckOptions CheckManpage CheckTexinfo)
+  endif()
   foreach(_class ${CheckOptions})
     add_test(NAME ${_class}
       COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/${_class}.py

--- a/test/CheckManpage.py
+++ b/test/CheckManpage.py
@@ -13,15 +13,16 @@ from CheckOptions import CheckOptions
 class CheckManpage (CheckOptions):
   def __init__(self, args):
     CheckOptions.__init__(self, args)
-    self.option_pattern = '\.It Fl \\\\-([-A-Za-z]+)'
-    self.function_pattern = '\.It Fn ([-A-Za-z_]+)'
+    self.option_pattern = r'^\.It Fl \\-([-A-Za-z]+)'
+    self.function_pattern = r'^\.It Fn ([-A-Za-z_]+)'
+    self.symbol_pattern = r'^\.It Sy ([-A-Za-z_]+)'
     self.source_file = join(self.source, 'doc', 'ledger.1')
     self.source_type = 'manpage'
 
 if __name__ == "__main__":
   args = argparse.ArgumentParser(prog='CheckManpage',
-                                 description='Check that ledger options are documented in the manpage'
-                                 parents=[CheckOptions.parser()]).parse_args()
+                                 description='Check that ledger options are documented in the manpage',
+                                 parents=[CheckManpage.parser()]).parse_args()
   script = CheckManpage(args)
   status = script.main()
   sys.exit(status)

--- a/test/CheckOptions.py
+++ b/test/CheckOptions.py
@@ -23,6 +23,7 @@ class CheckOptions (object):
 
   def __init__(self, args):
     self.option_pattern = None
+    self.symbol_pattern = None
     self.source_file = None
     self.sep = "\n  --"
 
@@ -39,10 +40,16 @@ class CheckOptions (object):
     return {match.group(1) for match in {regex.match(line) for line in open(filename)} if match}
 
   def find_options(self, filename):
-    return self.find_pattern(filename, self.option_pattern)
+    return self.find_pattern(filename, self.option_pattern) \
+          if self.option_pattern else set()
 
   def find_functions(self, filename):
-    return self.find_pattern(filename, self.function_pattern)
+    return self.find_pattern(filename, self.function_pattern) \
+          if self.function_pattern else set()
+
+  def find_symbols(self, filename):
+    return self.find_pattern(filename, self.symbol_pattern) \
+          if self.symbol_pattern else set()
 
   def find_alternates(self):
     command = shlex.split('grep --no-filename OPT_ALT')
@@ -99,6 +106,10 @@ class CheckOptions (object):
           functions.remove(function)
     known_functions = {'tag', 'has_tag', 'meta', 'has_meta'}
     self.unknown_functions = functions - known_functions
+
+    symbols = self.find_symbols(self.source_file)
+    # NOTA BENE: Some "functions" are actually symbols and documented as such
+    self.missing_functions -= symbols
 
     if len(self.missing_options):
       print("Missing %s option entries for:%s%s\n" % (self.source_type, self.sep, self.sep.join(sorted(list(self.missing_options)))))

--- a/test/CheckTexinfo.py
+++ b/test/CheckTexinfo.py
@@ -13,11 +13,11 @@ from CheckOptions import CheckOptions
 class CheckTexinfo (CheckOptions):
   def __init__(self, args):
     CheckOptions.__init__(self, args)
-    self.option_pattern = '^@item\s+--([-A-Za-z]+)'
-    self.function_pattern = '^@defun\s+([-A-Za-z_]+)'
+    self.option_pattern = r'^@item\s+--([-A-Za-z]+)'
+    self.function_pattern = r'^@defun\s+([-A-Za-z_]+)'
+    self.symbol_pattern = r'^@defvar\s+([-A-Za-z_]+)'
     self.source_file = join(self.source, 'doc', 'ledger3.texi')
     self.source_type = 'texinfo'
-
 
   def find_functions(self, filename):
     functions = set()
@@ -27,10 +27,12 @@ class CheckTexinfo (CheckOptions):
     function = None
     fun_doc = str()
     fun_example = False
+    fun_undocumented = False
     item_regex = re.compile(self.function_pattern)
-    itemx_regex = re.compile(r'^@defunx')
+    itemx_regex = re.compile(r'^@def(un|var)x')
     example_regex = re.compile(r'^@smallexample\s+@c\s+command:')
     fix_regex = re.compile(r'FIX')
+    undocumented_regex = re.compile(r'@value{FIXME:UNDOCUMENTED}')
     comment_regex = re.compile(r'^\s*@c')
     for line in open(filename):
         line = line.strip()
@@ -41,13 +43,18 @@ class CheckTexinfo (CheckOptions):
                 function = match.group(1)
         elif state == state_function:
             if line == '@end defun':
-                if function and fun_example and len(fun_doc) and not fix_regex.search(fun_doc):
+                # FIXME: Do not require an example (fun_example) for now
+                if function and len(fun_doc) \
+                    and not fix_regex.search(fun_doc) \
+                    and not undocumented_regex.search(fun_doc):
                     functions.add(function)
                 state = state_normal
-                fun_example = None
+                fun_example = False
                 fun_doc = str()
             elif itemx_regex.match(line):
                 continue
+            elif undocumented_regex.match(line):
+                fun_undocumented = True
             elif example_regex.match(line):
                 fun_example = True
             elif not comment_regex.match(line):
@@ -92,7 +99,7 @@ class CheckTexinfo (CheckOptions):
 if __name__ == "__main__":
   args = argparse.ArgumentParser(prog='CheckTexinfo',
                                  description='Check that ledger options are documented in the texinfo manual',
-                                 parents=[CheckOptions.parser()]).parse_args()
+                                 parents=[CheckTexinfo.parser()]).parse_args()
   script = CheckTexinfo(args)
   status = script.main()
   sys.exit(status)


### PR DESCRIPTION
While debugging #2302 I noticed that `CheckManpage.py` and `CheckTexinfo.py` are not included in the test suite. I believe it is safe to include them even though they currently fail due to missing documentation for a few options and functions (see below), because the tests can only be run if ledger has been built with debug support as the `CheckManpage.py` and `CheckTexinfo.py` (via `CheckOptions.py`) use the ledger option `--debug option.names parse true` which only provides useful information with built with debug support.

@jwiegley from the top of your head could you provide a short description for the following missing option and function documentation (I'm happy to accept this here as a PR comment and take care of the manpage and texinfo syntax)?

```
$ python test/CheckManpage.py -l ./result-debug/bin/ledger -s .
Missing manpage option entries for:
  --sort-all

Missing manpage function entries for:
  averaged_lots
  clear_commodity
  commodity_price
  display_amount
  display_total
  lot_date
  lot_price
  lot_tag
  nail_down
  round
  rounded
  set_commodity_price
  top_amount
  unround
  unrounded

$ python test/CheckTexinfo.py -l ./result-debug/bin/ledger -s .
Missing texinfo option entries for:
  --sort-all

Missing texinfo function entries for:
  averaged_lots
  clear_commodity
  commodity_price
  lot_date
  lot_price
  lot_tag
  nail_down
  round
  rounded
  set_commodity_price
  top_amount
  unround
  unrounded
```