### PR TITLE
test: add regression test for declared accounts output (#2519)

### DIFF
--- a/test/regress/fix-declared-accounts.test
+++ b/test/regress/fix-declared-accounts.test
@@ -1,0 +1,25 @@
+; Regression test for issue #2519: declared accounts don't show up
+; in accounts output.
+;
+; Accounts declared with the `account` directive but having no postings
+; should still appear in the accounts command output.
+
+account Foo:Bar
+account Baz:Qiz
+account Also:Declared
+
+2000-01-01 A thing
+    Foo:Bar  6
+    Baz:Qiz
+
+test accounts
+Also:Declared
+Baz:Qiz
+Foo:Bar
+end test
+
+test accounts --count
+0 Also:Declared
+1 Baz:Qiz
+1 Foo:Bar
+end test


### PR DESCRIPTION
## Summary
- Adds a regression test for issue #2519 (declared accounts don't show up in accounts output)
- The fix was already merged in PR #2530 but lacked a dedicated regression test
- Tests both `accounts` and `accounts --count` with declared-but-unused accounts

Closes #2519

## Test plan
- [x] New regression test `fix-declared-accounts.test` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)