### PR TITLE
test: add regression test for print with commodity date annotations

### DIFF
--- a/test/regress/2509.test
+++ b/test/regress/2509.test
@@ -1,0 +1,26 @@
+; Regression test for issue #2509: print command does not print commodity
+; annotations with dates.
+;
+; When a posting has both a lot price {$100} and a lot date [2012-03-01],
+; the print command was dropping both annotations, outputting only the
+; per-unit cost (@ $120).
+
+2012-03-01 AAPL
+    Assets                                        10 APPL @ $100
+    Assets                                    -$1000
+
+2012-03-02 AAPL
+    Assets                                       -10 APPL {$100} [2012-03-01] @ $120
+    Capital Gains                              -$200
+    Assets                                     $1200
+
+test print -> 0
+2012/03/01 AAPL
+    Assets                                   10 APPL @ $100
+    Assets                                    $-1000
+
+2012/03/02 AAPL
+    Assets                              -10 APPL {$100} [2012/03/01] @ $120
+    Capital Gains                              $-200
+    Assets                                     $1200
+end test


### PR DESCRIPTION
## Summary
- Adds a regression test for issue #2509 where the `print` command was dropping commodity annotations when both a lot price `{$100}` and lot date `[2012-03-01]` were present
- The underlying bug was already fixed in commit 2f35e24f (PR #2534), but no regression test was added for this specific scenario
- The test verifies that `print` correctly preserves `{price} [date] @ cost` annotations

## Test plan
- [x] New test `RegressTest_2509` passes
- [x] Verified the exact scenario from the issue report produces correct output

Closes #2509

🤖 Generated with [Claude Code](https://claude.com/claude-code)