### PR TITLE
Restore expr context after calc

### DIFF
--- a/src/post.cc
+++ b/src/post.cc
@@ -642,11 +642,12 @@ void post_t::add_to_value(value_t& value, const optional<expr_t&>& expr) const
       add_or_set_value(value, xdata_->compound_value);
   }
   else if (expr) {
-    bind_scope_t bound_scope(*expr->get_context(),
-                             const_cast<post_t&>(*this));
+    scope_t *ctx = expr->get_context();
+    bind_scope_t bound_scope(*ctx, const_cast<post_t&>(*this));
 #if 1
     value_t temp(expr->calc(bound_scope));
     add_or_set_value(value, temp);
+    expr->set_context(ctx);
 #else
     if (! xdata_) xdata_ = xdata_t();
     xdata_->value = expr->calc(bound_scope);

--- a/test/regress/2330.test
+++ b/test/regress/2330.test
@@ -1,0 +1,14 @@
+2024/01/01 * Test1
+    Expenses:Test                            $1.00
+    Assets:Checking
+2024/01/01 * Test2
+    Expenses:Test                            $1.00
+    Assets:Checking
+
+test bal --group-by 'payee' --invert ^Expenses:
+Test1
+              $-1.00  Expenses:Test
+
+Test2
+              $-1.00  Expenses:Test
+end test


### PR DESCRIPTION
Part of the `expr_t::compile()` process is to store the current scope, but In `post_t::add_to_value` that scope is temporary and on the stack.

Restore the original context after that process is complete.

Fixes: #2330 #2343