### PR TITLE
Allow $expr in automated xact account names, not just $account

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -848,12 +848,18 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context)
         string fullname = account->fullname();
         assert(! fullname.empty());
 
-        if (contains(fullname, "$account")) {
-          fullname = regex_replace(fullname, regex("\\$account\\>"),
-                                   initial_post->account->fullname());
-          while (account->parent)
-            account = account->parent;
-          account = account->find_account(fullname);
+        const regex re("\\$([A-Za-z_]+)");
+        smatch matches;
+        if (regex_search(fullname, matches, re)) {
+          bind_scope_t bound_scope(*context.scope, *initial_post->account);
+          const string subexpr = matches[1];
+          value_t result = expr_t(subexpr).calc(bound_scope);
+          if (result.is_string()) {
+            fullname = regex_replace(fullname, re, result.as_string());
+            while (account->parent)
+              account = account->parent;
+            account = account->find_account(fullname);
+          }
         }
         else if (contains(fullname, "%(")) {
           format_t account_name(fullname);


### PR DESCRIPTION
For example, from one of the tests:
```
; payroll taxes
= /^Payroll/
  Liabilities:Taxes:CFICA  0.062
  Liabilities:Taxes:CMED   0.0145
  $account:EFICA   -0.062
  $account:EMED    -0.0145
```
This reference to `$account` used to be hard-coded, meaning it was the only expression allowed, and not `$account_base`, for example. With this PR, any expression is allowed, evaluated with the context of the account, so that `$account` has the current meaning, but now you can use any value expression. This is much more consistent with expectations.