### PR TITLE
man: Fix common glyph usage errors

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -138,7 +138,7 @@ The prices are reported with the granularity of a single day.
 Report prices for all commodities in postings matching the
 .Ar report-query .
 Prices are reported down to the second, using the same format as the
-.Pa ~/.pricedb
+.Pa \[ti]/.pricedb
 file.
 .It Ic print Oo Ar report-query Oc
 Print out the full transactions of any matching postings using the same
@@ -214,10 +214,10 @@ Sort postings by evaluating the given
 Note that a comma-separated list of expressions is allowed, in which case each
 sorting term is used in order to determine the final ordering.  For example,
 to search by date and then amount, one would use:
-.Dl ledger reg --sort 'date, amount'
+.Dl ledger reg --sort \[aq]date, amount\[aq]
 The sort order may be controlled with the '-' sign. For example, to sort in
 reverse chronological order:
-.Dl ledger reg --sort '-date'
+.Dl ledger reg --sort \[aq]-date\[aq]
 .It Fl \-tail Ar number
 Only show the last
 .Ar number
@@ -261,7 +261,7 @@ are also accepted.
 List all postings matching the
 .Ar sql-query .
 This command allows to generate SQL-like queries, e.g.:
-.Dl Li ledger select date,amount from posts where account=~/Income/
+.Dl Li ledger select date,amount from posts where account=\[ti]/Income/
 .It Ic source
 Parse a journal file and checks it for errors.
 .Nm
@@ -319,11 +319,11 @@ desired width.
 Prepend
 .Ar EXPR
 to all accounts reported.  That is, the option
-.Fl \-account Ar \*q'Personal'\*q
+.Fl \-account Ar \*q\[aq]Personal\[aq]\*q
 would tack
 .Ar Personal:
 and
-.Fl \-account Ar \*qtag('VAT')\*q
+.Fl \-account Ar \*qtag(\[aq]VAT\[aq])\*q
 would tack the value of the VAT tag to the beginning of every account
 reported in a
 .Ic balance
@@ -453,7 +453,7 @@ according to
 .Ar FMT .
 .It Fl \-current Pq Fl c
 Shorthand for
-.Fl \-limit Ar "'date <= today'" .
+.Fl \-limit Ar "\[aq]date <= today\[aq]" .
 .It Fl \-daily Pq Fl D
 Shorthand for
 .Fl \-period Ar daily .
@@ -1434,14 +1434,14 @@ may be set using an environment variable if the option has a long name.
 For example setting the environment variable
 .Ev LEDGER_DATE_FORMAT="%d.%m.%Y"
 will have the same effect as specifying
-.Fl \-date-format Ar '%d.%m.%Y'
+.Fl \-date-format Ar \[aq]%d.%m.%Y\[aq]
 on the command-line.  Options on the command-line always take precedence over
 environment variable settings, however.
 .Sh FILES
 .Bl -tag -width -indent
 .It Pa $XDG_CONFIG_HOME/ledger/ledgerrc
-.It Pa ~/.config/ledger/ledgerrc
-.It Pa ~/.ledgerrc
+.It Pa \[ti]/.config/ledger/ledgerrc
+.It Pa \[ti]/.ledgerrc
 Your personal
 .Nm
 initializations.


### PR DESCRIPTION
by using correct special characters as defined in groff_char(7), e.g. using \[aq] instead of "'", as "'" may get displayed as "’" by certain groff output devices, e.g. PDF or utf8.

For details see section _"When viewing man pages, some characters on my UTF-8 terminal emulator look funny or copy-and-paste wrong. Why?"_ in groff's [`PROBLEMS` file](http://git.savannah.gnu.org/cgit/groff.git/tree/PROBLEMS) and the `grotty` section in the [groff 1.23.0 announcement email](https://lists.gnu.org/archive/html/groff/2023-07/msg00051.html).