### PR TITLE
fix: set parse context during CSV convert to prevent segfault with --strict

### DIFF
--- a/test/regress/GH2521.dat
+++ b/test/regress/GH2521.dat
@@ -1,0 +1,3 @@
+date,amount,payee,posting_type
+01/02/2024,-45.67,GROCERY STORE,DEBIT
+01/05/2024,-4.50,COFFEE SHOP,DEBIT

--- a/test/regress/GH2521.test
+++ b/test/regress/GH2521.test
@@ -1,0 +1,19 @@
+; Regression test for GitHub issue #2521
+; CSV convert command segfaults with --strict when unknown metadata columns exist
+; The issue was that journal.current_context was not set during CSV parsing,
+; causing a null pointer dereference when --strict triggers metadata warnings.
+
+test -f /dev/null --strict --input-date-format '%m/%d/%Y' convert test/regress/GH2521.dat
+2024/01/02 * GROCERY STORE
+    ; posting_type: DEBIT
+    Expenses:Unknown                          -45.67
+    Equity:Unknown
+
+2024/01/05 * COFFEE SHOP
+    ; posting_type: DEBIT
+    Expenses:Unknown                            -4.5
+    Equity:Unknown
+__ERROR__
+Warning: "$sourcepath/test/regress/GH2521.dat", line 0: Unknown metadata tag 'posting_type'
+Warning: "$sourcepath/test/regress/GH2521.dat", line 0: Unknown metadata tag 'posting_type'
+end test


### PR DESCRIPTION
## Summary
- Fixes segmentation fault when using `convert` command with `--strict` and CSV files containing unknown metadata columns
- Sets `context.scope` to provide valid scope for metadata validation
- Uses RAII guard to properly set/restore `journal.current_context` during CSV parsing

## Root Cause
When converting CSV files with `--strict` enabled, `register_metadata()` would try to emit warnings about unknown tags by calling `current_context->warning()`. However, `journal.current_context` was never set during CSV parsing (unlike in the textual parser), causing a null pointer dereference.

## Test plan
- [x] Added regression test `GH2521.test` that exercises `convert --strict` with unknown metadata columns
- [x] All 511 tests pass
- [x] Manual verification: command no longer segfaults and properly emits warnings

Fixes #2521

🤖 Generated with [Claude Code](https://claude.ai/code)