### PR TITLE
fix: include declared accounts in accounts command output

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -125,12 +125,12 @@ public:
 };
 
 class report_accounts : public item_handler<post_t> {
-protected:
-  report_t& report;
-
+public:
   typedef std::map<account_t*, std::size_t>::value_type accounts_pair;
   typedef std::map<account_t*, std::size_t, account_compare> accounts_report_map;
 
+protected:
+  report_t& report;
   accounts_report_map accounts;
 
 public:

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -985,6 +985,7 @@ void instance_t::account_directive(char* line) {
 
   char* p = skip_ws(line);
   account_t* account = context.journal->register_account(p, NULL, top_account());
+  account->add_flags(ACCOUNT_KNOWN);
   unique_ptr<auto_xact_t> ae;
 
   while (peek_whitespace_line()) {


### PR DESCRIPTION
## Summary
- Accounts declared with `account` directives were not appearing in `accounts` command output
- Ensures declared accounts are included alongside accounts referenced in transactions

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)