### PR TITLE
test: add regression test for group-by with interval reporting (#2511)

### DIFF
--- a/test/regress/2511.test
+++ b/test/regress/2511.test
@@ -1,0 +1,59 @@
+; Regression test for issue #2511
+; Register report using -M with --group-by should not duplicate
+; posts from earlier groups in subsequent groups.
+
+2025/01/01 * Uber eats
+    Expenses:Eating out                          $10
+    Assets
+
+2025/01/01 * Tesco
+    Expenses:Groceries                           $10
+    Assets
+
+2025/02/01 * Uber eats
+    Expenses:Eating out                          $10
+    Assets
+
+2025/02/01 * Tesco
+    Expenses:Groceries                           $10
+    Assets
+
+2025/03/01 * Uber eats
+    Expenses:Eating out                          $10
+    Assets
+
+2025/03/01 * Tesco
+    Expenses:Groceries                           $10
+    Assets
+
+test reg expenses -M --group-by account
+Expenses:Eating out
+25-Jan-01 - 25-Jan-31           Expenses:Eating out             $10          $10
+25-Feb-01 - 25-Feb-28           Expenses:Eating out             $10          $20
+25-Mar-01 - 25-Mar-31           Expenses:Eating out             $10          $30
+
+Expenses:Groceries
+25-Jan-01 - 25-Jan-31           Expenses:Groceries              $10          $10
+25-Feb-01 - 25-Feb-28           Expenses:Groceries              $10          $20
+25-Mar-01 - 25-Mar-31           Expenses:Groceries              $10          $30
+end test
+
+test reg expenses -D --group-by account
+Expenses:Eating out
+25-Jan-01 - 25-Jan-01           Expenses:Eating out             $10          $10
+25-Feb-01 - 25-Feb-01           Expenses:Eating out             $10          $20
+25-Mar-01 - 25-Mar-01           Expenses:Eating out             $10          $30
+
+Expenses:Groceries
+25-Jan-01 - 25-Jan-01           Expenses:Groceries              $10          $10
+25-Feb-01 - 25-Feb-01           Expenses:Groceries              $10          $20
+25-Mar-01 - 25-Mar-01           Expenses:Groceries              $10          $30
+end test
+
+test reg expenses -Y --group-by account
+Expenses:Eating out
+25-Jan-01 - 25-Dec-31           Expenses:Eating out             $30          $30
+
+Expenses:Groceries
+25-Jan-01 - 25-Dec-31           Expenses:Groceries              $30          $30
+end test


### PR DESCRIPTION
## Summary

- Adds regression test for issue #2511, which reported that `reg -M --group-by account` duplicated posts from earlier groups in subsequent groups
- The underlying fix was already committed in PR #2533 (`cee6fce5`), which added `all_posts.clear()` to `interval_posts::clear()` to prevent posts from bleeding across groups
- This PR adds a dedicated regression test covering `-D`, `-M`, and `-Y` interval modes with `--group-by account` to prevent future regressions

Closes #2511

## Test plan

- [x] New regression test `test/regress/2511.test` passes locally
- [x] Tests cover `-D` (daily), `-M` (monthly), and `-Y` (yearly) intervals
- [x] Each group shows only its own posts with correctly isolated running totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)