### PR TITLE
disable checks for synthetic xacts, fixes  #2348

### DIFF
--- a/src/draft.cc
+++ b/src/draft.cc
@@ -242,6 +242,9 @@ xact_t * draft_t::insert(journal_t& journal)
   xact_t *              matching = NULL;
   unique_ptr<xact_t> added(new xact_t);
 
+  // There is no need to check drafts for errors, because we generated them.
+  journal.checking_style = journal_t::CHECK_PERMISSIVE;
+
   if (xact_t * xact =
       lookup_probable_account(tmpl->payee_mask.str(), journal.xacts.rbegin(),
                               journal.xacts.rend()).first) {

--- a/src/draft.cc
+++ b/src/draft.cc
@@ -102,13 +102,15 @@ void draft_t::parse_args(const value_t& args)
   value_t::sequence_t::const_iterator end   = args.end();
 
   for (; begin != end; begin++) {
+    string arg = (*begin).to_string();
+
     if (check_for_date &&
-        regex_match((*begin).to_string(), what, date_mask)) {
+        regex_match(arg, what, date_mask)) {
       tmpl->date = parse_date(what[0]);
       check_for_date = false;
     }
     else if (check_for_date &&
-             bool(weekday = string_to_day_of_week((*begin).to_string()))) {
+             bool(weekday = string_to_day_of_week(arg))) {
 #if defined(__GNUC__) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
@@ -124,8 +126,6 @@ void draft_t::parse_args(const value_t& args)
       check_for_date = false;
     }
     else {
-      string arg = (*begin).to_string();
-
       if (arg == "at") {
         if (++begin == end)
           throw std::runtime_error(_("Invalid xact command arguments"));

--- a/test/regress/2348.test
+++ b/test/regress/2348.test
@@ -1,0 +1,16 @@
+2024/04/24 Foobar
+    Expenses:Fournitures                                              25.00 EUR
+    ; Tag: Hello
+    Assets:Cash
+
+test xact --strict 2024/05/12 Foobar -> 0
+2024/05/12 Foobar
+    Expenses:Fournitures                   25.00 EUR
+    ; Tag: Hello
+    Assets:Cash
+__ERROR__
+Warning: "$FILE", line 2: Unknown account 'Expenses:Fournitures'
+Warning: "$FILE", line 2: Unknown commodity 'EUR'
+Warning: "$FILE", line 4: Unknown account 'Assets:Cash'
+Warning: "$FILE", line 4: Unknown metadata tag 'Tag'
+end test


### PR DESCRIPTION
There were two use-after-free bugs when using `xact`, one was only visible when using `--strict`

This fixes that issue by disabling checking when the `parse_context_stack` is empty, and moving the regex_match parameters into scope.