### PR TITLE
Fix build with Boost 1.89.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 
 # Set BOOST_ROOT to help CMake to find the right Boost version
 find_package(Boost ${Required_Boost_Version}
-  REQUIRED date_time filesystem system iostreams regex unit_test_framework
+  REQUIRED date_time filesystem iostreams regex unit_test_framework
   ${BOOST_PYTHON} OPTIONAL_COMPONENTS nowide
   CONFIG)
 

--- a/acprep
+++ b/acprep
@@ -507,7 +507,7 @@ class PrepareBuild(CommandLineApp):
                     'brew', 'install',
                     'cmake', 'ninja',
                     'mpfr', 'gmp',
-                    'gpgme',
+                    'gpgme', 'gpgmepp',
                 ] + BoostInfo().dependencies('darwin-homebrew', self.options.python)
                 self.log.info('Executing: ' + ' '.join(packages))
                 self.execute(*packages)


### PR DESCRIPTION
In the upcoming Boost 1.89.0 release, Boost.System stub has been removed (https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3) which causes CMake error:

```
CMake Error at /opt/homebrew/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake
```

I noticed this while testing 1.89.0.beta1 in Homebrew https://github.com/Homebrew/homebrew-core/pull/233031.

Since master currently requires a minimum of 1.72, it should be safe to remove `system` which was made into a stub back in 1.69[^1]. See `https://github.com/boostorg/system/issues/132#issuecomment-3146378680`

[^1]: https://www.boost.org/doc/libs/1_69_0/libs/system/doc/html/system.html#changes_in_boost_1_69