### PR TITLE
fix: don't show fixated price annotations in plain reports (#2130)

### DIFF
--- a/src/annotate.cc
+++ b/src/annotate.cc
@@ -309,9 +309,7 @@ commodity_t& annotated_commodity_t::strip_annotations(const keep_details_t& what
   commodity_t* new_comm;
 
   bool keep_price =
-      ((what_to_keep.keep_price ||
-        (details.has_flags(ANNOTATION_PRICE_FIXATED) && has_flags(COMMODITY_SAW_ANN_PRICE_FLOAT) &&
-         has_flags(COMMODITY_SAW_ANN_PRICE_FIXATED))) &&
+      (what_to_keep.keep_price &&
        (!what_to_keep.only_actuals || !details.has_flags(ANNOTATION_PRICE_CALCULATED)));
   bool keep_date = (what_to_keep.keep_date &&
                     (!what_to_keep.only_actuals || !details.has_flags(ANNOTATION_DATE_CALCULATED)));

--- a/test/regress/2130.test
+++ b/test/regress/2130.test
@@ -1,0 +1,22 @@
+; Regression test for GitHub issue #2130: Can't mix {=} expressions with @@
+; expressions when currencies overlap. The presence of @@ on one transaction
+; was causing fixated price annotations {=} on unrelated transactions to be
+; spuriously displayed in plain balance reports.
+
+2022-01-01 test
+    A                                             $1 {=EUR 10}
+    B
+
+2022-01-01 test
+    C                                            $10 @@ EUR 20
+    D
+
+test bal
+                  $1  A
+                 $-1  B
+                 $10  C
+              EUR-20  D
+--------------------
+                 $10
+              EUR-20
+end test

--- a/test/regress/C0212EAC.test
+++ b/test/regress/C0212EAC.test
@@ -19,12 +19,7 @@ test reg
 08-Jan-01 Buy 5.00 GBP          Assets:Cash                5.00 GBP     5.00 GBP
                                 Assets:Checking           -7.00 EUR    -7.00 EUR
                                                                         5.00 GBP
-09-Jan-01 Sell 5.00 GBP for 7.. Assets:Cash            -5.00 GBP {=1.40 EUR}    -7.00 EUR
-                                                                        5.00 GBP
-                                                           -5.00 GBP {=1.40 EUR}
+09-Jan-01 Sell 5.00 GBP for 7.. Assets:Cash               -5.00 GBP    -7.00 EUR
                                 Assets:Checking            7.50 EUR     0.50 EUR
-                                                                        5.00 GBP
-                                                           -5.00 GBP {=1.40 EUR}
-                                Income:Gain               -0.50 EUR     5.00 GBP
-                                                           -5.00 GBP {=1.40 EUR}
+                                Income:Gain               -0.50 EUR            0
 end test


### PR DESCRIPTION
## Summary
- Fixated price annotations were being displayed in plain reports where they shouldn't appear
- Hides fixated price annotations in non-annotated report output
- Fixes #2130

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)