### PR TITLE
fix: compare value of meta if given

### DIFF
--- a/src/query.cc
+++ b/src/query.cc
@@ -307,8 +307,7 @@ query_t::parser_t::parse_query_term(query_t::lexer_t::token_t::kind_t tok_contex
         assert(tok.value);
         arg2->set_value(mask_t(*tok.value));
 
-        node->set_right(expr_t::op_t::new_node(
-            expr_t::op_t::O_SEQ, expr_t::op_t::new_node(expr_t::op_t::O_CONS, arg1, arg2)));
+        node->set_right(expr_t::op_t::new_node(expr_t::op_t::O_CONS, arg1, arg2));
       } else {
         node->set_right(arg1);
       }

--- a/test/regress/783.test
+++ b/test/regress/783.test
@@ -1,0 +1,24 @@
+= %class = Booga
+    (Expenses:Electronics)    (amount)
+
+= %class=Education
+    (Expenses:Education)    (amount)
+
+2025/12/15 * Electronics
+    Assets                                   $100.00
+    Expenses
+    ; class: Booga
+
+
+2025/12/15 * Textbooks
+    Assets                                    $10.00
+    Expenses
+    ; class: Education
+
+test bal 'expenses:'
+            $-110.00  Expenses
+             $-10.00    Education
+            $-100.00    Electronics
+--------------------
+            $-110.00
+end test


### PR DESCRIPTION
The query "compiler" was previously creating an op node "has_tag( seq ( cons (name, value ) ) )" which would then get sent to the ledger::has_tag function.  This function checks the number of arguments to decide if it should compare value or not.  Because we send `seq` that's one argument always (holding some values but it's one argument), at least that's how the `args.size()` reports it.

So the solution is to pass the arguments as CONS.  

I am not 100% sure how the data model works so this is just an assumption, but it seems to work.  What is the difference between sequence and cons?

Note that this feature probably never worked.  Also, there is a difference between `%name=value` and `%name = value`.  The first will now get parsed as 

> "is there a meta with name `name` and value `value`",

 the second will get parsed as 

> "is there a tag `name` and does any note match `value` as a regex",

since the `=` shorthand is to match notes by regex (this might be unfortunate choice of operator).

Fixes #783 
