### PR TITLE
Fix C++ warnings, add default assignment operators

### DIFF
--- a/src/account.h
+++ b/src/account.h
@@ -218,6 +218,7 @@ public:
       {
         TRACE_CTOR(account_t::xdata_t::details_t, "copy");
       }
+      details_t& operator=(const details_t&) = default;
       ~details_t() throw() {
         TRACE_DTOR(account_t::xdata_t::details_t);
       }

--- a/src/annotate.h
+++ b/src/annotate.h
@@ -133,6 +133,7 @@ struct keep_details_t
       keep_tag(other.keep_tag), only_actuals(other.only_actuals) {
     TRACE_CTOR(keep_details_t, "copy");
   }
+  keep_details_t& operator=(const keep_details_t&) = default;
   ~keep_details_t() throw() {
     TRACE_DTOR(keep_details_t);
   }

--- a/src/draft.cc
+++ b/src/draft.cc
@@ -281,8 +281,8 @@ xact_t * draft_t::insert(journal_t& journal)
     
     // Check if the date string contains a year (has at least 2 slashes or a 4-digit year)
     size_t slash_count = std::count(date_str.begin(), date_str.end(), '/');
-    bool has_year = slash_count >= 2 || date_str.find_first_of("0123456789") != string::npos && 
-                    date_str.length() > 5; // Rough check for year presence
+    bool has_year = slash_count >= 2 || (date_str.find_first_of("0123456789") != string::npos &&
+                    date_str.length() > 5); // Rough check for year presence
     
     added->_date = parse_date(date_str);
     

--- a/src/draft.h
+++ b/src/draft.h
@@ -91,6 +91,7 @@ class draft_t : public expr_base_t<value_t>
     {
       TRACE_CTOR(xact_template_t, "copy");
     }
+    xact_template_t& operator=(const xact_template_t&) = default;
     ~xact_template_t() throw() {
       TRACE_DTOR(xact_template_t);
     }

--- a/src/mask.h
+++ b/src/mask.h
@@ -67,6 +67,7 @@ public:
   mask_t(const mask_t& m) : expr(m.expr) {
     TRACE_CTOR(mask_t, "copy");
   }
+  mask_t& operator=(const mask_t&) = default;
   ~mask_t() throw() {
     TRACE_DTOR(mask_t);
   }

