### PR TITLE
gpgme: Replace deprecated asString with asStdString

### DIFF
--- a/src/gpgme.cc
+++ b/src/gpgme.cc
@@ -149,7 +149,7 @@ shared_ptr<Data> decrypted_stream_t::decrypt(shared_ptr<Data> enc_d) {
 
     auto res = ctx->decrypt(*enc_d.get(), *dec_d.get());
     if (res.error())
-      throw_(runtime_error, _f("Decryption error: %1%: %2%") % res.error().source() % res.error().asString());
+      throw_(runtime_error, _f("Decryption error: %1%: %2%") % res.error().source() % res.error().asStdString());
   }
   return dec_d;
 }
@@ -157,7 +157,7 @@ shared_ptr<Data> decrypted_stream_t::decrypt(shared_ptr<Data> enc_d) {
 static inline void init_lib() {
   auto err = GpgME::initializeLibrary(0);
   if (err.code() != GPG_ERR_NO_ERROR)
-    throw_(runtime_error, _f("%1%: %2%") % err.source() % err.asString());
+    throw_(runtime_error, _f("%1%: %2%") % err.source() % err.asStdString());
 }
 
 istream* decrypted_stream_t::open_stream(const path& filename) {


### PR DESCRIPTION
## Summary
- Replace deprecated `asString()` calls with `asStdString()` in src/gpgme.cc
- Avoids use of deprecated gpgme API methods
- Maintains compatibility with current gpgme versions

## Background
The `asString()` method in gpgme has been [deprecated](https://github.com/gpg/gpgmepp/blob/cd13d4b00cd19d723574acf843abee95111070fb/src/error.h#L50-L53) in favor of `asStdString()`. This PR updates the code to use the non-deprecated method.

## Test plan
- [x] Built successfully with `./acprep update`
- [x] All tests pass (429/429 tests passed)
- [x] No functional changes, only API method update

Fixes #2434

🤖 Generated with [Claude Code](https://claude.ai/code)