### PR TITLE
fix: allow quoted commodity alias names

### DIFF
--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1153,6 +1153,9 @@ void instance_t::commodity_directive(char* line) {
 
 void instance_t::commodity_alias_directive(commodity_t& comm, string alias) {
   trim(alias);
+  // Strip surrounding quotes if present, matching how commodity names are parsed
+  if (alias.length() > 2 && alias[0] == '"' && alias[alias.length() - 1] == '"')
+    alias = alias.substr(1, alias.length() - 2);
   commodity_pool_t::current_pool->alias(alias, comm);
 }
 


### PR DESCRIPTION
## Summary
- Commodity alias names containing special characters could not be quoted
- Adds support for quoted strings in `alias` directive for commodity names

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)