### PR TITLE
fix: print balance assignments as = amount, not amount = amount (#2100)

### DIFF
--- a/src/print.cc
+++ b/src/print.cc
@@ -196,7 +196,11 @@ void print_xact(report_t& report, std::ostream& out, xact_t& xact) {
 
     unistring name(pbuf.str());
 
-    if (!post->has_flags(POST_CALCULATED) || report.HANDLED(generated)) {
+    bool is_balance_assignment =
+        post->has_flags(POST_CALCULATED) && post->assigned_amount;
+
+    if (!post->has_flags(POST_CALCULATED) || is_balance_assignment ||
+        report.HANDLED(generated)) {
       out << name.extract();
       std::string::size_type slip = (static_cast<std::string::size_type>(account_width) -
                                      static_cast<std::string::size_type>(name.length()));
@@ -206,7 +210,10 @@ void print_xact(report_t& report, std::ostream& out, xact_t& xact) {
                ? lexical_cast<std::size_t>(report.HANDLER(amount_width_).str())
                : 12);
       string amt;
-      if (post->amount_expr) {
+      if (is_balance_assignment) {
+        // For balance assignments, don't print the computed amount;
+        // only the = assignment will be printed below.
+      } else if (post->amount_expr) {
         std::ostringstream amt_str;
         justify(amt_str, post->amount_expr->text(), (int)amount_width, true);
         amt = amt_str.str();

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -1741,6 +1741,7 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
                                            << "Overwrite null posting with zero diff with "
                                            << amt - amt);
           }
+          post->add_flags(POST_CALCULATED);
         } else {
           // balance assertion
           diff -= post->amount.reduced().strip_annotations(keep_details_t());

--- a/test/regress/2100.test
+++ b/test/regress/2100.test
@@ -1,0 +1,13 @@
+; Regression test for GitHub issue #2100: print garbles balance assignment.
+; The print command should output balance assignments as "Account = $20"
+; not "Account $20 = $20".
+
+2022-01-01 * Opening balance
+    Checking                         = $20
+    Equity:Adjustments
+
+test print
+2022/01/01 * Opening balance
+    Checking                             = $20
+    Equity:Adjustments
+end test


### PR DESCRIPTION
## Summary
- Balance assignments were being printed as `amount = amount` instead of `= amount`
- Corrects the `print` command output format for balance assignments
- Fixes #2100

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)