### PR TITLE
ci: add gcov/lcov code coverage reporting to CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -107,3 +107,40 @@ jobs:
           else
             echo "::warning::Sanitizer issues were detected. See above for details."
           fi
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        name: Check out repository code
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo ./acprep dependencies
+          sudo apt-get install -y lcov
+
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DUSE_GCOV=ON -DDISABLE_ASSERTS=ON
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config Debug
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C Debug || ctest -C Debug --rerun-failed --output-on-failure
+
+      - name: Generate coverage report
+        working-directory: ${{github.workspace}}/build
+        run: |
+          lcov --capture --directory . --output-file coverage.info --ignore-errors mismatch
+          lcov --remove coverage.info '/usr/*' '*/test/*' --ignore-errors unused --output-file coverage.info
+          lcov --summary coverage.info
+          genhtml coverage.info --output-directory coverage-report
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: ${{github.workspace}}/build/coverage-report/
+          retention-days: 30
+          if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ option(BUILD_DEBUG "Build support for runtime debugging" OFF)
 option(PRECOMPILE_SYSTEM_HH "Precompile system.hh" ON)
 
 option(USE_GPGME "Build with support for encrypted journals" OFF)
+option(USE_GCOV "Enable code coverage with gcov/lcov" OFF)
 option(USE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 option(BUILD_LIBRARY "Build and install Ledger as a library" ON)
 option(BUILD_DOCS "Build and install documentation" OFF)
@@ -63,8 +64,14 @@ else()
 endif()
 
 if(CLANG_GCOV)
+  set(USE_GCOV ON)
   set(PROFILE_LIBS profile_rt)
   set(CMAKE_REQUIRED_LIBRARIES ${PROFILE_LIBS})
+endif()
+
+if(USE_GCOV)
+  add_compile_options(-fprofile-arcs -ftest-coverage)
+  add_link_options(-fprofile-arcs -ftest-coverage)
 endif()
 
 if(USE_SANITIZERS)


### PR DESCRIPTION
## Summary
- Adds gcov/lcov code coverage reporting to the CI pipeline
- Generates coverage reports for test runs

## Dependencies
- Depends on #2550 (ci: add ASan/UBSan sanitizer build to CI matrix) — must merge first

## Test plan
- [ ] Verify CI workflow runs successfully with coverage reporting

🤖 Generated with [Claude Code](https://claude.ai/code)