### PR TITLE
Fix acprep script

### DIFF
--- a/acprep
+++ b/acprep
@@ -840,7 +840,7 @@ class PrepareBuild(CommandLineApp):
         PrepareBuild.__dict__['setup_flavor_' + self.current_flavor](self)
 
     def escape_string(self, data):
-        return re.sub(r'(['\\\\])', '\\\\\\1', data)
+        return re.sub(r'(["\\\\])', '\\\\\\1', data)
 
     def finalize_config(self):
         self.setup_flavor()


### PR DESCRIPTION
The script has a syntax error, caused by commit 815305b9: in the `escape_string()` function the first argument to `re.sub()` was probably changed unintentionally, resulting in invalid syntax.

This pull request reverts this one line. To test, I used `./acprep` to build the binary locally, which succeeded. More testing might be needed, I don't have enough context to do that.
