### PR TITLE
Fix --invert to work correctly with composite reports (#1908)

### DIFF
--- a/src/report.h
+++ b/src/report.h
@@ -740,7 +740,10 @@ public:
   OPTION(report_t, inject_);
 
   OPTION_(report_t, invert, DO() {
-      OTHER(amount_).on(whence, "-amount_expr");
+      OTHER(display_amount_)
+        .on(whence, "-display_amount");
+      OTHER(display_total_)
+        .on(whence, "-display_total");
     });
 
   OPTION_

--- a/test/regress/1895.test
+++ b/test/regress/1895.test
@@ -24,8 +24,10 @@ Assets:foo  10.00 EUR  10.00 EUR  10.00 EUR         10.00 EUR  10.00 EUR
 Assets:bar -10.00 EUR -10.00 EUR          0        -10.00 EUR          0
 end test
 
+; With --invert, only display_amount and display_total are negated.
+; amount_expr and total are kept unchanged for correct aggregate calculations.
 test reg --format="%(account) %10(amount) %10(amount_expr) %10(total)        %10(display_amount) %10(display_total)\n" --invert
-Assets:foo  10.00 EUR -10.00 EUR -10.00 EUR        -10.00 EUR -10.00 EUR
-Assets:bar -10.00 EUR  10.00 EUR          0         10.00 EUR          0
+Assets:foo  10.00 EUR  10.00 EUR  10.00 EUR        -10.00 EUR -10.00 EUR
+Assets:bar -10.00 EUR -10.00 EUR          0         10.00 EUR          0
 end test
 

--- a/test/regress/1908.test
+++ b/test/regress/1908.test
@@ -1,0 +1,29 @@
+; Bug #1908: --invert does not work with composite reports
+; --invert should correctly invert amounts even when combined with --collapse
+; The fix ensures --invert only affects display_amount and display_total,
+; not the intermediate amount_expr used for aggregation.
+
+2017-07-01 t1
+    Income:Sub1   -10 USD
+    Assets
+
+2019-07-01 t2
+    Income:Sub1   -100 USD
+    Income:Sub2  -1000 USD
+    Assets
+
+test register Income --invert
+17-Jul-01 t1                    Income:Sub1                  10 USD       10 USD
+19-Jul-01 t2                    Income:Sub1                 100 USD      110 USD
+                                Income:Sub2                1000 USD     1110 USD
+end test
+
+test register Income --invert --collapse
+17-Jul-01 t1                    Income:Sub1                  10 USD       10 USD
+19-Jul-01 t2                    <Total>                    1100 USD     1110 USD
+end test
+
+test register Income --collapse
+17-Jul-01 t1                    Income:Sub1                 -10 USD      -10 USD
+19-Jul-01 t2                    <Total>                   -1100 USD    -1110 USD
+end test


### PR DESCRIPTION
## Summary

- Fixed `--invert` option to work correctly with composite reports like `--collapse`, `--gains`, and `--monthly`
- Changed `--invert` to modify only `display_amount` and `display_total` instead of `amount_expr`
- Updated test for related issue #1895 to reflect new correct behavior
- Added regression test for issue #1908

## Problem

The `--invert` option was modifying `amount_expr` (the expression used for intermediate calculations), which caused incorrect results when combined with composite reports. For example:

```
$ ledger -j -f repro.ledger --invert --collapse register Income
2017-07-01 10
2019-07-01 -1100  # BUG: should be 1100
```

The intermediate filters would use the negated amounts and then aggregate them incorrectly.

## Solution

Changed `--invert` to only modify `display_amount` and `display_total` (the expressions used for final display), leaving `amount_expr` and `total_expr` unchanged. This ensures that:
- Intermediate calculations (aggregation, collapse, gains) use correct (non-negated) values
- Only the final displayed output is inverted

## Test plan

- [x] All 495 existing tests pass
- [x] New regression test for issue #1908 passes
- [x] Updated test for related issue #1895 passes
- [x] Manual verification with `--invert --collapse` shows correct results

Fixes #1908

🤖 Generated with [Claude Code](https://claude.com/claude-code)