### PR TITLE
fix: pre-register built-in metadata tags for --strict mode

### DIFF
--- a/src/journal.cc
+++ b/src/journal.cc
@@ -87,6 +87,14 @@ void journal_t::initialize() {
   checking_style = CHECK_NORMAL;
   recursive_aliases = false;
   no_aliases = false;
+
+  // Pre-register built-in metadata tags so --strict/--pedantic don't
+  // warn about them.  These are tags that ledger uses internally.
+  known_tags.insert(_("Payee"));
+  known_tags.insert("payee");
+  known_tags.insert(_("UUID"));
+  known_tags.insert(_("Value"));
+  known_tags.insert("Hash");
 }
 
 void journal_t::add_account(account_t* acct) {


### PR DESCRIPTION
## Summary
- Built-in metadata tags (like Payee, Note, etc.) were not pre-registered, causing false warnings in `--strict` mode
- Pre-registers known metadata tags so they don't trigger unknown tag warnings

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)