### PR TITLE
Improve CMake files

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:
@@ -58,7 +58,7 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{matrix.config.cmake_args}} -DBUILD_DEBUG=ON  -DPython_FIND_VERSION_MAJOR=${{matrix.config.PY_MAJOR}}
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{matrix.config.cmake_args}} -DPython_FIND_VERSION_MAJOR=${{matrix.config.PY_MAJOR}}
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,13 @@ set(Required_Gpgmepp_Version 1.13.1)
 
 cmake_minimum_required(VERSION ${Required_CMake_Version})
 
+option(CMAKE_BUILD_TYPE "CMake Build type" "Release")
+if (BUILD_DEBUG)
+  message(DEPRECATION "BUILD_DEBUG is deprecated! Set CMAKE_BUILD_TYPE to Debug instead!")
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "CMake Build type" FORCE)
+  unset(BUILD_DEBUG CACHE)
+endif()
+
 PROJECT(ledger)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/doc")
@@ -40,11 +47,9 @@ option(BUILD_LIBRARY "Build and install Ledger as a library" ON)
 option(BUILD_DOCS "Build and install documentation" OFF)
 option(BUILD_WEB_DOCS "Build version of documentation suitable for viewing online" OFF)
 
-if (BUILD_DEBUG)
-  set(CMAKE_BUILD_TYPE Debug)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(DEBUG_MODE 1)
 else()
-  set(CMAKE_BUILD_TYPE Release)
   set(DEBUG_MODE 0)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,8 @@ endif()
 # Set BOOST_ROOT to help CMake to find the right Boost version
 find_package(Boost ${Required_Boost_Version}
   REQUIRED date_time filesystem system iostreams regex unit_test_framework
-  ${BOOST_PYTHON} OPTIONAL_COMPONENTS nowide)
+  ${BOOST_PYTHON} OPTIONAL_COMPONENTS nowide
+  CONFIG)
 
 # enable Boost::nowide library (for UTF8 command line args on Windows)
 set(HAVE_BOOST_NOWIDE 0)

--- a/acprep
+++ b/acprep
@@ -883,16 +883,16 @@ class PrepareBuild(CommandLineApp):
         pass
 
     def setup_flavor_debug(self):
-        self.configure_args.append('-DBUILD_DEBUG=1')
+        self.configure_args.append('-DCMAKE_BUILD_TYPE=Debug')
 
     def setup_flavor_opt(self):
-        self.configure_args.append('-DBUILD_DEBUG=0')
+        self.configure_args.append('-DCMAKE_BUILD_TYPE=Release')
         self.configure_args.append('-DNO_ASSERTS=1')
 
     def setup_flavor_gcov(self):
         # NO_ASSERTS is set so that branch coverage ignores the never-taken
         # else branch inside assert statements.
-        self.configure_args.append('-DBUILD_DEBUG=1')
+        self.configure_args.append('-DCMAKE_BUILD_TYPE=Debug')
         self.configure_args.append('-DNO_ASSERTS=1')
         self.configure_args.append('-DCLANG_GCOV=1')
 
@@ -905,7 +905,7 @@ class PrepareBuild(CommandLineApp):
             self.LDFLAGS.append('-lgcov')
 
     def setup_flavor_gprof(self):
-        self.configure_args.append('-DBUILD_DEBUG=1')
+        self.configure_args.append('-DCMAKE_BUILD_TYPE=Debug')
 
         self.CXXFLAGS.append('-pg')
         self.LDFLAGS.append('-pg')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,7 +223,7 @@ else()
   add_ledger_library_dependencies(ledger)
 endif()
 
