### PR TITLE
fix: specifying price "not per unit" does not change the commodity price

### DIFF
--- a/src/annotate.h
+++ b/src/annotate.h
@@ -58,7 +58,7 @@ struct annotation_t : public flags::supports_flags<>, public equality_comparable
 #define ANNOTATION_VALUE_EXPR_CALCULATED 0x20
 
 // Mask for flags that affect semantic equality (not just metadata)
-#define ANNOTATION_SEMANTIC_FLAGS (ANNOTATION_PRICE_FIXATED | ANNOTATION_PRICE_NOT_PER_UNIT)
+#define ANNOTATION_SEMANTIC_FLAGS (ANNOTATION_PRICE_FIXATED)
 
   optional<amount_t> price;
   optional<date_t> date;

--- a/test/regress/2498.test
+++ b/test/regress/2498.test
@@ -1,0 +1,14 @@
+2025/12/13 * Food
+    expenses                                  100.00 Kc {{=5.00 EUR}}
+    assets
+
+2025/12/13 * Food
+    expenses                                  200.00 Kc {=0.05 EUR}
+    assets
+
+test bal --lots
+-300.00 Kc {=EUR0.05}  assets
+300.00 Kc {=EUR0.05}  expenses
+--------------------
+                   0
+end test


### PR DESCRIPTION
Related to #2498 (see comments there)