### PR TITLE
gpgme: Avoid use of deprecated asString

### DIFF
--- a/src/gpgme.cc
+++ b/src/gpgme.cc
@@ -149,7 +149,13 @@ shared_ptr<Data> decrypted_stream_t::decrypt(shared_ptr<Data> enc_d) {
 
     auto res = ctx->decrypt(*enc_d.get(), *dec_d.get());
     if (res.error())
-      throw_(runtime_error, _f("Decryption error: %1%: %2%") % res.error().source() % res.error().asString());
+      throw_(runtime_error, _f("Decryption error: %1%: %2%") % res.error().source() %
+      #if GPGME_VERSION_NUMBER >= 0x011800
+        res.error().asStdString()
+      #else
+        res.error().asString()
+      #endif
+      );
   }
   return dec_d;
 }
@@ -157,7 +163,13 @@ shared_ptr<Data> decrypted_stream_t::decrypt(shared_ptr<Data> enc_d) {
 static inline void init_lib() {
   auto err = GpgME::initializeLibrary(0);
   if (err.code() != GPG_ERR_NO_ERROR)
-    throw_(runtime_error, _f("%1%: %2%") % err.source() % err.asString());
+    throw_(runtime_error, _f("%1%: %2%") % err.source() %
+    #if GPGME_VERSION_NUMBER >= 0x011800
+        err.asStdString()
+    #else
+        err.asString()
+    #endif
+    );
 }
 
 istream* decrypted_stream_t::open_stream(const path& filename) {


### PR DESCRIPTION
Just a minor clean-up to avoid use of [deprecated `asString`](https://github.com/gpg/gpgmepp/blob/cd13d4b00cd19d723574acf843abee95111070fb/src/error.h#L50-L53).
We could also update the gpgme dependency requirement to at least gpgme 1.24.0 (released Nov 2024) and always use `asStdString`.

What to people think?