### PR TITLE
Make the expr syntax explicit in the docs

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -8252,34 +8252,34 @@ The amount can be any kind of amount supported by ledger,
 with or without a commodity.  Use this for decimal values.
 
 @item /REGEX/
-@itemx expr account =~ /REGEX/
+@itemx expr "account =~ /REGEX/"
 A regular expression that matches against an account's full name.  If
 a posting, this will match against the account affected by the
 posting.
 
 @item @@/REGEX/
-@itemx expr payee =~ /REGEX/
+@itemx expr "payee =~ /REGEX/"
 A regular expression that matches against a transaction's payee name.
 
 @item %/REGEX/
-@itemx expr has_tag(/REGEX/)
-@itemx expr has_tag('TAG')
+@itemx expr "has_tag(/REGEX/)"
+@itemx expr "has_tag('TAG')"
 A regular expression (REGEX) or string (TAG) that checks for the tags of
 a transaction.
 
-@item expr has_meta(/REGEX/)
-@itemx expr has_meta('TAG')
+@item expr "has_meta(/REGEX/)"
+@itemx expr "has_meta('TAG')"
 A regular expression (REGEX) or string (TAG) that checks for the metadata
 key of a transaction.
 
-@item expr tag(REGEX) =~ /REGEX/
+@item expr "tag(REGEX) =~ /REGEX/"
 A regular expression that matches a transaction's tags against its values.
 
-@item expr date =~ /REGEX/
+@item expr "date =~ /REGEX/"
 Useful for specifying a date in plain terms.  For example, you could say
-@samp{expr date =~ /2014/}.
+@samp{expr "date =~ /2014/"}.
 
-@item expr comment =~ /REGEX/
+@item expr "comment =~ /REGEX/"
 A regular expression that matches against a posting's comment
 field.  This searches only a posting's field, not the transaction's note
 or comment field.  For example, @code{ledger reg "expr" "comment =~
@@ -8303,7 +8303,7 @@ but will not match:
 To match the latter, use @samp{ledger reg "expr" "note =~ /landline/"}
 instead.
 
-@item expr note =~ /REGEX/
+@item expr "note =~ /REGEX/"
 A regular expression that matches against a transaction's note field.
 This searches all comments in the transaction, including comments on
 individual postings.  Thus, @samp{ledger reg "expr" "note =~ /landline/"}
@@ -8333,23 +8333,23 @@ A sub-expression is nested in parenthesis.  This can be useful passing
 more complicated arguments to functions, or for overriding the natural
 precedence order of operators.
 
-@item expr base =~ /REGEX/
+@item expr "base =~ /REGEX/"
 A regular expression that matches against an account's base name.  If
 a posting, this will match against the account affected by the
 posting.
 
-@item expr code =~ /REGEX/
+@item expr "code =~ /REGEX/"
 A regular expression that matches against the transaction code (the
 text that occurs between parentheses before the payee).
 
-@item expr any(KEYWORD =~ /REGEX/)
+@item expr "any(KEYWORD =~ /REGEX/)"
 The @command{any} keyword is used to specify that at least one posting of
 the transaction must match the expression in brackets.  For example,
 @samp{ledger -f d reg expr "any(account =~ /Assets:/)"} can be used to
 display all transactions which involve at least one @samp{Assets:}
 account.
 
-@item expr all(KEYWORD =~ /REGEX/)
+@item expr "all(KEYWORD =~ /REGEX/)"
 The @command{all} keyword is used to specify that all postings of a
 transactions must match the expression in brackets.  For example,
 @samp{ledger -f d reg expr "all(account =~ /Assets:/)"} can be used to


### PR DESCRIPTION
ledger/ledger#2350 shows me it's possible for the docs to be misinterpreted. This could lead to errors as explained in the issue. This change makes the syntax more explicit so people can translate for their use cases easier 