### PR TITLE
Fix build with Boost 1.86.0

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -238,7 +238,7 @@ void anonymize_posts::render_commodity(amount_t& amt)
 void anonymize_posts::operator()(post_t& post)
 {
 	boost::uuids::detail::sha1  sha;
-  unsigned int message_digest[5];
+  unsigned char message_digest[20];
   bool         copy_xact_details = false;
 
   if (last_xact != post.xact) {
@@ -1269,7 +1269,7 @@ void budget_posts::report_budget_items(const date_t& date)
     foreach (pending_posts_list::iterator& i, posts_to_erase)
       pending_posts.erase(i);
   }
-  
+
   if (pending_posts.size() == 0)
     return;
 

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -237,8 +237,6 @@ void anonymize_posts::render_commodity(amount_t& amt)
 
 void anonymize_posts::operator()(post_t& post)
 {
-	boost::uuids::detail::sha1  sha;
-  boost::uuids::detail::sha1::digest_type message_digest;
   bool         copy_xact_details = false;
 
   if (last_xact != post.xact) {
@@ -255,12 +253,7 @@ void anonymize_posts::operator()(post_t& post)
     std::ostringstream buf;
     buf << reinterpret_cast<boost::uintmax_t>(post.xact->payee.c_str())
         << integer_gen() << post.xact->payee.c_str();
-
-		sha.reset();
-    sha.process_bytes(buf.str().c_str(), buf.str().length());
-    sha.get_digest(message_digest);
-
-    xact.payee = digest_to_hex(message_digest, 8);
+    xact.payee = sha1sum(buf.str(), 8);
     xact.note  = none;
   } else {
     xact.journal = post.xact->journal;
@@ -273,12 +266,7 @@ void anonymize_posts::operator()(post_t& post)
        acct = acct->parent) {
     std::ostringstream buf;
     buf << integer_gen() << acct << acct->fullname();
-
-    sha.reset();
-    sha.process_bytes(buf.str().c_str(), buf.str().length());
-    sha.get_digest(message_digest);
-
-    account_names.push_front(digest_to_hex(message_digest, 8));
+    account_names.push_front(sha1sum(buf.str(), 8));
   }
 
   account_t * new_account =

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -238,7 +238,7 @@ void anonymize_posts::render_commodity(amount_t& amt)
 void anonymize_posts::operator()(post_t& post)
 {
 	boost::uuids::detail::sha1  sha;
-  unsigned char message_digest[20];
+  boost::uuids::detail::sha1::digest_type message_digest;
   bool         copy_xact_details = false;
 
   if (last_xact != post.xact) {
@@ -260,7 +260,7 @@ void anonymize_posts::operator()(post_t& post)
     sha.process_bytes(buf.str().c_str(), buf.str().length());
     sha.get_digest(message_digest);
 
-    xact.payee = to_hex(message_digest);
+    xact.payee = digest_to_hex(message_digest, 8);
     xact.note  = none;
   } else {
     xact.journal = post.xact->journal;
@@ -278,7 +278,7 @@ void anonymize_posts::operator()(post_t& post)
     sha.process_bytes(buf.str().c_str(), buf.str().length());
     sha.get_digest(message_digest);
 
-    account_names.push_front(to_hex(message_digest));
+    account_names.push_front(digest_to_hex(message_digest, 8));
   }
 
   account_t * new_account =

--- a/src/utils.h
+++ b/src/utils.h
@@ -604,7 +604,7 @@ inline string sha1sum(
   const string& str,
   size_t len = sizeof(boost::uuids::detail::sha1::digest_type) * 2
 ) {
-	boost::uuids::detail::sha1 sha;
+	static boost::uuids::detail::sha1 sha;
   boost::uuids::detail::sha1::digest_type message_digest;
 
 	sha.reset();

--- a/src/utils.h
+++ b/src/utils.h
@@ -578,29 +578,39 @@ inline int peek_next_nonws(std::istream& in) {
     *_p = '\0';                                         \
   }
 
-inline string to_hex(unsigned char * message_digest, const int len = 4)
-{
+inline string digest_to_hex(
+  const boost::uuids::detail::sha1::digest_type& message_digest,
+  size_t len = sizeof(boost::uuids::detail::sha1::digest_type) * 2
+) {
   std::ostringstream buf;
+  buf.setf(std::ios_base::hex, std::ios_base::basefield);
+  buf.fill('0');
 
-  for(int i = 0; i < 20 ; i++) {
-    buf.width(2);
-    buf.fill('0');
-    buf << std::hex << (int)message_digest[i];
-    if (i + 1 >= len)
-      break;                    // only output the first LEN dwords
+  // sha1::digest_type is an array type and may change between Boost versions
+  const size_t count = std::min(
+    sizeof(message_digest) / sizeof(message_digest[0]),
+    (len - 1) / (sizeof(message_digest[0]) * 2) + 1
+  );
+  for(size_t i = 0; i < count; i++) {
+    buf.width(sizeof(message_digest[i]) * 2);
+    buf << (unsigned int)message_digest[i];
   }
-  return buf.str();
+  string hex = buf.str();
+  hex.resize(len, '0'); // in case a partial element is requested
+  return hex;
 }
 
-inline string sha1sum(const string& str)
-{
+inline string sha1sum(
+  const string& str,
+  size_t len = sizeof(boost::uuids::detail::sha1::digest_type) * 2
+) {
 	boost::uuids::detail::sha1 sha;
+  boost::uuids::detail::sha1::digest_type message_digest;
 
+	sha.reset();
   sha.process_bytes(str.c_str(), str.length());
-
-  unsigned char message_digest[20];
   sha.get_digest(message_digest);
-  return to_hex(message_digest, 20);
+  return digest_to_hex(message_digest, len);
 }
 
 extern const string version;

--- a/src/utils.h
+++ b/src/utils.h
@@ -578,14 +578,14 @@ inline int peek_next_nonws(std::istream& in) {
     *_p = '\0';                                         \
   }
 
-inline string to_hex(unsigned int * message_digest, const int len = 1)
+inline string to_hex(unsigned char * message_digest, const int len = 4)
 {
   std::ostringstream buf;
 
-  for(int i = 0; i < 5 ; i++) {
-    buf.width(8);
+  for(int i = 0; i < 20 ; i++) {
+    buf.width(2);
     buf.fill('0');
-    buf << std::hex << message_digest[i];
+    buf << std::hex << (int)message_digest[i];
     if (i + 1 >= len)
       break;                    // only output the first LEN dwords
   }
@@ -598,9 +598,9 @@ inline string sha1sum(const string& str)
 
   sha.process_bytes(str.c_str(), str.length());
 
-  unsigned int message_digest[5];
+  unsigned char message_digest[20];
   sha.get_digest(message_digest);
-  return to_hex(message_digest, 5);
+  return to_hex(message_digest, 20);
 }
 
 extern const string version;


### PR DESCRIPTION
A recent update to Boost changed the type of message digests from `int[5]` to `char[20]`. This PR updates the handling of message digests to use the updated type.

Fixes #2378.