### PR TITLE
fix: allow --sort and --sort-xacts to work together

### DIFF
--- a/src/report.h
+++ b/src/report.h
@@ -901,7 +901,6 @@ public:
 
   OPTION_(
       report_t, sort_, DO_(str) { // -S
-        OTHER(sort_xacts_).off();
         OTHER(sort_all_).off();
       });
 
@@ -913,7 +912,6 @@ public:
 
   OPTION_(
       report_t, sort_xacts_, DO_(str) {
-        OTHER(sort_).on(whence, str);
         OTHER(sort_all_).off();
       });
 


### PR DESCRIPTION
## Summary
- `--sort` and `--sort-xacts` could not be used simultaneously
- Fixes the interaction between posting-level and transaction-level sorting

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)