### PR TITLE
fix: prevent REPL state leakage when --gain precedes other commands

### DIFF
--- a/src/op.cc
+++ b/src/op.cc
@@ -127,7 +127,7 @@ expr_t::ptr_op_t expr_t::op_t::compile(scope_t& scope, const int depth, scope_t*
   } else if (is_scope()) {
     shared_ptr<scope_t> subscope(new symbol_scope_t(*scope_t::empty_scope));
     set_scope(subscope);
-    bound_scope.reset(new bind_scope_t(*scope_ptr, *subscope.get()));
+    bound_scope.reset(new lexical_scope_t(*scope_ptr, *subscope.get()));
     scope_ptr = bound_scope.get();
   } else if (kind < TERMINALS) {
     result = this;

--- a/src/scope.h
+++ b/src/scope.h
@@ -143,6 +143,28 @@ public:
   }
 };
 
+//
+// lexical_scope_t
+//
+// Like bind_scope_t, but defines only go to the grandchild (local scope),
+// not the parent.  Used for SCOPE node compilation so that local variable
+// definitions (O_DEFINE) don't leak into enclosing scopes.
+//
+class lexical_scope_t : public bind_scope_t {
+  lexical_scope_t();
+
+public:
+  explicit lexical_scope_t(scope_t& _parent, scope_t& _grandchild)
+      : bind_scope_t(_parent, _grandchild) {
+    TRACE_CTOR(lexical_scope_t, "scope_t&, scope_t&");
+  }
+  virtual ~lexical_scope_t() { TRACE_DTOR(lexical_scope_t); }
+
+  virtual void define(const symbol_t::kind_t kind, const string& name, expr_t::ptr_op_t def) {
+    grandchild.define(kind, name, def);
+  }
+};
+
 template <typename T>
 T* search_scope(scope_t* ptr, bool prefer_direct_parents = false) {
   DEBUG("scope.search", "Searching scope " << ptr->description());

--- a/test/regress/2131_repl_gain.dat
+++ b/test/regress/2131_repl_gain.dat
@@ -1,0 +1,2 @@
+--no-pager --columns=80 bal --gain
+--no-pager --columns=80 bal

--- a/test/regress/2131_repl_gain.test
+++ b/test/regress/2131_repl_gain.test
@@ -1,0 +1,29 @@
+; Regression test for REPL state leakage with --gain
+;
+; Running "bal --gain" followed by "bal" in REPL mode (via --script) used to
+; fail with "Attempting to get argument at index 1 from an amount" because
+; the --gain expression's SCOPE node leaked a display_total definition into
+; the session, which persisted across commands.
+
+2024/01/01 Buy Stock
+    Assets:Brokerage  10 AAPL @ $100
+    Assets:Checking  $-1000
+
+P 2024/06/01 AAPL $150
+
+2024/07/01 Sell Stock
+    Assets:Checking  $750
+    Assets:Brokerage  -5 AAPL {$100} @ $150
+    Income:Capital Gains  $-250
+
+test --script test/regress/2131_repl_gain.dat
+                $250  Assets:Brokerage
+               $-250
+              5 AAPL  Assets
+              5 AAPL    Brokerage
+               $-250    Checking
+               $-250  Income:Capital Gains
+--------------------
+               $-500
+              5 AAPL
+end test


### PR DESCRIPTION
## Summary
- REPL state from a `--gain` command was leaking into subsequent commands
- Fixes state isolation between REPL commands

## Test plan
- [ ] Run `ctest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)