### PR TITLE
WIP: Make virtual-balanced transactions balance separately.

### DIFF
--- a/test/baseline/balanced-virtual.test
+++ b/test/baseline/balanced-virtual.test
@@ -1,0 +1,12 @@
+2024/08/11 Example
+    Income                                     $1.00
+    Expenses
+    [Income]                                   $1.00
+    [Expenses]
+
+test bal
+              $-2.00  Expenses
+               $2.00  Income
+--------------------
+                   0
+end test

--- a/test/regress/1942_a.test
+++ b/test/regress/1942_a.test
@@ -20,7 +20,7 @@ While balancing transaction from "$FILE", lines 10-13:
 >     [Assets:Budget:Rent]                       = $100.00
 >     [Assets:Budget:Emergency]                  = $400.00
 >     [Assets:Bank]                               -$500.00
-Unbalanced remainder is:
+Unbalanced virtual remainder is:
             $-300.00
 Amount to balance against:
              $200.00

--- a/test/regress/1942_b.test
+++ b/test/regress/1942_b.test
@@ -20,7 +20,7 @@ While balancing transaction from "$FILE", lines 10-13:
 >     [Assets:Budget:Rent]                    $0 = $100.00
 >     [Assets:Budget:Emergency]                  = $400.00
 >     [Assets:Bank]                               -$500.00
-Unbalanced remainder is:
+Unbalanced virtual remainder is:
             $-300.00
 Amount to balance against:
              $200.00

--- a/test/regress/2105.test
+++ b/test/regress/2105.test
@@ -1,0 +1,33 @@
+2024/08/11 Example
+    Income                                     $1.00
+    [Expenses]                                $-1.00
+
+2024/08/12 Example
+    Income                                     $1.00
+    Income                                    $-1.00
+    [Expenses]                                $-1.00
+
+test bal -> 2
+__ERROR__
+While parsing file "/home/phil/local/src/ledger/test/regress/2105.test", line 3:
+While balancing transaction from "/home/phil/local/src/ledger/test/regress/2105.test", lines 1-3:
+> 2024/08/11 Example
+>     Income                                     $1.00
+>     [Expenses]                                $-1.00
+Unbalanced remainder is:
+                   0
+Amount to balance against:
+               $1.00
+Error: Transaction does not balance
+While parsing file "/home/phil/local/src/ledger/test/regress/2105.test", line 8:
+While balancing transaction from "/home/phil/local/src/ledger/test/regress/2105.test", lines 5-8:
+> 2024/08/12 Example
+>     Income                                     $1.00
+>     Income                                    $-1.00
+>     [Expenses]                                $-1.00
+Unbalanced virtual remainder is:
+              $-1.00
+Amount to balance against:
+               $1.00
+Error: Transaction does not balance
+end test


### PR DESCRIPTION
This is intended to close #2105: in a given transaction, virtual postings (with `[]`) should balance to 0 and real postings should balance to 0, but until now it's just been required that the complete set "virtual postings (with `[]`) and real postings" should balance to 0. Minimally:

```
2024/08/11 Example
    Income                                     $1.00
    [Expenses]                                $-1.00
```

ought to error but until now has been accepted.

It's not complete yet. There are some design decisions and I'd appreciate some opinions on them. Also, I don't really know C++. Right now a lot of the code here is just "copy the existing code and do it again with some variables and some flags changed", and if there's some way to avoid that it would be nice to know.