### PR TITLE
ledger.xsl: add ability for number formatting

### DIFF
--- a/contrib/html/README
+++ b/contrib/html/README
@@ -13,3 +13,9 @@ usage:
   from ledger file directly:
 
     ledger -f input.ledger xml | xsltproc --output output-ledger.html ledger.xsl -
+
+parameters:
+
+  - `quantityFormat`: format for quantities, default is '#.00' (2 decimal
+    places). If you want no decimals, use `xsltproc --param quantityFormat "'#'"
+    ...`

--- a/contrib/html/README
+++ b/contrib/html/README
@@ -18,4 +18,5 @@ parameters:
 
   - `quantityFormat`: format for quantities, default is '#.00' (2 decimal
     places). If you want no decimals, use `xsltproc --param quantityFormat "'#'"
-    ...`
+    ...`, see the xslt spec for details:
+    https://www.w3.org/TR/1999/REC-xslt-19991116/#function-format-number

--- a/contrib/html/ledger.xsl
+++ b/contrib/html/ledger.xsl
@@ -35,6 +35,8 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="html" encoding="UTF-8" indent="yes" doctype-system="about:legacy-compat"/>
 
+  <xsl:param name="quantityFormat" select="'#.00'"/>
+
   <xsl:template match="/">
     <html>
       <head>
@@ -232,10 +234,10 @@
         <xsl:choose>
           <xsl:when test="not(contains(commodity/@flags,'D') or contains(commodity/@flags,'E'))">
             <!-- TODO Thousands markers -->
-            <xsl:value-of select="quantity"/>
+            <xsl:value-of select="format-number(quantity, $quantityFormat)"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="translate(quantity,'.',',')"/>
+            <xsl:value-of select="format-number(translate(quantity,'.',','), $quantityFormat)"/>
           </xsl:otherwise>
         </xsl:choose>
       </span>


### PR DESCRIPTION
# Why

Without number formatting, the generated output may look silly in terms of quantities, as quantities will have an arbitrary amount of decimals in the fractional part.

# How

I added number formatting using [xslt's number-format](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-format-number) function, with a reasonable default, and documentation in the README.