### PR TITLE
build: setup clangd for lsp support

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,5 @@
+CompileFlags:
+  CompilationDatabase: "."
+  Remove:
+    - "-include"
+    - "*cmake_pch.hxx"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(Required_Icu_Version 63)
 set(Required_Python_Version 3.10)
 set(Required_Gpgmepp_Version 1.13.1)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 cmake_minimum_required(VERSION ${Required_CMake_Version})
 
 option(CMAKE_BUILD_TYPE "CMake Build type" "Release")


### PR DESCRIPTION
Setup clangd so I can use LSP for the project.

To use it with Emacs' `lsp-mode` one also needs to add `--query-driver=/usr/bin/c++,/usr/bin/g++,/usr/bin/g++-*` to `lsp-clients-clangd-args` (not sure about eglot).

I see that in the `acprep` "setup for john" you already add the option to generate the compile commands, so if you want I can also remove it from there if we will just always generate it (is there any downside anyway?).

With this setup + the `lsp-client-clangd-args` it seems to "just work" in my Emacs.