### PR TITLE
Fix build with Boost 1.85.0

### DIFF
--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -140,7 +140,6 @@
 #include <boost/date_time/posix_time/posix_time_io.hpp>
 #include <boost/date_time/gregorian/gregorian_io.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/filesystem/exception.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>


### PR DESCRIPTION
Currently, the build with Boost 1.85.0 fails due to usage of removed `convenience.hpp` https://github.com/boostorg/filesystem/commit/5df060e95ca844fe91b29001b4ae22bdb65635c6

I didn't see any usage of removed functionality from header. Main question would be if any indirect headers were used. At least I didn't see any missing headers when compiling with this change.

Ref: https://www.boost.org/doc/libs/1_85_0/libs/filesystem/doc/deprecated.html

---

Seen while updating Boost in https://github.com/Homebrew/homebrew-core/pull/169237