### PR TITLE
fix: preserve user-specified commodity annotations in print output

### DIFF
--- a/src/post.h
+++ b/src/post.h
@@ -60,6 +60,7 @@ public:
 #define POST_ANONYMIZED 0x0800      // a temporary, anonymous posting
 #define POST_DEFERRED 0x1000        // the account was specified with <angles>
 #define POST_IS_TIMELOG 0x2000      // the posting is a timelog entry
+#define POST_AMOUNT_USER_ANNOTATED 0x4000 // amount has user-specified annotations
 
   xact_t* xact; // only set for posts of regular xacts
   account_t* account;

--- a/src/print.cc
+++ b/src/print.cc
@@ -219,10 +219,12 @@ void print_xact(report_t& report, std::ostream& out, xact_t& xact) {
         // first.
       } else {
         std::ostringstream amt_str;
+        bool suppress_computed =
+            !report.HANDLED(generated) && !post->has_flags(POST_AMOUNT_USER_ANNOTATED);
         value_t(post->amount)
             .print(amt_str, static_cast<int>(amount_width), -1,
                    AMOUNT_PRINT_RIGHT_JUSTIFY |
-                       (report.HANDLED(generated) ? 0 : AMOUNT_PRINT_NO_COMPUTED_ANNOTATIONS));
+                       (suppress_computed ? AMOUNT_PRINT_NO_COMPUTED_ANNOTATIONS : 0));
         amt = amt_str.str();
       }
 

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1521,6 +1521,9 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
                                      << "post amount = " << post->amount);
 
       if (!post->amount.is_null() && post->amount.has_commodity()) {
+        if (post->amount.has_annotation())
+          post->add_flags(POST_AMOUNT_USER_ANNOTATED);
+
         context.journal->register_commodity(post->amount.commodity(), post.get());
 
         if (!post->amount.has_annotation()) {

--- a/src/xact.cc
+++ b/src/xact.cc
@@ -351,6 +351,7 @@ bool xact_base_t::finalize() {
                                                               : breakdown.amount.annotation().tag,
                                                           breakdown.amount.annotation().value_expr))
                 : breakdown.amount;
+        post->drop_flags(POST_AMOUNT_USER_ANNOTATED);
         DEBUG("xact.finalize", "added breakdown, balance = " << balance);
       }
 


### PR DESCRIPTION
## Summary
- User-specified commodity annotations were being lost in `print` command output
- Preserves original annotation formatting in printed transactions

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)