### PR TITLE
fix: handle VOID values in arithmetic operations for --dc --exchange

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -303,6 +303,9 @@ value_t value_t::number() const {
 }
 
 value_t& value_t::operator+=(const value_t& val) {
+  if (val.is_null())
+    return *this;
+
   if (is_string()) {
     if (val.is_string())
       as_string_lval() += val.as_string();
@@ -442,6 +445,9 @@ value_t& value_t::operator+=(const value_t& val) {
 }
 
 value_t& value_t::operator-=(const value_t& val) {
+  if (val.is_null())
+    return *this;
+
   if (is_sequence()) {
     sequence_t& seq(as_sequence_lval());
 
@@ -465,6 +471,11 @@ value_t& value_t::operator-=(const value_t& val) {
   }
 
   switch (type()) {
+  case VOID:
+    *this = val;
+    in_place_negate();
+    return *this;
+
   case DATETIME:
     switch (val.type()) {
     case INTEGER:
@@ -1637,6 +1648,8 @@ void value_t::in_place_unreduce() {
 
 value_t value_t::abs() const {
   switch (type()) {
+  case VOID:
+    return *this;
   case INTEGER: {
     long val = as_long();
     if (val < 0)

--- a/test/regress/1590.test
+++ b/test/regress/1590.test
@@ -1,0 +1,29 @@
+; Regression test for bug #1590: crash when using --dc with --exchange option
+; due to VOID values in display_total components that cannot be added or
+; passed through abs().
+
+commodity $
+    note United States Dollar
+    alias USD
+    format $1,234.56
+
+commodity EUR
+    note Euro
+    format 1,234.56 EUR
+
+P 2024-06-01 USD 0.80 EUR
+
+2024-07-05 * Payee
+    Expenses    42.00 EUR
+    Assets:Checking
+
+2024-07-05 * Payee 2
+    Expenses    $42.00
+    Assets:Checking
+
+test bal --dc -X $
+                       $94.50        $-94.50  Assets:Checking
+        $94.50                        $94.50  Expenses
+--------------------------------------------
+        $94.50         $94.50              0
+end test


### PR DESCRIPTION
## Summary
- VOID values in arithmetic operations caused incorrect results with `--dc --exchange`
- Properly handles VOID value type in addition/subtraction operations

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)