### PR TITLE
generate: fix generate command by priming generate_posts_iterator

### DIFF
--- a/src/generate.cc
+++ b/src/generate.cc
@@ -65,6 +65,7 @@ generate_posts_iterator::generate_posts_iterator(session_t& _session, unsigned i
   next_aux_date = parse_date(next_aux_date_buf.str());
 
   TRACE_CTOR(generate_posts_iterator, "bool");
+  increment();
 }
 
 void generate_posts_iterator::generate_string(std::ostream& out, int len, bool only_alpha) {

--- a/test/regress/1096.test
+++ b/test/regress/1096.test
@@ -1,0 +1,540 @@
+test generate --seed=54321 --head=5
+2265/07/18=1973/10/23 * (EmH) vFVI:xG30XvQM:06c42Zs:54 w5CKa23F
+    [Ks4s6fil7VLZu46R]                       iK 9943.07 @ 8460.56 QhdSt
+    w00Ub6KYA6                                8524.55 b @@ 760.671 gv
+    [j 99kK4b84p1V:syP16:oW0lV6t 35T:g2N]     Lv5237.81
+    [rK2:64G:F7:L:OV9R1:DE:qps7zwA:g0q:H5F]  -2136.06 K @ 1149.34 EhsHXu
+    BYl7gZDk735F0O
+    ; uHex
+
+2265/07/21 * (wY56) z463743:JNnz5:B3
+    V:2 5DCf                              wbg -6037.73 @@ 7341.07 pWucVV
+    ; M5:65FL0sR99trF 7wrv5:M:dMPUVa0TGjcR
+    (G9:EEzZXWE3 d:c0iG90akAH c:H)        mlKw -5770.67 {KK9874.97} [1982/08/22] @@ YtWCP 9552.33
+    ; o3 806n33OT1B433762V9:Lpox5Hf75qpT2SZoK2
+    (O:fY8KV8738WQ:0YO6:T:JL33S11H:k)       Xwt9820.16 @ XCR2239.25
+    (Bu:o6FUXJ:wzwV:F7xQ05eruC4Rr0nt1AdmG)  -5436.37 k @ BMiDZ 6347.65
+    S2V82JvNYX:369M2B98WFZWrN             mNcg-5755.08
+    ; hsJEoi t:lg2rh5:RdpbND 9ickl
+    (T65J71d66TR7 cn:R)                   -2816.21 KhzbHK @ hgRm 5599.42
+    F4R1jxU48bB:C80Bo1lq8ufsafMmCZRF322
+
+2265/07/24=1973/10/27 ! (QQ st7) tmB5 Eb22Y5lQG:dXvN321WH4GNke 36F4
+    ; MWj1h6:p4n n69N40 xYz
+    (O:9Kke694j:GO:eU3xrU l:0Mc5)          -7296.78W
+    (X)                                 7025.75Vpj [2236/03/01]
+
+2265/07/28=1973/10/31 (Rb70tO) q3
+    C:nsava7cpSA74 Y1s5Ln7Ds            YEZC-4537.19
+    [DZP0jhs8s:T2CofWutSSHP2]           uiiu -7388.53
+    [R5:4ZLj PDc:goY2u t:wb2pty9r19:Fw]  nw3132.73 {QwZO236.783}
+    (i8CUGX4Ptq6q 5vj:TbY64yYp5AB)       nyWK7552.45 @ IGcFQw574.603
+    W9Q5Hx4e 5yUZF8 2j9q
+    ; lQXldz4eeYpD1MLj:8fz8LaE
+
+2265/08/03=1973/11/02 * (i6) x1iK
+    ; sDGy:K5eP5I12x9XJ
+    [kOc1 7Jp2C45sF40uQL1abS]                -542.422 J @ 9123.26EQv
+    ; pStiRmZs5CgqM1Tlfv 63Le4:hTq7DMQ
+    iK 0YGgx:hp:UagIIi:X:bv:l T6m5g        -5973.96 xKf {ud9047.29} @@ 4456.36 SoQEqp
+    BAU6xj:QYE49Idc4PO:s5yBBT91Ja66ju05 B u
+    ; Hf7:829:7i r6e7
+end test
+
+test generate --seed=54321
+2265/07/18=1973/10/23 * (EmH) vFVI:xG30XvQM:06c42Zs:54 w5CKa23F
+    [Ks4s6fil7VLZu46R]                       iK 9943.07 @ 8460.56 QhdSt
+    w00Ub6KYA6                                8524.55 b @@ 760.671 gv
+    [j 99kK4b84p1V:syP16:oW0lV6t 35T:g2N]     Lv5237.81
+    [rK2:64G:F7:L:OV9R1:DE:qps7zwA:g0q:H5F]  -2136.06 K @ 1149.34 EhsHXu
+    BYl7gZDk735F0O
+    ; uHex
+
+2265/07/21 * (wY56) z463743:JNnz5:B3
+    V:2 5DCf                              wbg -6037.73 @@ 7341.07 pWucVV
+    ; M5:65FL0sR99trF 7wrv5:M:dMPUVa0TGjcR
+    (G9:EEzZXWE3 d:c0iG90akAH c:H)        mlKw -5770.67 {KK9874.97} [1982/08/22] @@ YtWCP 9552.33
+    ; o3 806n33OT1B433762V9:Lpox5Hf75qpT2SZoK2
+    (O:fY8KV8738WQ:0YO6:T:JL33S11H:k)       Xwt9820.16 @ XCR2239.25
+    (Bu:o6FUXJ:wzwV:F7xQ05eruC4Rr0nt1AdmG)  -5436.370 k @ BMiDZ 6347.65
+    S2V82JvNYX:369M2B98WFZWrN             mNcg-5755.08
+    ; hsJEoi t:lg2rh5:RdpbND 9ickl
+    (T65J71d66TR7 cn:R)                   -2816.21 KhzbHK @ hgRm 5599.42
+    F4R1jxU48bB:C80Bo1lq8ufsafMmCZRF322
+
+2265/07/24=1973/10/27 ! (QQ st7) tmB5 Eb22Y5lQG:dXvN321WH4GNke 36F4
+    ; MWj1h6:p4n n69N40 xYz
+    (O:9Kke694j:GO:eU3xrU l:0Mc5)         -7296.78 W
+    (X)                                 7025.75Vpj [2236/03/01]
+
+2265/07/28=1973/10/31 (Rb70tO) q3
+    C:nsava7cpSA74 Y1s5Ln7Ds            YEZC-4537.19
+    [DZP0jhs8s:T2CofWutSSHP2]           uiiu -7388.53
+    [R5:4ZLj PDc:goY2u t:wb2pty9r19:Fw]  nw3132.73 {QwZO236.783}
+    (i8CUGX4Ptq6q 5vj:TbY64yYp5AB)       nyWK7552.45 @ IGcFQw574.603
+    W9Q5Hx4e 5yUZF8 2j9q
+    ; lQXldz4eeYpD1MLj:8fz8LaE
+
+2265/08/03=1973/11/02 * (i6) x1iK
+    ; sDGy:K5eP5I12x9XJ
+    [kOc1 7Jp2C45sF40uQL1abS]                -542.422 J @ 9123.26EQv
+    ; pStiRmZs5CgqM1Tlfv 63Le4:hTq7DMQ
+    iK 0YGgx:hp:UagIIi:X:bv:l T6m5g        -5973.96 xKf {ud9047.29} @@ 4456.36 SoQEqp
+    BAU6xj:QYE49Idc4PO:s5yBBT91Ja66ju05 B u
+    ; Hf7:829:7i r6e7
+
+2265/08/09=1973/11/05 ! (J) Pv7i4HeRl06NfO 5mwD:uU2H785x3G3G y1
+    ; h:v3gp
+    [vI:06U]                            jrYvho 3576.51
+    ; g3S94Q85 4tpMUiQxRU5:8MG:406B60MV
+    (x8ERrK0:no1 f8:XK4aeVve6D)         -8177.42 pswqU @ 5817upyY
+    z3Bu19dLVc:xLuU:v4Z
+    ; X1i0:HK4BraS8z1f:X0KJHd1j8
+
+2265/08/13=1973/11/06 (N:2mbh) HhyHW aZ
+    ; aVe4737UEFh2ABc
+    [BhvOu8pTz 85aHV41ON:nf31 c3CQc m3 KU60]  -9689.54 W
+    ; nBw:rXJ4881e:3Bu4:aeXy ydOz8U9
+    (j1B1B:xn:7:7EW9zsXzR6AI)               -5266.36 lxrOFd (TA)
+    ; M6b 5h S2 yO
+    rViCbpm78 n X57072Vb2nVsClmP2
+
+2265/08/16 ! (bu) Vu:A3w
+    ; Fg7Oy74xF 7:cvm Acn9V34
+    [f J:2O4nQp7NA:vc:r97boO2]                -7428.48bXlg
+    ; T63bP6pN0:aFFdx9mJ:4Hl
+    (b1h20 oX84)                              ZPEtL-1655.72 @ rGmqFK8137.04
+    ; w8:BUs4i
+    [KTA3]                                     Hce 9244.36 @@ 7049.87 M
+    ; bFq8p01wl
+    MDlt:ne:23ai4N10MipKEBWnwv nX54Jbb:TWK       9162.67 Y @@ A 618.662
+    c5:8L91kEut4O:4VKV5Kx2v:I0p4              7790.25lBcFTM @@ 4846.52 Y
+    (kcr56:xO 6Z9N r0:gOb9:WC64e9Qw5tGC0hF0jh)  -1524.24JfG @@ dOuIK 4183.68
+    ; huCzGj:170PB
+    UE
+
+2265/08/19 (o1Td) klu7041 H63:z:PidD:fyM86U0Z35p8 6CoFf
+    (uFX64kN2:D5eh:M:5OA7j)             Bo-5745.67 (DXIq)
+    (D970:2j5Gdm5LO5zZ:NZhEg45jEp)      Efukq9600.39 @@ 3207.43FzWSDz
+    (OM2Q O9Ewv:v)                      2493.23iqibk @ 2106.35 Cmm
+    ; sk8Hgs
+    [u9O:56]                             EEUO52.0402
+    mFa4cwAkl                           mJDCc 2537.24 @@ 4502.06dhj
+    ; ZRmyw89JF9M50:RkuyQeos Ha2 6
+    vcv5p                               -9834.79 sRV @ 1990.32 iOKb
+    ; C8W1j80mWJ628Hkcw98TE0
+    u3x:ehd71yld:HW5HYRSv531 K9aJ:rf6
+
+2265/08/21 ! (O) JVx2we1zkUr5JA41B 8GPcv:71vDrL1
+    ; TW:ovm088aw:J42wL s Ds
+    [geE6cjhc96:s:MF97:TK28CH676 TwC65ZXt]  -8495.44 p {X121.464}
+    gT:q                                    -3125.96et @@ cCE 129.549
+    ; ek 3sHR2 2NCjYmZZWQKZBBI
+    vo6M sr:6 bFOybo6Z Oa
+
+2265/08/25 * (Er9f6k) fHTE5ow yN l716:bZQktQ
+    ; ye8
+    (aWqi5l j)                                   uD6516.36 @ 5022.05Sohtct
+    ; U286CKkVKiS:5mxMQ5E2 lt:06B4 Uy
+    [mjxXr5PMnnr6Rbl6KXzLv1nI:Oxy7FlU3PCOtC5G]  -9320.75 qy @@ uqkbM2376.82
+    (bzyTz5c:R7v16Tgu:3fXH60ysa)              STvflw 4894.65 {TjvF0.3994831091} [2265/08/25] (Kh) @@ TjvF1955.33
+    [S dK:5a6Ic2J:Qm:gfauw 3V0f:TvnKw6]        Me -837.884
+    ; xw8k8tpi:k:SnrgetcK
+    lZacf 9JjkhE:r7aEYp20xM80x
+    ; L
+
+2265/08/30=1973/11/07 ! (Iyk) TjPapr:MzDk5hGd
+    ; faMs8 je:7DbB9Af2:Tpik7aXfJ4fXimE60dE
+    (mYGjlgM11FL:h84:p9:r:rA:vqR)        wcw 6023.88
+    ; uxW573YrqG9m u541D2GR:xOw
+    gUVx5S:1:lMUue42p:zqZ5r:L6O8        6203.43nboaQS
+    ; nI5x0i:j77om M8:0t8JfEdYFyN:887194aC:m6
+    jj14xW13nkll2nbjasK47C:W8bP:WojMu:x   4676.26 qF
+    y7                                     3409.69 a @@ UG 9679.61
+    A2m13:t3q
+
+2265/09/03 (Hn) v0 t7:NgHcC8698DMU5MDHrVb9E4
+    [Ffb6qG41]                           5711.52HRs {EFFh9352.38}
+    T v2Pv6                                -390.949nC @@ 7259.690 J
+    (Nn20WdZ:q qnKIK J XSubg2x:lI:vJ6)   WrwCt-9880.12
+    ; D
+    WB593L1cajATtI9yX31MWR6LDVutm:jm001Nd    8053.15E
+    ; n2 Ho:GnKd:9i9:56U5k45
+    i:E:J5B:1zX
+    ; Q:5
+
+2265/09/06 ! (O:cWN7) f:hX5u19q8M6dJMh:ns9q5U:h:49A63:qyZgXvb5
+    ; xYI2v4m:1Qm499L1Q Z4wi4W6
+    [pt7O3172q43m7]                     crtlIZ-3718.37 [1974/10/20]
+    ; R2:F0:Kxj8 96:85q:2bxOTi:j:mHDT7s4g1Rnb
+    [i R0QPj3:Z66TIUk4w]                 byM-9251.74
+    zAA0YHqRB5jnkCIWmmOFe
+
+2265/09/08 ! (Z:G4) jf49sT80o41:NCe buc:NF8yp5
+    (f2i:A1vm Mg0V0mX1Uyb58JD)             3184.80 W @@ 9010.93 b
+    ; rx41Ij8r xfGgsq5E:o7x2T00m:36sd 4
+    [um l:r129p sS:yB5]                 Bv 3554.12 {7835.15 x} @ 946.578Yiql
+    BkW4157lcs
+
+2265/09/10=1973/11/10 (u:0) cw04xjwW91 14TC1
+    ; aR VJL80p YTCb08WdpCGQQx7nnBfADQn
+    rcQ8mWe8lT3hXf10a:rrM6 48l:4W:tgTLPT6m08  6184.32yQSKC
+    (Rag13hJ3KKEPn:KgA64E2 896 5t2B1:0:6 E 3)  -8738.5 lyH [2231/10/04]
+    [sU3uu9]                                 -9566.91 WoiUft
+    ; U3bRO9f1X75:PGh3:5Nuz7i53:9
+    [D20Ij 9A57:9C8EeQlUHh5:38SOgu]            -7084.90 M @@ KuDq6871.69
+    ; oH7i1DLx1393T0kzYJx3AN9
+    [S3J5bJd:Re1SB]                          -6724.89 qXUwMq @@ WC 3669.28
+    TI25MpA:7w1tQX:S rTwR0o:ImT26:h          8928.29 clEd
+    ; y2Lb:1:352D6:5:jd:pq7hc0VnB2GS6is
+    A M06cN0 U6:t7q7EF0Lo2
+    ; mHw163
+
+2265/09/13=1973/11/13 * (Z) f1Vcr0
+    ; D:2sHu:8Wk
+    (C:5u dW7ES8:NOw 157mS33jCGjQ2441 2)  -8773.63 N @@ mg8762.55
+    fQg46rBJ46tjqJN 1E8                 3542.68vJ {t3666.41} [2057/02/26]
+    ; yq22xw9DH1RQ6RcZ:2f01i:R:5FNr:0
+    zUr 9sY9 3LM0gYzp:DPT3
+
+2265/09/16 * (Bc:H) F:5d:95Sc:6:16Q:0
+    (R:25JQ8Otk8s euEh1A7TauN67)             1104.8400u {6602.15l} [2150/11/15]
+    ; FqZOBf7pB08fq n
+    (G3s6434viN8J1Bjd5ZjTy2vPYQ4iz3qJ:K65U1Y)  CzdOXa4365.5
+    AU7:6:C                                  MNSciP 6475.83 @ bfQoeZ 1398.55
+    (Ec9w:W73D8x2kGe)                        qsYbm-3146.07 @ Jfdhx1159.01
+    [lXr2TJLJ8xFd3RGml cFa]                   70.7323 ecw
+    ; S:3bln
+    (OUdzhlfi:Ju0v1oUTcz7f1:175:V47)         -6055.13 KNpWS @ dpcxP 8529.74
+    Yam8YYL4:ZtlUwPM:P:LdAx12n
+    ; vAbC9J 2pLc
+
+2265/09/19 ! (yYCgoD) R112X4 9:LpQ1
+    b31i64NfZ8ZH5x053H6w2LvxF           fmkvjp -1072.38 {uITCV1453.96} [2153/09/13] @@ 9459.16oKkhmt
+    c:xVK0                              -3568.48 FrQat @ 1112.710 J
+    (nWZ5jG1O:6HlU9m6T87)                 nj 4691.98
+    (F29CUhh9X4)                          5671.37 HR
+    I0 fG
+    ; u85C320RLNoh95g7
+
+2265/09/24=1973/11/14 (X9) K9Vw:gC:6B34D5 TBN:Bgb1yB:kHo:i
+    [yVZF G]                                 3167.23 rEA
+    [A4Xsj]                                 -5701.66 YiNtDs {ThMCA7988.28} @@ REg 1912.83
+    qW1q5 430bNZ:c                          mW-5821.92 {sEkG4762.52} [1901/03/09] @ 1533.03LmAFYF
+    ; v14vuLxr3:SlMBr812vUE2fYU5qLn
+    [Gso00lSwQ11wsX39 201B01nQ2D:x00g:c:r2i]  6085.33 zGnfOu {OTdLgE4350.03}
+    lFxIti G1:n43GYo H6Lx58RL
+
+2265/09/30 (WCe) tH:84xg3:7P:n:hG 4b48 oA4WX
+    ; d2TuL2Z:cTtE1NU:nKjvi:6ii7p aI
+    xBc2Bwa8052:4a:k8YawC7R1n              4425.91sK @ 317.42 JcLM
+    ; qbIW1E4Jgf4p53n
+    mK3UE9bv036ht:2W PEm5dr 4I 6e5z     -7867.47 dykb
+    ; X07Y7824e26nO2M5n9:TWb8jT48F1MEzjJ:1y Ri
+    S 2F5zj8668uREHx8:oAbfYh
+    ; KqjS b2:pUH3Ewnkwpid2flAqW
+
+2265/10/05 ! (on) jShVHE7J07vl2c5:uCuDl0:G9m1lOOgzq3 a
+    ; k cnH
+    [j 3:lGafUD 858U4m]                   -40.2113Yg
+    YL:8OjbwyI:Qvg8dB:iUB               KDZfit-8132.63 @ aKTUZ 4970.1
+    ; z YKK8beX:bTld v4 A5XGV5O76:cw k0S
+    [bTVA7CL7zPL F76PUVG456]            UYNBdx -5563.8 {RLqQXz509.858} @@ 7109.61tad
+    ; Yq8PK R69A 2 1155:ej:l472
+    (JEoUCIL0uryM8XlnDgsV72cwsp5Xw4)    -1404.82 Fjgn @ 3696.95l
+    eLFgoFNo8
+
+2265/10/11=1973/11/16 * (bTh) J A:0jw6451OlGzi6S 90S9
+    (V85L0M75KBca410F48KGO:3S:KS97G2vrIx)  iRCl1791.49
+    (WO8qoB4FDBdT25)                     Zhyuuz3197.5
+    w4OfZAte4ch7:d:r9usD:IjL ak:vl       8103.66 SVkenx
+    ; T3HUQ J:kqi TnZCTi:g:aT9ah
+    (N3WsmK9rk:dL:9Io0XxqC6Iv)           Fwzo -8021.44
+    ; wFFWxn0TV1y
+    rtwT:T5Ldpkqe22e5V:0mz:IS:pP:a5n1kZ
+
+2265/10/15 * (Z) Wt eZci0
+    [kB:qu8igw3EE8 s6992O2Mr4]            -4054.12Q (V9)
+    ; O8XG2Kyu35Pjbm9VKjF22 GI0q2J0f
+    [YlN7iO 8i]                            -7057.29 eJ
+    ; g12:aRvfqmI:9vxE3sNQmCeRAap80q6yp
+    [ow]                                    -7639.07Tw @ AoyJtd 9587.93
+    aFv:Tm                                   6509.57ZB @@ 2272.92 OYKJtw
+    [K2 R1wFqt3l30puh2Bk2A:t4WX6oZE IxZvG]  -8368.76 XJFOG @@ 8799.54 gZE
+    r5Pk42gO74r r6:IWdn9DFKE1M0:FGmd84W   tpKmxO3269.2 @@ w 7427.35
+    brrnngeKpw2FNsE
+    ; Ism:kSQS 1dfUJJ88I
+
+2265/10/17 ! (Z) KksvI:b 8kG52Zqp2nu346JO5
+    ; B L1E O8B17t
+    (a5:L:q44Z2JTWp8881H uz899CktKkCO0uC:C Y9)  w -8352.97 {VCKXBX181.739} @@ 1538.2 OCMqws
+    (Z 5Szzf:sFTws5j6vmeV3nU18zNy8B2 dkD2y)      2718.94 y
+    ; f:7gZ9isC3:s11vd45:Jy6Gz1Hagh 7
+    (C0jME1ff9THT408M10cQ4 mn:af8p9y6DhWU4xG)   -2732.85 x @ ddQwY 9443.09
+    hIC3:Xr75Hn56ahM2q37:Q:H:f 90a01tE9 OT2     -5694.77 T
+    ; EmkKEL:8BN01U868lkZ5NCr4G B
+    GUq:pN:0 O093qlP:19
+
+2265/10/18 * (vS) P:J2
+    ; N:6uX n:8 K5Kjma
+    (A3:T:fT:SehiNQ9 sekp69n rbt0Sz)     3408.09rgCW @ ktse3416.84
+    ; rWYhBCNxQNl05qp E:2Y286yoSm oe
+    O3 ETL:h Bhi XVH 32d2HUA2IPY6jFh9LOZ  xOSWTq -5565.37 @@ CZ 8487.39
+    xji                                 JwOEg 1346.41 @ 3451.95Ry
+    ; P14TBWH3H2EbegI8hk9Wr0
+    [kfmiA55rQFD P7HTMv:2NhD:8kUf]      -2301.33 SvinE @@ CQmRq 5516.22
+    ; A6I52:t:15JP 9q:Aq m:3y940 B4890Oc:Bo
+    CE:51a
+    ; bR3o4XPNJehQ4k:FT7pjxXysK8BPA0
+
+2265/10/22=1973/11/19 (H) yIJ:x
+    s u21DmZw                                xoQhNx 2390.11
+    ; N1718B2:5Gk462nN
+    (QG:hf:mxl:ZOB46YBnMq1:9y14h F0 E63T:OPR)  dMM -2297.17 @ dLYBB 9445.84
+    ; x
+    E:8llV:qP:4GE6060q5OHh yA y:RuoCl0r9MkRt
+
+2265/10/27=1973/11/24 (m) h I24:VOb5xG3l
+    ; kbDPr:fAioY917cYk3rB10racd
+    [B9:t2quSb]                           MbLUMj 6455.61 @ hOeM 865.189
+    (H23a414UM9Ily9Q4 5Bif9E:jbt3)        ojEd-4307.58 @ 5426.63QKnjJ
+    ; Hk:Oun5b:RZ9 Kkl:7dy3:e4wk3
+    [dF2vWu3L3Icpm02Nc4:eRR5eulFw73hzSz9Z]   O-8087.23
+    pwN1A8V7KN00Q                           3189.12Ntn @ 7610.93G
+    SIER31l03m06f9PZe O0e5Nifs
+
+2265/11/02=1973/11/26 * (y1) r2 Ff3OOSY8 QbZ83cW48Gx:Tl
+    diAN7J7:rB                          -1171.89 qvAp @ 5428.480 k
+    [IEWUl4zZd7:920zEFr75635Ni]         7809.05Mw {ad5827.4}
+    mIGk 7:i:1q9TCFIDSMG68D3EUG         -7752.71 cqRya
+    (c:90:n 8NbD65lEL)                  -9272.97 Qma @@ 7414.11 y
+    ; s4:2qp0ic 6:Q:o5:0YY5anjz2
+    U2 eJuKO6:tINyga1
+    ; QVK1uT1Uv 49WJ67HX5K
+
+2265/11/06 (I4AqIh) F:i:hi4
+    ; bEdjN97c5tiikWTe0Z DYT48P 0lTWO
+    [D:02j9f 79hq8zD4D8eeS4 B7UBx1mKZH:P1I:n8]  oK -2556.97
+    ; KbI:y5
+    (K33Pm6G6:T)                                 6097.19yq @@ Rn7212.97
+    LUUU2 9oGOP66:oxMZ7 o6W7AbCGLqX7          -9098.06 CYDG @ 1090.25 li
+    [h10aHY3akFtd:YAL4O6GHp:ONLKMWonHx]       1100.77 gPwrJ @ 7701.87v
+    ; n
+    (j99P:p:OTR:GO:3W:L:2z8L42JU)             JhXFW 2634.19
+    ; JsnLuyJB8OzkO28a:u4:P73Uv
+    [SFD1379UU9bEPFypxQ]                      kaB7609.78 {Jim6040.26} (nWSj)
+    qPS
+
+2265/11/11=1973/11/27 (lA0) Lw0Uy4 ba3oC1v:IfWuf5z3:b6XH5E1
+    ; nUzApVcKvn9:w:Pr
+    [tT:Y46F:Wq:mS1U5Jtkn]              -2764.78cBpV
+    ; Gq:h834riS703694558EL:f9f71r RkDr
+    (zsZa)                                  8659.22q
+    ; O2 w6n38VfL:a
+    BGP3M6U:s r:L9                       -1453.04 xM @ 7079.26bqYet
+    [SxC 0Co6:01t6q6zg2jrDxiX46]        -8426.33 QKE {g871.704}
+    ; aGqK2:QXa 8N0:bkXcN2e1:PP:IQoA
+    mSvvR:2 5kv4P1seyT
+
+2265/11/16=1973/11/30 (v) L0775
+    ; Y:c6tf64uSZc4:W:Gjq
+    [vk2 2XTN:16bfZNqqJr]                   -9160.71 RJK @ wASxbH2836.69
+    ; Q7XQe66olp9IL36zr:D9k:UgeUXmfsr585
+    [NSx]                                    9184.91YigT @@ 6337.07aTXr
+    ; o 6i6F6 8p6Pu6Ec
+    (qIk4A1u91Fa)                              -77.576RV
+    U1pe9Q1:0DokrYD WE2A146Q8W:0OR0X3ZSkS6 c  2284.72 KG {Zx 2.3221270002} [2265/11/16] (j) @@ Zx 5305.41
+    ; f8:I bB 8e46:0n5YVVYhe6ei
+    TTF7X
+    ; k06JN41G
+
+2265/11/20 ! (mV1) Jh BB0UX5J5cS03E F4H:uO5y86:JZr9V0g
+    iTu5XOY t268568 Y 54Clhd                 pu 390.053 @@ 7263.49 cQN
+    ; nPF9GAaq2qu653 Ne1OncF 1M
+    [q 26 sHJ f186ib]                      -3420.85ecBW
+    ; V6K99:kuSn6mb2FPw33kBmh:Bv SVi 1Eda4Q
+    i566d Au0LQ:9S                         FmqJT9292.59 @@ 1521.04Se
+    ; x3x:S94w45hyhmY:pJ:vZl3A0jBObGK
+    (acrj:Juy8jxn0:0Xh187NR49k9K)          EdQ938.177 {qNsMU3086.95} @ 3858.3d
+    cVmhn G3h8KeVT:bQR375:1X6ue10HN:04FPR07  9776.33 wH
+    eCK:jA2Dn07 M1i0oaqp829:0w3N824        -2315.38 cGlBiv @@ lqao 3963.03
+    VRKvlr2I
+    ; uyIucm3ZZ6 5sx P78Cq0:b4HA3 qn1
+
+2265/11/25=1973/12/03 (PI) H 0b7H98C25FP9Eou oy8aklr9:P2:Sf o:bY610
+    ; gBS9:J3v3K4Z51
+    Q                                     -4898.72 p
+    (g40Mj)                                hQ6451.34
+    (b3)                                -2735.87 OUi {Mh9325.21} [1902/11/01] @ Te6684.77
+    (eqh 3yTMj:J6A59BqmWMEkItx0T 8:Jyd)  dJDEE-2300.35 {nP5218.43} (r)
+    jfKnGb6:bnKp8hAB
+    ; vsPM8H7Os3djqw125VIoC7nmdzvX
+
+2265/12/01 (iK) im:65:hIe
+    [NPW6:9q07:I LF3Wc]                     Ehi-1295.91
+    [WK6:I5Bg8lgx4:Gs G047iFxoYCONvU UlQw9]  -9116.46CcPJUj @@ 7430.92NvilDJ
+    ; yVGtc5yE3
+    [ATdf8LJqe2:xnK5C m9WA2Bt:fM8fp 2vw96Y]  7734.41WgR (Qm9:w)
+    ; w384226I2hbktYX:gr3Sv8g5vm:4UmacF
+    U7Z3WEtuWQU4 Q7P649qS7Wof               -8902.31 sL
+    ; ZtIyJ0Bq:y8WRY:YGJQqA0z1
+    Sno8Rm2o0 73z
+
+2265/12/06=1973/12/08 (x:8D42) sX
+    ; o5e28PNvc78R69:3I2:2
+    sr660hWb                                   -4823.09 Jo
+    ; p9X:gV0
+    (g0804T:3267oSxCi6ER0df46f4 3ex:BB5c8L2u1)  2326.63 QkyI @ 6907.65YmkwcL
+    ; IMIc:Zj1Go6
+    [b9joD04:fPlgKCK:zk3]                       8643.08 AB
+    iiWR7tm:Xnqk5SN59p0:4C89orNj:b:s          3928.1 vYVUgp @@ GtDrLt 5069.08
+    ; uHw5wg61GXC3Wh:122E9S:R0bTziK:u5icv
+    [oA9us5Ih5uZC34gznm5E:L1uCD]              -7511.49pMeaax [1977/05/16]
+    FO:E7O8                                   WGXPf9925.98
+    ; uYX:C7dRisP Pp2oUDC5nN43VL:1N
+    UwB71
+    ; d Zd 3H0QG2Oz:l2gtO
+
+2265/12/11=1973/12/12 * (WU) d0:v4:ye2GV754aK:9n
+    [w6Le4K7tgk8ML1VyH1f52I:a3CR 88g58 zcj5:l]   -2735.51q @ 9800.72OCEZ
+    iB:Ro8DbgKo8EwjyBUn                       Nlkhgi-4892.45
+    N5g:n7KQ:xT19NYc2O3687cAA
+    ; KLrq778:zJlr:Qj
+
+2265/12/16 (e7) Z M 09Y 0OsR79h534Is 6iWN pSR781SE
+    ; l5XI4:rhY iWN4:KZ2w
+    (B7km2mT16R2C70W75p223o 9c)         -6229.65 x {P8854.54} @ P3629.51
+    HrSd M6wBcvHM Jn71IgLD8891:X        -4028.68 FdIu @@ iokd5644.29
+    [KMK]                               1133.67 ihxquf
+    ; x7riO 1:zJpdV7kt9tFQc:h
+    (cQ6:8)                             KxlGc4642.66
+    Jh1FD uqC05
+    ; Y07:Idqbc:v:r4:MM
+
+2265/12/18 * (QUl) tb:LUGjNY2H6 VyME Wplqv2 Ot1wVs
+    ; w648Wb NTfh:c:TOY:eUAZa2ufU
+    [PdBXC0]                            6535.74rx {Qxh24.1936} (uleZ) @@ 5409.79 hx
+    ; A4Kz:T8:4jc79uA74Fs IL:D1 Xn9zAqMAlgw
+    (o:J:fscV8FzBi)                       -6796.77Wy @@ 9609.49 oBMlJo
+    ; B BiXfDz:x43mf:WWKz0v3D
+    [MDiV9rX4Qi4nhmR]                   TRmRAs8258.14
+    ; R0UUZGpK14:4cayw6 YNrR65h 3H:3
+    (rTh6ZTWC1LDwUC)                       631.158MB @@ 3809.81 JIq
+    XT4qB:M                             -1118.78 K {rR1624.5} @@ 7212.33 L
+    ad:7:5:6i60:6r:m                       -45.3278u @ wVC 582.397
+    ; oH6aeZmDL40VIIw3j
+    r8wKs6pU4:h1oCW
+
+2265/12/23 (Ou8k) H0nAMi oCX5o8yge:v 6
+    xM6Bf:rzA                             -7913.89 T
+    ; dm90
+    uj616pR es974:5532774yeq4Wp:21n6g7a4  MDXpsC -4688.3
+    ; xQO0 a66wJa42RMmxq1Y6
+    qcEcXk7V4:5rV6xZkk5                 5114.77 FcZyf
+    (jg8z wSFZ62:vOnBfZKO:WEzm)          LqQa2708.05
+    ; Gn3swh1hliVLv
+    [k:O:An7aEF8iC97t:SyD6Vqw:1beO8x:5]  qZgX-3943.2
+    [c]                                  8482.9oaZmE
+    eox4zsqoJ:5DU2RZ6wUBNJ2u61B6F4Ke6o2
+    ; cXJ37D9H0d:3kS59R7Hh:Tci9Z:u SC:A1BC18b
+
+2265/12/24=1973/12/16 ! (Lf8) jYfR27V6t8:Pw4ORP3jjgXg
+    [QIYQzmjBrQMMQkrr 4kf73VOQ23h8:1o3fGeX]  iu -9880.48
+    ; GYvNB8ScIXj3
+    L0:EjK2cuN0QME1qHaP9k0PXA6v N4b5Z      1460.33 vHCo @@ 4940.88 Vqa
+    ; KL8gj:gm99gc3Z4z:1HmFC:10zcih3bFazvpMi
+    bNmacj0OA1c6aq8d9BU:7
+    ; r21o5D
+
+2265/12/25 (F) pQr0uoj8MNRYzC G1n l9K4W6TCljbTnxeOKc
+    ; SZdw:60 bL96HDxar7S6D1dp aDG7zZ1:4R
+    f2F 67:RIKjQApQ6                       pE -5925.56 @@ 9977.58DaEVsK
+    ; tVdO
+    (LNF0KUv3Gq:qI0G7ke2ZL1Hr:5 w)           5551.48 N @ 9177.60 p
+    (VLM 05R9xxax7EkE:va:586T8Z1MG)       -9544.85 UWZ {eu2145.84}
+    [El2AtPQm:Gxu]                          hp 4315.42 @ 425.312lXB
+    (oZ7N5z4z1IOakW68vuC)                  xfSj351.814 @ GtJWC 2903.35
+    ; Oi5Wko:6YtUJ1Sj:G5nx3
+    GGo9                                    1222.06OhN @@ 40.5446 IWu
+    ; rMOnr0En9j102w385cv6rWBr:5
+    Y19rV0:sLqNBsZfWgWlYU:tlku21YS5d76smwa
+
+2265/12/26 ! (i:k) A KY9vL34gT42:0a0 qwch02y
+    ; mkj5Qgo f6Y2v Ry1wd:r6Y2C10pGdy00
+    [h:fVLc0Y 6j6:7Bf J3u3:eGwH]            Rgowk-9819.25 @@ 8561.53GD
+    FTp4m6 u912R8fr                            TJ8558.56 @ 9662.57VdA
+    (Xz854NRgrmEAZ 2016aPnrT7Sx3:i:ul aWh5X)  9019.68 Nmzw {Ya2604.38}
+    (ruaLzhe4h:6XN1Zg61yZv iiYi:1Mw 1857Ees)  loAr-4684.52 {Psm9523.66} (Vz 9:7)
+    [V:V]                                      o 9204.88 @ 6074.7 zSlFq
+    fhtD                                     EVLd 4001.7
+    jia0LO3
+    ; IQYEgz
+
+2265/12/30 ! (H406G8) nLU:5w:8:wfo8:hVmFy0:zg384T91p313oK
+    ; raAvpLt5xD3owmo4B82MQ9
+    kaVV:277410Q54lr:AV                 gbsD 6940.84
+    FC88                                NzCtR 4429.15
+    ; xD0:T
+    d o:wc:5aphbxGaUu e
+
+2266/01/04=1973/12/19 ! (AdWnX) f3:5Q74gVH26IQp5D10V:HwRVV8tze70DT:B
+    A9:5P7D75moiDxKHEO6TJ X13fAZiP0 LH5JOb  uSVST 5425.04 @@ S676.021
+    ; Ku4
+    wyy47:uVt:6:a3sJ                      8830.88 cxf {vy8564.43}
+    ; K9a:0eKUbEoP 8VYMya6AFB80pKXu5SL
+    UR2Z:HE4Z2                               776.593 k
+    ; S10:8ZS1521Kykzj20q9pN
+    [J8LKh:X:Vy5LYWc9]                      -5072.35Dx @@ zkvILW 659.642
+    T:U0TLAm7k6b3k7RUyqh j6ltg0V8r
+    ; W5VAZS0CA:A3pC4j1w:xsCGLS0819uaoil:k5
+
+2266/01/07 ! (l2i) S9r5BaJ:n7vo R5ETn:21oEn:1:7vS2K8 8 rR
+    ; d ywA:CNoc2
+    PoE 78fHcO2pD:Sv3ejjJGF 6QpmX 10    MknCzN -187.331 @ 8004.96RP
+    ; OuMSx40:1podtaCygP GA8t3q:t1aj8eL:809
+    [goRNvMT5C:l:0sIQZ6YU7]               kH 747.478 @ 7204.65ontO
+    m:2 F:2
+
+2266/01/09=1973/12/23 * (S8K1:R) U5K:fck5xYMl51ikz d:oyLtE r7T6:5YSI4 8
+    ; pq0576X12qL4:j
+    [g8An Ad LR:49:V9 KspZ6mUl:uZ:J962e]  wjA 3260.65 @@ A 5987.720
+    ; W1
+    [mDz:6nuu5N]                           YwT3059.17 @@ SZAS2428.13
+    ; q75dH4:tr8Az39B9 9U9BE1c334hj8L7C
+    (fIqA2LE5R:45tg:Uqr08slYphyQP:cFS0Oq)  kMvSr -4430.52 @@ Ve 9366.67
+    ; bl4FQC3g zMTT:eg:4403y IUrDIeu 0:IZu5
+    G5c2:4nof ObMu8x9i84H73azI4vi2yZE     -1365.670 k @@ pCiu 6970.41
+    ; Hk4H9JX4bV:vE:8a1U6TF0g8 79 q6grA5OwX:3
+    R:3c2Xb32
+
+2266/01/12 ! (SB34) mC4:z1tpM4j:H2
+    ; hPvB:7rC
+    [S0Il1k8Rw904:Wo:5 I2:a:0H UIGM20182:h71]  -9149.66tPCrsf
+    [x BPs:P:s]                              mxnewE -8134.89
+    ; Ot0:f20x:Vt8:IIqo1zy6fd
+    C1Tv3Mk030 NCZGjC9ikhj9
+
+2266/01/15=1973/12/24 (dKF:Jm) y0Sx:j8GR:8Tcll3kg 3N1ndZ 4FK6Xm
+    (O78h0w0118Sw539:X3)                        -1563.20q @@ NGJqh 464.223
+    [V Dzi06lViz74u:yv3]                     SisiRH -6643.61
+    [N:3SVK71S2uskW:zKqTM06 L7i3aa6XaF:FJVhS]  -7638.44bb
+    ; My bs1x t
+    iErC3HB2kK                                -6833.83Pnp
+    ; hV5uhRHG5P 4gm3M0A1mO2tZzd5
+    Vg:aMaS93i7OltkG:R5IQG
+    ; nf2e3c tp B1Vhu7M9K fkd:5QO3:Yac
+
+2266/01/20=1973/12/27 * (S7) eHR:0324HVt:9aDq4s570HQH
+    ; K
+    [GJFbMFd:8 460HH6pa7 1]              -7826.52 uFFt @@ LmHqm7283.12
+    ; MNB:61fd247l
+    Et03Uz:k9Sv:332GTh63UfAZg1SKZ        zFBK 4601.36
+    ; S
+    [eH y x:9lXt5qWg3N:n0QIg2Ek67IHc33EY]  7417.43 UU
+    [Z:SF DN9iGA 0i]                     ntiy 7055.95 @@ 6817.34 a
+    ; lRKi31487bQVs:tjFu7LzPC
+    P61fpFQzkECvlA5Q Ir6p                -7175.78bPzT {iXLmIx8679.99} (KCa)
+    ; WD:oWi7YBS6yR0z2YDuFe685:229y9llZZ:G
+    j m467jrtu48:V 503 Ov77              nOgxeC-1469.48
+    P:Iv P4a262o
+end test


### PR DESCRIPTION
Previously, `generate_posts_iterator` never initialized its first post. The base class `iterator_facade_base` sets `m_node` to NULL, and the `increment()` method is responsible for populating it with a post. Since the constructor did not call `increment()`, the iterator appeared empty, and `ledger generate` produced no output.

This patch calls `increment()` at the end of the constructor, ensuring that the iterator is correctly initialized with the first generated post.

Tested-by:
- `ledger generate` now produces valid transactions
- `ledger print` and `ledger balance` work with generated transactions
- All existing unit and regression tests pass
- Added new regression test covering this fix

Fixes #1096