### PR TITLE
fix: commodity exchange (-X) for quoted commodities (#2321)

### DIFF
--- a/src/commodity.cc
+++ b/src/commodity.cc
@@ -98,7 +98,7 @@ optional<price_point_t> commodity_t::find_price_from_expr(expr_t& expr,
     call_args.push_back(string_value(base_symbol()));
     call_args.push_back(moment);
     if (commodity)
-      call_args.push_back(string_value(commodity->symbol()));
+      call_args.push_back(string_value(commodity->base_symbol()));
 
     result = as_expr(result)->call(call_args, *scope_t::default_scope);
   }

--- a/test/regress/2321.test
+++ b/test/regress/2321.test
@@ -1,0 +1,30 @@
+; Regression test for issue #2321
+; Commodity exchange (-X) should work for quoted commodities
+; that use value expressions with market() function.
+
+commodity N1
+commodity N2
+	value s, d, t -> market(2 "N1", d, t)
+commodity N3
+	value s, d, t -> market(2 "N2", d, t)
+commodity N4
+	value s, d, t -> market(2 "N3", d, t)
+
+2024-01-05 Buy
+	Assets	1 "N4"
+	Equity
+
+test reg -X 'N3' -> 0
+24-Jan-05 Buy                   Assets                         2 N3         2 N3
+                                Equity                        -2 N3            0
+end test
+
+test reg -X 'N2' -> 0
+24-Jan-05 Buy                   Assets                         4 N2         4 N2
+                                Equity                        -4 N2            0
+end test
+
+test reg -X 'N1' -> 0
+24-Jan-05 Buy                   Assets                         8 N1         8 N1
+                                Equity                        -8 N1            0
+end test


### PR DESCRIPTION
## Summary

- Fix `-X`/`--exchange` option not working for commodities whose names require quoting (contain digits, spaces, etc.)
- In `find_price_from_expr()`, the target commodity was passed via `symbol()` which returns the display form with enclosing quotes (e.g., `"N3"`). This caused `exchange_commodities()` to fail its pool lookup since commodities are stored by unquoted `base_symbol()`.
- Changed to `base_symbol()` so the commodity name matches the pool key format.

Fixes #2321

## Test plan

- [x] Added regression test `test/regress/2321.test` covering `-X N3`, `-X N2`, and `-X N1` with value-expression-based commodity chains
- [x] Full test suite passes (1374/1377 — 3 pre-existing failures in coverage tests)

🤖 Generated with [Claude Code](https://claude.ai/code)