### PR TITLE
Update jammy python dependency (acprep dependency install error on Ubuntu 22.04)

### DIFF
--- a/acprep
+++ b/acprep
@@ -542,7 +542,7 @@ class PrepareBuild(CommandLineApp):
                             'ninja-build',
                             'zlib1g-dev',
                             'libbz2-dev',
-                            'python-dev',
+                            'python3-dev',
                             'libgmp3-dev',
                             'libmpfr-dev',
                             'gettext',


### PR DESCRIPTION
Resolves #2346 