### PR TITLE
fix: mark synthetic price posts as cleared for prices/pricedb commands

### DIFF
--- a/src/iterators.cc
+++ b/src/iterators.cc
@@ -97,6 +97,7 @@ struct create_price_xact {
       xact_temps.push_back(xact);
       xact->payee = symbol;
       xact->_date = date.date();
+      xact->_state = item_t::CLEARED;
       xacts_by_commodity.insert(std::pair<string, xact_t*>(symbol, xact));
       xact->journal = &journal;
     }
@@ -114,6 +115,7 @@ struct create_price_xact {
       post_t& temp = temps.create_post(*xact, account);
       temp._date = date.date();
       temp.amount = price;
+      temp._state = item_t::CLEARED;
 
       temp.xdata().datetime = date;
     }

--- a/test/regress/1541.test
+++ b/test/regress/1541.test
@@ -1,0 +1,14 @@
+; Regression test for bug #1541: prices and pricedb commands produce no output
+; when --cleared is in effect (e.g. from ~/.ledgerrc). Synthetic price posts
+; are now marked as cleared so they pass through the clearing state filter.
+
+2024/01/01 * Buy stock
+    Assets:Brokerage       10 AAPL @ $100
+    Assets:Checking
+
+P 2024/06/01 AAPL $150
+
+test --cleared prices
+2024/01/01 AAPL             $100
+2024/06/01 AAPL             $150
+end test


### PR DESCRIPTION
## Summary
- Synthetic price posts generated for `prices` and `pricedb` commands were not marked as cleared
- Fixes filtering issues when using `--cleared` with price reporting commands

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)