### PR TITLE
fix: show own amount instead of family total in --flat balance mode

### DIFF
--- a/src/report.h
+++ b/src/report.h
@@ -639,7 +639,14 @@ public:
         OTHER(market).on(whence);
       });
 
-  OPTION(report_t, flat);
+  OPTION_(
+      report_t, flat, DO() {
+        // In flat mode, each account is listed independently, so show only
+        // the account's own amount rather than the family total (which
+        // includes sub-accounts).  The root account (where parent is null)
+        // still uses total for the grand total line.
+        OTHER(total_).on(whence, "parent ? amount : total");
+      });
   OPTION(report_t, force_color);
   OPTION(report_t, force_pager);
   OPTION(report_t, forecast_while_);


### PR DESCRIPTION
## Summary
- In `--flat` balance mode, each account should show its own amount, not the family total (which includes subaccounts)
- Fixes incorrect balance display when using `--flat` flag

## Test plan
- [ ] Run `ctest` to verify no regressions
- [ ] Test `--flat` balance report with hierarchical accounts

🤖 Generated with [Claude Code](https://claude.ai/code)