### PR TITLE
Add regression test for stock split with lot notation (#1784)

### DIFF
--- a/test/regress/1784.test
+++ b/test/regress/1784.test
@@ -1,0 +1,53 @@
+; Test for issue #1784 - Stock split with lot notation
+;
+; This test documents the correct way to record stock splits using lot notation.
+; In a stock split, the total cost basis must be preserved - the per-share cost
+; changes inversely to the split ratio.
+;
+; Example: 4:1 split of 7 shares at 40 EUR each
+; - Before: 7 shares at 40 EUR = 280 EUR total cost basis
+; - After: 28 shares at 10 EUR = 280 EUR total cost basis (40 / 4 = 10)
+;
+; IMPORTANT: The cost basis per share must be DIVIDED by the split ratio,
+; not multiplied. Using {160.00 EUR} (40 * 4) instead of {10.00 EUR} (40 / 4)
+; is a user error and will correctly fail with "Transaction does not balance".
+
+2021-02-25 Buy shares
+    Assets:depot  7 "ABCDEF" {40.00 EUR} [2021-02-25]
+    Assets:Bank  -280.00 EUR
+
+; Correct 4:1 stock split - cost basis preserved (40/4 = 10)
+2022-08-03 Stock split 4:1
+    Assets:depot  28 "ABCDEF" {10.00 EUR} [2022-08-03]
+    Assets:depot  -7 "ABCDEF" {40.00 EUR} [2021-02-25]
+
+; Verify the balance - should have 28 shares and 280 EUR spent
+test bal
+           28 ABCDEF
+         -280.00 EUR  Assets
+         -280.00 EUR    Bank
+           28 ABCDEF    depot
+--------------------
+           28 ABCDEF
+         -280.00 EUR
+end test
+
+; Verify lot information is preserved correctly
+test bal --lots
+28 ABCDEF {10.00 EUR} [2022/08/03]
+         -280.00 EUR  Assets
+         -280.00 EUR    Bank
+28 ABCDEF {10.00 EUR} [2022/08/03]    depot
+--------------------
+28 ABCDEF {10.00 EUR} [2022/08/03]
+         -280.00 EUR
+end test
+
+; Verify the cost basis is correct for capital gains calculations
+test bal --basis
+                   0  Assets
+         -280.00 EUR    Bank
+          280.00 EUR    depot
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Add regression test documenting correct stock split syntax with lot notation
- Test verifies balance, lot information, and cost basis calculations
- Addresses confusion in issue #1784

## Context

Issue #1784 reported a "regression" where a stock split transaction failed with "Transaction does not balance". Investigation revealed this was **not a regression** but a user error - the transaction was mathematically incorrect.

In a 4:1 stock split:
- Original: 7 shares at 40 EUR = 280 EUR total cost basis
- After split: 28 shares at **10 EUR** (40 ÷ 4) = 280 EUR total

The user incorrectly used `{160.00 EUR}` (40 × 4) instead of `{10.00 EUR}` (40 ÷ 4).

## Test plan

- [x] New test passes: `ctest -R 1784`
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)