### PR TITLE
Change an assertion into an if test

### DIFF
--- a/src/history.cc
+++ b/src/history.cc
@@ -438,7 +438,8 @@ commodity_history_impl_t::find_price(const commodity_t& source,
                                      const datetime_t&  moment,
                                      const datetime_t&  oldest)
 {
-  assert(source != target);
+  if (source == target)
+    return none;
 
   vertex_descriptor sv = vertex(*source.graph_index(), price_graph);
   vertex_descriptor tv = vertex(*target.graph_index(), price_graph);


### PR DESCRIPTION
The given assertion is too strict. If the source and target are the same for a market value valuation, simply return `none`. Note that this happened to me on my data when I was playing around with the `market` function.