### PR TITLE
Bump required Python version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(Required_Boost_Version 1.72)
 set(Required_Gmp_Version 6.1.2)
 set(Required_Mpfr_Version 4.0.2)
 set(Required_Icu_Version 63)
-set(Required_Python_Version 3.9)
+set(Required_Python_Version 3.10)
 set(Required_Gpgmepp_Version 1.13.1)
 
 cmake_minimum_required(VERSION ${Required_CMake_Version})

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Dependency  | Version (or greater)
 [ICU]       | 63 _optional_
 [gettext]   | 0.17 _optional_
 [libedit]   | 20090111-3.0 _optional_
-[Python]    | 3.9 _optional_
+[Python]    | 3.10 _optional_
 [Gpgmepp]   | 1.13.1 _optional_
 [doxygen]   | 1.9.5 _optional_, for `make docs`
 [graphviz]  | 2.20.3 _optional_, for `make docs`

--- a/acprep
+++ b/acprep
@@ -58,7 +58,7 @@ class BoostInfo(object):
             return [ 'boost' ] + ([ 'boost-python3' ] if python else [])
 
         if system in ['darwin-macports']:
-            return [ 'boost-jam', 'boost' ] + ([ '+python37' ] if python else [])
+            return [ 'boost-jam', 'boost' ] + ([ '+python310' ] if python else [])
 
         if system in ['centos']:
             return [ 'boost-devel' ]
@@ -489,7 +489,7 @@ class PrepareBuild(CommandLineApp):
                 packages = [
                     'sudo', 'port', 'install', '-f',
                     'automake', 'autoconf', 'libtool',
-                    'python37',
+                    'python310',
                     'libiconv',
                     'zlib',
                     'gmp', 'mpfr',


### PR DESCRIPTION
With official [support for Python 3.9 ending around October 2025](https://www.python.org/downloads/) I think it's feasible to bump the minimum required version of Python to 3.10.