### PR TITLE
fix: implement --exchange A:B selective commodity conversion (#2115)

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -1519,23 +1519,46 @@ value_t value_t::exchange_commodities(const std::string& commodities, const bool
 
   // If we are repricing to just a single commodity, with no price
   // expression, skip the expensive logic below.
-  if (commodities.find(',') == string::npos && commodities.find('=') == string::npos)
+  if (commodities.find(',') == string::npos && commodities.find('=') == string::npos &&
+      commodities.find(':') == string::npos)
     return value(moment, commodity_pool_t::current_pool->find_or_create(commodities));
 
   std::vector<commodity_t*> comms;
+  std::vector<commodity_t*> sources;
   std::vector<bool> force;
 
   typedef tokenizer<char_separator<char>> tokenizer;
   tokenizer tokens(commodities, char_separator<char>(","));
 
   foreach (const string& name, tokens) {
-    string::size_type name_len = name.length();
+    string target_name = name;
+    string source_name;
 
-    if (commodity_t* commodity = commodity_pool_t::current_pool->parse_price_expression(
-            name[name_len - 1] == '!' ? string(name, 0, name_len - 1) : name, add_prices, moment)) {
+    // Handle A:B syntax for selective conversion (convert A to B only)
+    string::size_type colon_pos = name.find(':');
+    if (colon_pos != string::npos) {
+      source_name = string(name, 0, colon_pos);
+      target_name = string(name, colon_pos + 1);
+    }
+
+    string::size_type name_len = target_name.length();
+    bool is_forced = name_len > 0 && target_name[name_len - 1] == '!';
+    string expr_name = is_forced ? string(target_name, 0, name_len - 1) : target_name;
+
+    if (commodity_t* commodity =
+            commodity_pool_t::current_pool->parse_price_expression(expr_name, add_prices, moment)) {
       DEBUG("commodity.exchange", "Pricing for commodity: " << commodity->symbol());
       comms.push_back(&commodity->referent());
-      force.push_back(name[name_len - 1] == '!');
+      force.push_back(is_forced);
+
+      if (!source_name.empty()) {
+        if (commodity_t* src = commodity_pool_t::current_pool->find(source_name))
+          sources.push_back(&src->referent());
+        else
+          sources.push_back(NULL);
+      } else {
+        sources.push_back(NULL);
+      }
     }
   }
 
@@ -1544,9 +1567,15 @@ value_t value_t::exchange_commodities(const std::string& commodities, const bool
     switch (type()) {
     case AMOUNT:
       DEBUG("commodity.exchange", "We have an amount: " << as_amount_lval());
-      if (!force[index] && std::find(comms.begin(), comms.end(),
-                                     &as_amount_lval().commodity().referent()) != comms.end())
+      if (sources[index]) {
+        // A:B syntax: only convert if the amount is commodity A
+        if (&as_amount_lval().commodity().referent() != sources[index])
+          break;
+      } else if (!force[index] &&
+                 std::find(comms.begin(), comms.end(),
+                           &as_amount_lval().commodity().referent()) != comms.end()) {
         break;
+      }
 
       DEBUG("commodity.exchange", "Referent doesn't match, pricing...");
       if (optional<amount_t> val = as_amount_lval().value(moment, comm)) {
@@ -1565,8 +1594,17 @@ value_t value_t::exchange_commodities(const std::string& commodities, const bool
         DEBUG("commodity.exchange", "We have a balance amount of commodity: "
                                         << pair.first->symbol()
                                         << " == " << pair.second.commodity().symbol());
-        if (!force[index] &&
-            std::find(comms.begin(), comms.end(), &pair.first->referent()) != comms.end()) {
+        bool should_convert;
+        if (sources[index]) {
+          // A:B syntax: only convert if the amount is commodity A
+          should_convert = (&pair.first->referent() == sources[index]);
+        } else {
+          should_convert =
+              force[index] ||
+              std::find(comms.begin(), comms.end(), &pair.first->referent()) == comms.end();
+        }
+
+        if (!should_convert) {
           temp += pair.second;
         } else {
           DEBUG("commodity.exchange", "Referent doesn't match, pricing...");

--- a/test/regress/2115.test
+++ b/test/regress/2115.test
@@ -1,0 +1,17 @@
+; Regression test for GitHub issue #2115: --exchange A:B selective commodity
+; conversion. The A:B syntax should convert only commodity A to B, leaving
+; all other commodities unchanged.
+
+P 2022-01-01 A 1 B
+P 2022-01-01 A 1 C
+
+2022-01-01 test
+    Income
+    Assets  10 A
+    Assets  10 B
+    Assets  10 C
+
+test bal assets -X A:B
+                20 B
+                10 C  Assets
+end test


### PR DESCRIPTION
## Summary
- Implements selective commodity conversion syntax `--exchange A:B` to convert only commodity A to B
- Fixes #2115

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)