### PR TITLE
Documentation: Added negative numbers for introductory transactions

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -783,7 +783,7 @@ account, such as when you get paid.  Here is a typical transaction:
 @smallexample @c input:6B43DD4
 2004/09/29  My Employer
     Assets:Checking               $500.00
-    Income:Salary
+    Income:Salary                $-500.00
 @end smallexample
 
 Money, here, comes from an Income account belonging to @samp{My
@@ -798,7 +798,7 @@ it:
 @smallexample @c input:6B43DD4
 2004/09/30  Restaurant
     Expenses:Dining                $25.00
-    Liabilities:MasterCard
+    Liabilities:MasterCard        $-25.00
 @end smallexample
 
 The Dining account balance now shows $25 spent on Dining, and
@@ -880,9 +880,12 @@ each person or business that you spend money for.  For example:
 @end smallexample
 
 This shows $100.00 spent on a MasterCard at Circuit City, with the
-expense was made on behalf of Company XYZ.  Later, when Company XYZ
-pays the amount back, the money will transfer from that reimbursement
-account back to a regular asset account:
+expense was made on behalf of Company XYZ@footnote{Note that there
+is no negative amount. If left blank, Ledger will assume that the
+balanced amount is the same as the first line. For more information,
+@pxref{Eliding amounts}.}. Later, when Company XYZ pays the
+amount back, the money will transfer from that reimbursement account
+back to a regular asset account:
 
 @smallexample @c input:validate
 2004/09/29  Company XYZ


### PR DESCRIPTION
And added footnote explaining "negative number-less notation"

When reading the documentation from top to bottom, the main notation used is the one that has both positive and negative numbers. For example, here: https://github.com/ledger/ledger/blob/master/doc/ledger3.texi#L737-L741. Picture:
 
![image](https://github.com/user-attachments/assets/854f4c9d-f23c-478b-8b60-ec77b7d59943). 

The first mention of the "No negative numbers" notation (IINM) is done in chapter 4.1 (Specifically, here: https://github.com/ledger/ledger/blob/master/doc/ledger3.texi#L1544-L1546)

However, in chapter 3.3, the "no negative numbers" notations is used but not explained. Here: https://github.com/ledger/ledger/blob/master/doc/ledger3.texi#L783-L787. And also here: https://github.com/ledger/ledger/blob/master/doc/ledger3.texi#L798-L802. Picture:

![image](https://github.com/user-attachments/assets/220a3bdf-ea90-4b13-9c4b-f4e9e9a6e5f3)


Furthermore, in the latter there's a mention to a negative number that's not present in the resulting pdf (here:  https://github.com/ledger/ledger/blob/master/doc/ledger3.texi#L806-L807). Picture: 
![image](https://github.com/user-attachments/assets/3036fff3-4b2c-4764-b537-26d3158abc15)


So, I added negative numbers for the first two. This makes the reference to the negative number (here:  https://github.com/ledger/ledger/blob/master/doc/ledger3.texi#L806-L807) "real". Plus, it uses the already familiar notation (both positive and negative). 

I was hesitant of changing every single transaction and adding the missing negative numbers until chapter 4.1 where the "no negative numbers" notation is used. Instead, I decided to use a footnote on the next available transaction in the documentation. ~Said footnote contains a hyperef to the chapter where this notation is first introduced.~. Edit: I kept on reading the manual and found the section where amount elision is explained. The new commit has a reference to that section instead, since it seemed more appropriate.

Would love to get some feedback. Maybe I'm misinterpreting something, but I found that abrupt change of notation to be a bit confusing. Mainly because, up until then, the documentation was very adamant about explaining everything (Thank you btw! This has to be one of the **NICEST** and best well-written pieces of documentation I've ever read!!! It makes learning about Ledger so much fun ^_^)


Edit: By negative number-less notation I mean "amount elision". 