-if (PRECOMPILE_SYSTEM_HH AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if (PRECOMPILE_SYSTEM_HH)
   if (BUILD_LIBRARY)
     target_precompile_headers(libledger PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
     target_precompile_headers(ledger REUSE_FROM libledger)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,43 +167,6 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
       -Wno-unused-local-typedef
       --system-header-prefix=include/boost/
       --system-header-prefix=boost/)
-
-    macro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
-      set(_pch_filename "${_header_filename}.pch")
-
-      set_source_files_properties(
-        ${${_src_list}} PROPERTIES COMPILE_FLAGS "-include ${_header_filename}")
-      if (_other_srcs)
-        set_source_files_properties(
-          ${_other_srcs} PROPERTIES COMPILE_FLAGS "-include ${_header_filename}")
-      endif()
-      list(APPEND ${_src_list} ${_pch_filename})
-
-      set(_args ${CMAKE_CXX_FLAGS})
-      list(APPEND _args ${CMAKE_CXX_FLAGS_DEBUG})
-      if (BUILD_LIBRARY)
-        list(APPEND _args ${CMAKE_SHARED_LIBRARY_CXX_FLAGS})
-      endif()
-      list(APPEND _args "-std=c++11")
-      if (CYGWIN)
-        list(APPEND _args "-U__STRICT_ANSI__")
-      endif()
-      list(APPEND _args "-x c++-header " ${_inc})
-      list(APPEND _args -c ${_header_filename} -o ${_pch_filename})
-
-      get_directory_property(DIRINC INCLUDE_DIRECTORIES)
-      foreach(_inc ${DIRINC})
-        list(APPEND _args "-isystem " ${_inc})
-      endforeach(_inc ${DIRINC})
-
-      separate_arguments(_args)
-
-      add_custom_command(OUTPUT ${_pch_filename}
-        COMMAND rm -f ${_pch_filename}
-        COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${_args}
-        DEPENDS ${_header_filename})
-    endmacro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
-
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(GXX_WARNING_FLAGS
       -pedantic
@@ -225,56 +188,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
       -Wno-strict-aliasing)
 
     add_compile_options(${GXX_WARNING_FLAGS})
-
-    macro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
-      set(_gch_filename "${_header_filename}.gch")
-
-      set_source_files_properties(
-        ${${_src_list}} PROPERTIES COMPILE_FLAGS "-Winvalid-pch")
-      if (_other_srcs)
-        set_source_files_properties(
-          ${_other_srcs} PROPERTIES COMPILE_FLAGS "-Winvalid-pch")
-      endif()
-      list(APPEND ${_src_list} ${_gch_filename})
-
-      set(_args ${CMAKE_CXX_FLAGS})
-      list(APPEND _args ${CMAKE_CXX_FLAGS_DEBUG})
-      if (BUILD_LIBRARY)
-        list(APPEND _args ${CMAKE_SHARED_LIBRARY_CXX_FLAGS})
-      endif()
-      list(APPEND _args ${GXX_WARNING_FLAGS})
-      list(APPEND _args "-std=c++11 ")
-      if (CYGWIN)
-        list(APPEND _args "-U__STRICT_ANSI__")
-      endif()
-      list(APPEND _args "-x c++-header " ${_inc})
-      list(APPEND _args -c ${_header_filename} -o ${_gch_filename})
-
-      get_directory_property(DIRINC INCLUDE_DIRECTORIES)
-      foreach(_inc ${DIRINC})
-        list(APPEND _args "-I" ${_inc})
-      endforeach(_inc ${DIRINC})
-
-      separate_arguments(_args)
-
-      add_custom_command(OUTPUT ${_gch_filename}
-        COMMAND rm -f ${_gch_filename}
-        COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${_args}
-        DEPENDS ${_header_filename})
-    endmacro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
-
-  else()
-    macro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
-    endmacro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
   endif()
-else()
-  macro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
-  endmacro(ADD_PCH_RULE _header_filename _src_list _other_srcs)
-endif()
-
-if(PRECOMPILE_SYSTEM_HH AND NOT (COMMAND target_precompile_headers))
-  # enable fallback for CMake versions older than 3.16 without target_precompile_headers
-  add_pch_rule(${PROJECT_BINARY_DIR}/system.hh LEDGER_SOURCES LEDGER_CLI_SOURCES)
 endif()
 
 include(GNUInstallDirs)
@@ -309,7 +223,7 @@ else()
   add_ledger_library_dependencies(ledger)
 endif()
 
-if (PRECOMPILE_SYSTEM_HH AND (COMMAND target_precompile_headers) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+if (PRECOMPILE_SYSTEM_HH AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
   if (BUILD_LIBRARY)
     target_precompile_headers(libledger PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
     target_precompile_headers(ledger REUSE_FROM libledger)


### PR DESCRIPTION
Main changes:
  - Always use precompiled headers, if the configuration option is enabled
  - Deprecate `BUILD_DEBUG` and prefer `CMAKE_BUILD_TYPE` to also allow build types like `RelWithDebInfo`