### PR TITLE
Fix percentile balance report of time commodity

### DIFF
--- a/src/report.cc
+++ b/src/report.cc
@@ -840,7 +840,7 @@ value_t report_t::fn_ansify_if(call_scope_t& args)
 value_t report_t::fn_percent(call_scope_t& args)
 {
   return (amount_t("100.00%") *
-          (args.get<amount_t>(0) / args.get<amount_t>(1)).number());
+          (args.get<amount_t>(0).reduced() / args.get<amount_t>(1).reduced()).number());
 }
 
 value_t report_t::fn_commodity(call_scope_t& args)

--- a/test/regress/2403.test
+++ b/test/regress/2403.test
@@ -1,0 +1,10 @@
+i 2025-01-21 08:00:00 dev:abc  payee
+o 2025-01-21 08:45:00
+i 2025-01-21 12:00:00 dev:xyz  payee
+o 2025-01-21 12:30:00
+
+test bal --percent
+             100.00%  dev
+              60.00%    abc
+              40.00%    xyz
+end test


### PR DESCRIPTION
This is a draft PR to get some feedback of whether this is headed into the right direction. If it is, I'll add some tests.

```sh
cat << EOF | nix run github:ledger/ledger/pull/2404/merge -- -f - bal --time-colon --percent
i 2025-01-21 08:00:00 dev:abc  payee
o 2025-01-21 08:45:00
i 2025-01-21 12:00:00 dev:xyz  payee
o 2025-01-21 12:30:00
EOF
             100.00%  dev
              65.22%    abc
              43.48%    xyz
```

Fixes #2403