### PR TITLE
Expand the size of an arbitrary safety limit

### DIFF
--- a/src/error.cc
+++ b/src/error.cc
@@ -92,7 +92,7 @@ string source_context(const path&                  file,
     return _("<no source context>");
 
   assert(len > 0);
-  assert(len < 65536);
+  assert(len < 1048576);
 
   std::ostringstream out;
 


### PR DESCRIPTION
This limit is just a sanity check, but there is no reason it should be one size or another. I ran into a real world use case where the current limit was much too small.