### PR TITLE
Address implicit-exception-spec-mismatch warning

### DIFF
--- a/src/utils.cc
+++ b/src/utils.cc
@@ -241,12 +241,12 @@ void * operator new[](std::size_t size) {
     ledger::trace_new_func(ptr, "new[]", size);
   return ptr;
 }
-void   operator delete(void * ptr) {
+void   operator delete(void * ptr) noexcept {
   if (DO_VERIFY() && ledger::memory_tracing_active)
     ledger::trace_delete_func(ptr, "new");
   std::free(ptr);
 }
-void   operator delete[](void * ptr) {
+void   operator delete[](void * ptr) noexcept {
   if (DO_VERIFY() && ledger::memory_tracing_active)
     ledger::trace_delete_func(ptr, "new[]");
   std::free(ptr);


### PR DESCRIPTION
Address the following warnings during compilation:

```
ledger/src/utils.cc:244:8: warning: function previously declared with an explicit exception specification
 redeclared with an implicit exception specification [-Wimplicit-exception-spec-mismatch]
  244 | void   operator delete(void * ptr) {
      |        ^
/nix/store/3dwjv57wm7w0dl8fqz4x9dczzflwsny4-libcxx-19.1.7-dev/include/c++/v1/new:209:35: note: previous declaration is here
  209 | _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p) _NOEXCEPT;
      |                                   ^
/Users/afh/Developer/ledger/src/utils.cc:249:8: warning: function previously declared with an explicit exception specification
 redeclared with an implicit exception specification [-Wimplicit-exception-spec-mismatch]
  249 | void   operator delete[](void * ptr) {
      |        ^
/nix/store/3dwjv57wm7w0dl8fqz4x9dczzflwsny4-libcxx-19.1.7-dev/include/c++/v1/new:218:35: note: previous declaration is here
  218 | _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p) _NOEXCEPT;
      |    
```