### PR TITLE
feat: show build type (Debug/Release) in --version output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,8 @@ configure_file(
   ${PROJECT_SOURCE_DIR}/src/system.hh.in
   ${PROJECT_BINARY_DIR}/system.hh)
 
+set(Ledger_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
+
 configure_file(
   ${PROJECT_SOURCE_DIR}/src/ledger.hh.in
   ${PROJECT_BINARY_DIR}/ledger.hh)

--- a/src/global.h
+++ b/src/global.h
@@ -118,6 +118,8 @@ public:
       out << Ledger_VERSION_PRERELEASE;
     if (std::strlen(Ledger_VERSION_DATE) > 0)
       out << '-' << Ledger_VERSION_DATE;
+    if (std::strlen(Ledger_BUILD_TYPE) > 0)
+      out << " (" << Ledger_BUILD_TYPE << ')';
     out << _(", the command-line accounting tool");
     out << _("\nwith");
 #if !HAVE_GPGME

--- a/src/ledger.hh.in
+++ b/src/ledger.hh.in
@@ -45,6 +45,7 @@
 #define Ledger_VERSION_PRERELEASE "@Ledger_VERSION_PRERELEASE@"
 #define Ledger_VERSION_DATE      "@Ledger_VERSION_DATE@"
 #define Ledger_VERSION           "@Ledger_VERSION_MAJOR@.@Ledger_VERSION_MINOR@.@Ledger_VERSION_PATCH@"
+#define Ledger_BUILD_TYPE        "@Ledger_BUILD_TYPE@"
 
 /**
  * @name Default values


### PR DESCRIPTION
## Summary
- Adds the CMake build type (Debug/Release/RelWithDebInfo) to the `--version` output
- Helps diagnose issues by making the build configuration visible

## Test plan
- [ ] Run `ctest` to verify no regressions
- [ ] Verify `--version` shows build type

🤖 Generated with [Claude Code](https://claude.ai/code)