### PR TITLE
fix: clear interval posts between group-by groups

### DIFF
--- a/src/filters.h
+++ b/src/filters.h
@@ -676,6 +676,7 @@ public:
 
   virtual void clear() {
     interval = start_interval;
+    all_posts.clear();
 
     subtotal_posts::clear();
     create_accounts();


### PR DESCRIPTION
## Summary
- Interval posts were not being cleared between group-by groups
- Fixes incorrect accumulation across groups in grouped reports

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)