### PR TITLE
docs: add documentation and tests for named auto-xact directives (PR #2512)

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -3875,6 +3875,8 @@ transaction.
 * State flags::
 * Effective Dates::
 * Periodic Transactions::
+* Named Automated Transactions::
+* Controlling Automated Transactions::
 * Concrete Example of Automated Transactions::
 @end menu
 
@@ -4154,7 +4156,7 @@ Note that the @option{--aux-date} option is an alias for
 @option{--effective}; for a brief explanation of auxiliary date
 @pxref{Auxiliary dates}.
 
-@node Periodic Transactions, Concrete Example of Automated Transactions, Effective Dates, Automated Transactions
+@node Periodic Transactions, Named Automated Transactions, Effective Dates, Automated Transactions
 @subsection Periodic Transactions
 @findex --budget
 
@@ -4164,7 +4166,142 @@ forecasting only, they have no effect without the @option{--budget}
 option specified.  For examples and details, @pxref{Budgeting and
 Forecasting}.
 
-@node Concrete Example of Automated Transactions,  , Periodic Transactions, Automated Transactions
+@node Named Automated Transactions, Controlling Automated Transactions, Periodic Transactions, Automated Transactions
+@subsection Named Automated Transactions
+
+Automated transactions can be given names using the @samp{::} syntax.
+This allows you to reference and control them later in the journal file.
+A named automated transaction is defined by placing a name (optionally
+quoted) between the @samp{=} sign and the @samp{::} separator, followed
+by the predicate:
+
+@smallexample @c input:validate
+= "tithe" :: /^Income:/
+    (Liabilities:Tithe)                   0.10
+@end smallexample
+
+This defines an automated transaction named @samp{tithe} that applies
+to any posting matching @samp{/^Income:/}.
+
+Names can be specified with or without quotes:
+
+@smallexample @c input:validate
+= savings :: /^Income:/
+    (Assets:Savings)                      0.05
+
+= "vacation fund" :: /^Income:Bonus/
+    (Assets:Vacation)                     0.25
+@end smallexample
+
+Quotes (single @samp{'}, double @samp{"}, or forward slash @samp{/})
+are required if the name contains spaces or special characters.
+
+Named automated transactions must have unique names.  Attempting to
+define two automated transactions with the same name will result in
+a parse error.
+
+@node Controlling Automated Transactions, Concrete Example of Automated Transactions, Named Automated Transactions, Automated Transactions
+@subsection Controlling Automated Transactions
+
+Named automated transactions can be controlled using special directives
+that enable, disable, or delete them.  These directives use the same
+@samp{=} prefix as automated transactions but are followed by a name
+pattern and a command.
+
+@subsubsection Disabling Automated Transactions
+
+To temporarily disable a named automated transaction, use the
+@samp{disable} command:
+
+@smallexample @c input:validate
+= "tithe" :: /^Income:/
+    (Liabilities:Tithe)                   0.10
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+= tithe disable
+
+2024-02-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+@end smallexample
+
+In this example, the first salary transaction will have the tithe
+automated transaction applied, but after the @samp{disable} directive,
+the second salary transaction will not.
+
+@subsubsection Enabling Automated Transactions
+
+To re-enable a previously disabled automated transaction, use the
+@samp{enable} command:
+
+@smallexample @c input:validate
+= savings :: /^Income:/
+    (Assets:Savings)                      0.10
+
+= savings disable
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+= savings enable
+
+2024-02-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+@end smallexample
+
+The first salary will not have savings applied (disabled), but the
+second one will (re-enabled).
+
+@subsubsection Deleting Automated Transactions
+
+To permanently remove a named automated transaction, use the
+@samp{delete} command:
+
+@smallexample @c input:validate
+= "temp-tax" :: /^Income:/
+    (Expenses:Tax:Estimate)               0.25
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+= temp-tax delete
+
+2024-02-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+@end smallexample
+
+After deletion, the automated transaction cannot be re-enabled.
+
+@subsubsection Pattern Matching
+
+The name used in enable, disable, and delete commands is treated as
+a pattern (regular expression).  This allows you to control multiple
+automated transactions at once:
+
+@smallexample @c input:validate
+= "tax:federal" :: /^Income:/
+    (Expenses:Tax:Federal)                0.22
+
+= "tax:state" :: /^Income:/
+    (Expenses:Tax:State)                  0.05
+
+= "tax:.*" disable
+@end smallexample
+
+This disables both @samp{tax:federal} and @samp{tax:state} automated
+transactions with a single command.
+
+If a command's pattern does not match any automated transaction,
+a warning is issued.
+
+@node Concrete Example of Automated Transactions,  , Controlling Automated Transactions, Automated Transactions
 @subsection Concrete Example of Automated Transactions
 
 @subsubsection Tithing

--- a/test/regress/2512_delete_autoxact.test
+++ b/test/regress/2512_delete_autoxact.test
@@ -1,0 +1,20 @@
+; Test for PR #2512: Delete automated transactions
+; https://github.com/ledger/ledger/pull/2512
+; Test that delete command removes auto xact permanently
+
+= "temp-tax" :: /^Income:/
+    (Expenses:Tax:Estimate)               0.25
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+= temp-tax delete
+
+2024-02-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+test bal Expenses:Tax
+                $250  Expenses:Tax:Estimate
+end test

--- a/test/regress/2512_disable_autoxact.test
+++ b/test/regress/2512_disable_autoxact.test
@@ -1,0 +1,20 @@
+; Test for PR #2512: Disable automated transactions
+; https://github.com/ledger/ledger/pull/2512
+; Test that disable command prevents auto xact from being applied
+
+= "tithe" :: /^Income:/
+    (Liabilities:Tithe)                   0.10
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+= tithe disable
+
+2024-02-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+test bal Liabilities:Tithe
+                $100  Liabilities:Tithe
+end test

--- a/test/regress/2512_duplicate_name_fail.test
+++ b/test/regress/2512_duplicate_name_fail.test
@@ -1,0 +1,21 @@
+; Test for PR #2512: Duplicate name error
+; https://github.com/ledger/ledger/pull/2512
+; Test that duplicate names produce an error
+
+= "savings" :: /^Income:/
+    (Assets:Savings)                      0.10
+
+= "savings" :: /^Income:Bonus/
+    (Assets:Savings)                      0.05
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 8:
+While parsing automated transaction:
+> = "savings" :: /^Income:Bonus/
+Error: Automated transaction with name 'savings' already exists
+end test

--- a/test/regress/2512_enable_autoxact.test
+++ b/test/regress/2512_enable_autoxact.test
@@ -1,0 +1,22 @@
+; Test for PR #2512: Enable automated transactions
+; https://github.com/ledger/ledger/pull/2512
+; Test that enable command re-enables a previously disabled auto xact
+
+= "savings" :: /^Income:/
+    (Assets:Savings)                      0.10
+
+= savings disable
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+= savings enable
+
+2024-02-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+test bal Assets:Savings
+                $100  Assets:Savings
+end test

--- a/test/regress/2512_named_autoxact.test
+++ b/test/regress/2512_named_autoxact.test
@@ -1,0 +1,18 @@
+; Test for PR #2512: Named automated transactions
+; https://github.com/ledger/ledger/pull/2512
+; Basic test for naming an automated transaction using :: syntax
+
+= "savings" :: /^Income:/
+    (Assets:Savings)                      0.10
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+2024-01-15 Bonus
+    Income:Bonus                          $500
+    Assets:Checking
+
+test bal Assets:Savings
+                $150  Assets:Savings
+end test

--- a/test/regress/2512_pattern_match.test
+++ b/test/regress/2512_pattern_match.test
@@ -1,0 +1,27 @@
+; Test for PR #2512: Pattern matching for automated transaction commands
+; https://github.com/ledger/ledger/pull/2512
+; Test that pattern matching works for enable/disable commands
+
+= "tax:federal" :: /^Income:/
+    (Expenses:Tax:Federal)                0.22
+
+= "tax:state" :: /^Income:/
+    (Expenses:Tax:State)                  0.05
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+= "tax:.*" disable
+
+2024-02-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+test bal Expenses:Tax
+                $270  Expenses:Tax
+                $220    Federal
+                 $50    State
+--------------------
+                $270
+end test

--- a/test/regress/2512_quoted_name.test
+++ b/test/regress/2512_quoted_name.test
@@ -1,0 +1,20 @@
+; Test for PR #2512: Quoted names with spaces
+; https://github.com/ledger/ledger/pull/2512
+; Test that quoted names with spaces work correctly
+
+= "vacation fund" :: /^Income:Bonus/
+    (Assets:Vacation)                     0.25
+
+2024-01-01 Bonus
+    Income:Bonus                         $1000
+    Assets:Checking
+
+= "vacation fund" disable
+
+2024-06-01 Bonus
+    Income:Bonus                         $1000
+    Assets:Checking
+
+test bal Assets:Vacation
+                $250  Assets:Vacation
+end test

--- a/test/regress/2512_unquoted_name.test
+++ b/test/regress/2512_unquoted_name.test
@@ -1,0 +1,14 @@
+; Test for PR #2512: Unquoted names
+; https://github.com/ledger/ledger/pull/2512
+; Test that unquoted (bare) names work correctly
+
+= tithe :: /^Income:/
+    (Liabilities:Tithe)                   0.10
+
+2024-01-01 Salary
+    Income:Salary                        $1000
+    Assets:Checking
+
+test bal Liabilities:Tithe
+                $100  Liabilities:Tithe
+end test


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and regression tests for the new features introduced in PR #2512:

- **Documentation** in `doc/ledger3.texi`:
  - New "Named Automated Transactions" section explaining the `::` syntax for naming auto-xacts
  - New "Controlling Automated Transactions" section covering `enable`, `disable`, and `delete` commands
  - Pattern matching syntax for controlling multiple auto-xacts at once

- **Regression Tests** (8 new test files):
  - `2512_named_autoxact.test` - Basic named auto-xact functionality
  - `2512_disable_autoxact.test` - Disable command
  - `2512_enable_autoxact.test` - Enable command for re-enabling
  - `2512_delete_autoxact.test` - Delete command
  - `2512_pattern_match.test` - Pattern matching for commands
  - `2512_quoted_name.test` - Quoted names with spaces
  - `2512_unquoted_name.test` - Unquoted bare names
  - `2512_duplicate_name_fail.test` - Duplicate name error handling

All 8 tests pass locally.

## Code Review Notes

The cpp-pro agent review of PR #2512 identified a few items to note:

1. **Missing `break` in switch statement** - The quoted string parsing case falls through to `default`
2. **Uninitialized `enabled` member in copy constructor** - Should be initialized from `other.enabled`
3. **Memory ownership** - The delete command erases pointers but ownership semantics should be verified

These are recommendations for the main PR (#2512) to address.

## Test plan

- [x] Run `ctest -R 2512` - all 8 tests pass
- [x] Documentation builds correctly (texi format validated)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)