### PR TITLE
fix: correct decimal comma parsing for European currency formats

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -1021,9 +1021,16 @@ bool amount_t::parse(std::istream& in, const parse_flags_t& flags) {
         no_more_commas = true;
       } else {
         if (last_comma != string::npos) {
+          // A period appearing after a comma that was tentatively treated as
+          // a thousands separator means the comma was actually the decimal
+          // separator (European style). Retroactively switch to decimal_comma.
           decimal_comma_style = true;
+          new_quantity->prec =
+              static_cast<precision_t>(quant.length() - 1 - last_comma);
           if (decimal_offset % 3 != 0)
             throw_(amount_error, _("Incorrect use of thousand-mark period"));
+          comm_flags |= COMMODITY_STYLE_THOUSANDS;
+          no_more_commas = true;
         } else {
           no_more_periods = true;
           new_quantity->prec = decimal_offset;
@@ -1046,7 +1053,11 @@ bool amount_t::parse(std::istream& in, const parse_flags_t& flags) {
           decimal_offset = 0;
         }
       } else {
-        if (decimal_offset % 3 != 0) {
+        if (decimal_offset % 3 != 0 ||
+            // A single comma with more than 3 digits after it cannot
+            // be a thousands separator (which requires commas every 3
+            // digits). Treat it as a decimal comma instead.
+            (last_comma == string::npos && decimal_offset > 3)) {
           if (last_comma != string::npos || last_period != string::npos) {
             throw_(amount_error, _("Incorrect use of thousand-mark comma"));
           } else {
@@ -1057,7 +1068,11 @@ bool amount_t::parse(std::istream& in, const parse_flags_t& flags) {
           }
         } else {
           comm_flags |= COMMODITY_STYLE_THOUSANDS;
-          no_more_periods = true;
+          // Only block periods after the second comma confirms thousands
+          // style. The first comma with exactly 3 trailing digits is
+          // ambiguous and a later period can disambiguate it.
+          if (last_comma != string::npos)
+            no_more_periods = true;
         }
       }
 

--- a/test/regress/1559.test
+++ b/test/regress/1559.test
@@ -1,0 +1,15 @@
+; Regression test for bug #1559: value corruption when converting currencies
+; at high precision with decimal comma format. When digits after a comma are
+; a multiple of 3, the parser incorrectly treats the comma as a thousands
+; separator instead of a decimal separator.
+
+commodity PLN
+    format 1.000,000000000 PLN
+
+2024/01/01 Test
+    Expenses:Test    -6.005,76 USD @ 4,166728274 PLN
+    Assets:Bank
+
+test bal Assets
+25.024,369998858 PLN  Assets:Bank
+end test


### PR DESCRIPTION
## Summary
- European currency formats using decimal commas (e.g., 1.000,50) were not parsed correctly
- Fixes decimal separator detection for comma-based formats

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)