### PR TITLE
Add price_point_t to python bindings

### DIFF
--- a/src/py_commodity.cc
+++ b/src/py_commodity.cc
@@ -392,6 +392,15 @@ void export_commodity()
 
     .def("valid", &commodity_t::valid)
     ;
+  class_< price_point_t > ("PricePoint")
+    .add_property("price", make_getter(&price_point_t::price),
+                  make_setter(&price_point_t::price))
+    .add_property("when", make_getter(&price_point_t::when,
+                                      return_value_policy<return_by_value>()),
+                  make_setter(&price_point_t::when,
+                              return_value_policy<return_by_value>()))
+    ;
+  register_optional_to_python<price_point_t>();
 
   class_< annotation_t > ("Annotation")
 #if 1


### PR DESCRIPTION
The function find_price in Commodity can't be used without this binding since it is the return type for this function.