### PR TITLE
Documented need for an explicit commodity in stock sale postings.

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -1816,6 +1816,8 @@ The @samp{@{$30.00@}} is a lot price.  You can also use a lot date,
 same price/date and your taxation model is based on
 longest-held-first.
 
+The lot price and sale price must include an explicit commodity name.
+
 @node Fixing Lot Prices, Complete control over commodity pricing, Buying and Selling Stock, Currency and Commodities
 @subsection Fixing Lot Prices
 @cindex fixing lot prices


### PR DESCRIPTION
Added a sentence to the documentation to mention that implicit commodities do not work with stock sale transactions.

To address the issue reported in https://github.com/ledger/ledger/issues/2353. So users know and don't create ledger files that won't work properly.