### PR TITLE
test: Accept test names as arguments

### DIFF
--- a/test/RegressTests.py
+++ b/test/RegressTests.py
@@ -27,6 +27,10 @@ args = parser.parse_args()
 multiproc &= (args.jobs >= 1)
 harness = LedgerHarness(args.ledger, args.sourcepath, args.verify, args.gmalloc, args.python)
 
+match = re.match(r'(Baseline|Regress|Manual)Test_(.*)', str(args.tests))
+if match:
+  args.tests = pathlib.Path('test') / match.group(1).lower() / (match.group(2) + '.test')
+
 if not args.tests.is_dir() and not args.tests.is_file():
     print(f'{args.tests} is not a directory or file (cwd: {os.getcwd()})'
           , file=sys.stderr)


### PR DESCRIPTION
This PR allows to use the test names from ctest output, e.g. `BaselineTest_opt-primary-date` when manually running `RegressTest.py`, e.g. `./test/RegressTests.py -l ./build/ledger -s . RegressTest_A3FA7601`