### PR TITLE
Add Python bindings for roundto

### DIFF
--- a/src/py_amount.cc
+++ b/src/py_amount.cc
@@ -207,6 +207,10 @@ internal precision."))
     .def("in_place_round", &amount_t::in_place_round,
          return_internal_reference<>())
 
+    .def("__round__", &amount_t::roundto)
+    .def("in_place_roundto", &amount_t::in_place_roundto,
+         return_internal_reference<>())
+
     .def("truncated", &amount_t::truncated)
     .def("in_place_truncate", &amount_t::in_place_truncate,
          return_internal_reference<>())

--- a/src/py_balance.cc
+++ b/src/py_balance.cc
@@ -182,6 +182,10 @@ void export_balance()
     .def("in_place_round", &balance_t::in_place_round,
          return_internal_reference<>())
 
+    .def("__round__", &balance_t::roundto)
+    .def("in_place_roundto", &balance_t::in_place_roundto,
+            return_internal_reference<>())
+
     .def("truncated", &balance_t::truncated)
     .def("in_place_truncate", &balance_t::in_place_truncate,
          return_internal_reference<>())

--- a/src/py_value.cc
+++ b/src/py_value.cc
@@ -251,6 +251,8 @@ void export_value()
 
     .def("rounded", &value_t::rounded)
     .def("in_place_round", &value_t::in_place_round)
+    .def("__round__", &value_t::roundto)
+    .def("in_place_roundto", &value_t::in_place_roundto)
     .def("truncated", &value_t::truncated)
     .def("in_place_truncate", &value_t::in_place_truncate)
     .def("floored", &value_t::floored)


### PR DESCRIPTION
Expose `roundto` and `in_place_roundto` to `Amount`, `Balance`, and `Value` Python classes.  They may be handy for debugging. The methods were added after introducing of bindings and likely it is a reason why they were missed.

Closes: #2365