### PR TITLE
Fix auto-transaction balance failure with cost annotations (#2566)

### DIFF
--- a/test/regress/2566.test
+++ b/test/regress/2566.test
@@ -1,0 +1,21 @@
+; Test for issue #2566
+; Automated transaction should balance when copying amount and cost
+; from a posting with a total cost annotation (@@)
+
+= /Expenses/
+    Copy    (a)
+    Copy   (-b)
+
+2026-02-02 ACME
+    Expenses  100 kWh @@ 72,00€
+    Liabilities         -72,00€
+
+test --decimal-comma reg
+26-Feb-02 ACME                  Expenses                    100 kWh      100 kWh
+                                Liabilities                 -72,00€      100 kWh
+                                                                         -72,00€
+                                Copy                        100 kWh      200 kWh
+                                                                         -72,00€
+                                Copy                        -72,00€      200 kWh
+                                                                        -144,00€
+end test


### PR DESCRIPTION
## Summary

- Fixes #2566: automated transactions now correctly balance when copying amounts from postings with cost annotations (e.g., `100 kWh @@ 72€`)
- When `extend_xact()` generates a posting whose amount carries a price annotation from the matched posting, the cost is now derived from that annotation so `verify()` can check the balance correctly
- Follows the same cost-derivation pattern already used in `finalize()` for fixated prices

## Test plan

- [x] Added regression test `test/regress/2566.test` reproducing the exact scenario from the issue
- [x] All 528 tests pass (527 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)