--- a/src/output.cc
+++ b/src/output.cc
@@ -284,7 +284,7 @@ void report_accounts::flush()
 {
   std::ostream& out(report.output_stream);
   format_t      prepend_format;
-  std::size_t   prepend_width;
+  std::size_t   prepend_width = 0;
   bool          do_prepend_format;
 
   if ((do_prepend_format = report.HANDLED(prepend_format_))) {

--- a/src/predicate.h
+++ b/src/predicate.h
@@ -60,6 +60,7 @@ public:
     : expr_t(other), what_to_keep(other.what_to_keep) {
     TRACE_CTOR(predicate_t, "copy");
   }
+  predicate_t& operator=(const predicate_t&) = default;
   predicate_t(ptr_op_t              _ptr,
               const keep_details_t& _what_to_keep,
               scope_t *             _context = NULL)

--- a/src/query.cc
+++ b/src/query.cc
@@ -459,7 +459,7 @@ query_t::parser_t::parse_query_expr(lexer_t::token_t::kind_t tok_context,
       case lexer_t::token_t::TOK_BOLD: {
         lexer.next_token(tok_context);
 
-        kind_t kind;
+        kind_t kind = QUERY_SHOW; // Initialize with a default value
         switch (tok.kind) {
         case lexer_t::token_t::TOK_SHOW:
           kind = QUERY_SHOW;

--- a/src/query.h
+++ b/src/query.h
@@ -217,6 +217,7 @@ public:
     {
       TRACE_CTOR(query_t::lexer_t, "copy");
     }
+    lexer_t& operator=(const lexer_t&) = default;
     ~lexer_t() throw() {
       TRACE_DTOR(query_t::lexer_t);
     }

--- a/src/sha512.cc
+++ b/src/sha512.cc
@@ -382,7 +382,7 @@ void SHA512_Update(SHA512_CTX* context, void *datain, size_t len) {
 	}
 	while (len >= SHA512_BLOCK_LENGTH) {
 		/* Process as many complete blocks as we can */
-		SHA512_Transform(context, (sha2_word64*)data);
+		SHA512_Transform(context, reinterpret_cast<const sha2_word64*>(data));
 		ADDINC128(context->bitcount, SHA512_BLOCK_LENGTH << 3);
 		len -= SHA512_BLOCK_LENGTH;
 		data += SHA512_BLOCK_LENGTH;

--- a/src/timelog.h
+++ b/src/timelog.h
@@ -81,6 +81,7 @@ public:
       desc(xact.desc), note(xact.note), position(xact.position) {
     TRACE_CTOR(time_xact_t, "copy");
   }
+  time_xact_t& operator=(const time_xact_t&) = default;
   ~time_xact_t() throw() {
     TRACE_DTOR(time_xact_t);
   }

--- a/src/times.h
+++ b/src/times.h
@@ -280,6 +280,7 @@ public:
       day(other.day), wday(other.wday) {
     TRACE_CTOR(date_specifier_t, "copy");
   }
+  date_specifier_t& operator=(const date_specifier_t&) = default;
   ~date_specifier_t() throw() {
     TRACE_DTOR(date_specifier_t);
   }
@@ -472,6 +473,7 @@ public:
       since_specified(other.since_specified) {
     TRACE_CTOR(date_interval_t, "copy");
   }
+  date_interval_t& operator=(const date_interval_t&) = default;
   ~date_interval_t() throw() {
     TRACE_DTOR(date_interval_t);
   }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -246,7 +246,17 @@ void   operator delete(void * ptr) noexcept {
     ledger::trace_delete_func(ptr, "new");
   std::free(ptr);
 }
+void   operator delete(void * ptr, std::size_t) noexcept {
+  if (DO_VERIFY() && ledger::memory_tracing_active)
+    ledger::trace_delete_func(ptr, "new");
+  std::free(ptr);
+}
 void   operator delete[](void * ptr) noexcept {
+  if (DO_VERIFY() && ledger::memory_tracing_active)
+    ledger::trace_delete_func(ptr, "new[]");
+  std::free(ptr);
+}
+void   operator delete[](void * ptr, std::size_t) noexcept {
   if (DO_VERIFY() && ledger::memory_tracing_active)
     ledger::trace_delete_func(ptr, "new[]");
   std::free(ptr);

--- a/src/xact.cc
+++ b/src/xact.cc
@@ -661,7 +661,7 @@ string xact_t::hash(string nonce, hash_type_t hash_type) const {
   unsigned char data[128];
   string repr_str(repr.str());
 
-  SHA512((void *)repr_str.c_str(), repr_str.length(), data);
+  SHA512(const_cast<char*>(repr_str.c_str()), repr_str.length(), data);
 
   return bufferToHex(
     data, hash_type == HASH_SHA512 ? 64 : 32 /*SHA512_DIGEST_LENGTH*/);


### PR DESCRIPTION
- **src/utils.cc**: Add sized delete operators (`operator delete(void*, size_t)` and `operator delete[](void*, size_t)`) to comply with C++14/17 requirements for matching allocation/deallocation functions when using sized deallocation

- **src/account.h**: Add default copy assignment operator to `account_t::xdata_t::details_t` to match existing copy constructor

- **src/annotate.h**: Add default copy assignment operator to `keep_details_t` to match existing copy constructor

- **src/draft.h**: Add default copy assignment operator to `xact_template_t` to match existing copy constructor

- **src/mask.h**: Add default copy assignment operator to `mask_t` to match existing copy constructor

- **src/predicate.h**: Add default copy assignment operator to `predicate_t` to match existing copy constructor

- **src/query.h**: Add default copy assignment operator to `query_t::lexer_t` to match existing copy constructor

- **src/timelog.h**: Add default copy assignment operator to `time_xact_t` to match existing copy constructor

- **src/times.h**: Add default copy assignment operators to `date_specifier_t` and `date_interval_t` to match existing copy constructors

- **src/draft.cc**: Fix operator precedence warning by adding parentheses around `&&` expression in compound condition with `||`

- **src/output.cc**: Initialize `prepend_width` variable to 0 to fix uninitialized variable warning

- **src/query.cc**: Initialize `kind` variable with default value `QUERY_SHOW` to fix potentially uninitialized variable warning

- **src/sha512.cc**: Replace C-style cast with `reinterpret_cast` for proper type conversion to `const sha2_word64*`

- **src/xact.cc**: Use `const_cast` instead of C-style cast when passing string data to SHA512 function that requires non-const pointer