### PR TITLE
Fix non-deterministic pricedb output (fixes #1783)

### DIFF
--- a/src/iterators.cc
+++ b/src/iterators.cc
@@ -138,7 +138,12 @@ void posts_commodities_iterator::reset(journal_t& journal)
 {
   journal_posts.reset(journal);
 
-  std::set<commodity_t *> commodities;
+  struct commodity_symbol_compare {
+    bool operator()(const commodity_t* a, const commodity_t* b) const {
+      return a->symbol() < b->symbol();
+    }
+  };
+  std::set<commodity_t *, commodity_symbol_compare> commodities;
 
   while (const post_t * post = *journal_posts++) {
     commodity_t& comm(post->amount.commodity());
@@ -151,6 +156,11 @@ void posts_commodities_iterator::reset(journal_t& journal)
     comm->map_prices
       (create_price_xact(journal, journal.master->find_account(comm->symbol()),
                          temps, xact_temps));
+
+  // Sort transactions by date to ensure deterministic output
+  xact_temps.sort([](const xact_t* a, const xact_t* b) {
+    return a->date() < b->date();
+  });
 
   xacts.reset(xact_temps.begin(), xact_temps.end());
 


### PR DESCRIPTION
## Summary
- Fixed non-deterministic output from the `pricedb` command that was causing test failures
- Resolves issue #1783 where `BaselineTest_cmd-pricedb` would intermittently fail

## Problem
The `pricedb` command was producing output in non-deterministic order because:
1. Commodities were stored in a `std::set` sorted by pointer address, which varies between program runs
2. Price transactions were not sorted by date, causing prices to be grouped by commodity rather than chronologically ordered

## Solution
1. Added a custom comparator to sort commodities by their symbol instead of pointer address
2. Added sorting of price transactions by date before outputting

This ensures the `pricedb` command always outputs prices in chronological order, making the test results deterministic.

## Test plan
- [x] Fixed test `BaselineTest_cmd-pricedb` now passes consistently
- [x] Ran the test 10 times in a row to verify determinism
- [x] Full test suite passes (435 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)