### PR TITLE
docs: escape cost @ and realign the amounts

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -3674,9 +3674,9 @@ source commodity and the destination commodity:
 
 @smallexample
 2025-04-12 Coinbase
-    Assets:Coinbase       -100 BTC @{$100@} @ 2 ETH @{$40@} [2025-04-12]
-    Assets:Coinbase        200 ETH @{$40@} [2025-04-12]
-    Expenses:Capital Loss  $2,000.00
+    Assets:Coinbase          -100 BTC @{$100@} @@ 2 ETH @{$40@} [2025-04-12]
+    Assets:Coinbase           200 ETH @{$40@} [2025-04-12]
+    Expenses:Capital Loss  $2,000
 @end smallexample
 
 In this example:
@@ -3702,9 +3702,9 @@ You can also sell the second commodity later and track its gain/loss:
 
 @smallexample
 2025-04-13 Coinbase
-    Assets:Coinbase       -200 ETH @{$40@} [2025-04-12] @ $50
-    Assets:Coinbase          $10,000
-    Income:Capital Gain   $-2,000.00
+    Assets:Coinbase          -200 ETH @{$40@} [2025-04-12] @@ $50
+    Assets:Coinbase       $10,000
+    Income:Capital Gain   $-2,000
 @end smallexample
 
 This approach provides full end-to-end tracking of your investments


### PR DESCRIPTION
This is how it's currently rendered

* missing `@` for cost
* inconsistent dollar amount rendering (sometimes with decimals, sometimes without, not aligned)

This PR addresses both issues.

<img width="1141" height="822" alt="image" src="https://github.com/user-attachments/assets/11e25453-cc35-4233-9cd0-45a6597cee66" />

# After fix 

(styles not rendering, but the text is corrected)

<img width="1226" height="626" alt="image" src="https://github.com/user-attachments/assets/994f0be3-17a8-443b-af89-ef193fc1655e" />
