### PR TITLE
Display parent accounts with one child if they contain posts

### DIFF
--- a/src/output.cc
+++ b/src/output.cc
@@ -223,6 +223,7 @@ format_accounts::mark_accounts(account_t& account, const bool flat)
     bind_scope_t bound_scope(report, account);
     call_scope_t call_scope(bound_scope);
     if ((! flat && to_display > 1) ||
+        (! flat && to_display == 1 && ! account.posts.empty()) ||
         ((flat || to_display != 1 ||
           account.has_xflags(ACCOUNT_EXT_VISITED)) &&
          (report.HANDLED(empty) ||

--- a/test/regress/cmd-balance-parent-has-transaction.test
+++ b/test/regress/cmd-balance-parent-has-transaction.test
@@ -1,0 +1,17 @@
+2021/01/01 Test
+	Left Column:Account A:Sub-Account    100
+	Right Column:Account 1:Sub-Account  -100
+
+2021/01/02 Test
+	Left Column:Account A               -100
+	Right Column:Account 2               100
+
+test bal
+                   0  Left Column:Account A
+                 100    Sub-Account
+                   0  Right Column
+                -100    Account 1:Sub-Account
+                 100    Account 2
+--------------------
+                   0
+end test


### PR DESCRIPTION
Display parent accounts with one child if they contain posts to avoid the user thinking the parent account doesn't have any posts. Previously an account with postings and a child account would just display the child account balance, which hides the actual account balance.

Fixes #2009