### PR TITLE
Revert "When calculating balance assignments, strip away lot annotations"

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1686,20 +1686,18 @@ post_t * instance_t::parse_post(char *          line,
       balance_t diff = amt;
 
       switch (account_total.type()) {
-      case value_t::AMOUNT: {
-        amount_t amt(account_total.as_amount().strip_annotations(keep_details_t()));
-        diff -= amt;
+      case value_t::AMOUNT:
+        diff -= account_total.as_amount();
         DEBUG("textual.parse", "line " << context.linenum << ": "
-              << "Subtracting amount " << amt << " from diff, yielding " << diff);
+              << "Subtracting amount " << account_total.as_amount() << " from diff, yielding " << diff);
         break;
-      }
-      case value_t::BALANCE: {
-        balance_t bal(account_total.as_balance().strip_annotations(keep_details_t()));
-        diff -= bal;
+
+      case value_t::BALANCE:
+        diff -= account_total.as_balance();
         DEBUG("textual.parse", "line " << context.linenum << ": "
-              << "Subtracting balance " << bal << " from diff, yielding " << diff);
+              << "Subtracting balance " << account_total.as_balance() << " from diff, yielding " << diff);
         break;
-      }
+
       default:
         break;
       }
@@ -1712,10 +1710,9 @@ post_t * instance_t::parse_post(char *          line,
       // Subtract amounts from previous posts to this account in the xact.
       for (post_t* p : xact->posts) {
         if (p->account == post->account && p->has_flags(POST_VIRTUAL) == post->has_flags(POST_VIRTUAL)) {
-          amount_t amt(p->amount.strip_annotations(keep_details_t()));
-          diff -= amt;
+          diff -= p->amount;
           DEBUG("textual.parse", "line " << context.linenum << ": "
-                << "Subtracting " << amt << ", diff = " << diff);
+                << "Subtracting " << p->amount << ", diff = " << diff);
         }
       }
 
@@ -1749,9 +1746,9 @@ post_t * instance_t::parse_post(char *          line,
         }
       } else {
         // balance assertion
-        diff -= post->amount.strip_annotations(keep_details_t());
+        diff -= post->amount;
         if (! no_assertions && ! diff.is_zero()) {
-          balance_t tot = (-diff + amt).strip_annotations(keep_details_t());
+          balance_t tot = -diff + amt;
           DEBUG("textual.parse", "Balance assertion: off by " << diff << " (expected to see " << tot << ")");
           throw_(parse_error,
                   _f("Balance assertion off by %1% (expected to see %2%)")


### PR DESCRIPTION
This relates to https://github.com/ledger/ledger/issues/2355.