### PR TITLE
fix: use --now flag in coverage report tests for timezone independence

### DIFF
--- a/test/regress/coverage-report-draft-cmd.test
+++ b/test/regress/coverage-report-draft-cmd.test
@@ -4,8 +4,8 @@
     Expenses:Food              $50.00
     Assets:Checking
 
-test draft "Grocery Store" Expenses:Food '$25.00' Assets:Checking
-2026/02/13 Grocery Store
+test draft --now 2024/01/16 "Grocery Store" Expenses:Food '$25.00' Assets:Checking
+2024/01/16 Grocery Store
     Expenses:Food                             $25.00
     Assets:Checking
 end test

--- a/test/regress/coverage-report-format-funcs.test
+++ b/test/regress/coverage-report-format-funcs.test
@@ -4,6 +4,6 @@
     Expenses:Food              $50.00
     Assets:Checking
 
-test eval "format_date(today, \"%Y-%m-%d\")"
-2026-02-13
+test eval --now 2024/01/15 "format_date(today, \"%Y-%m-%d\")"
+2024-01-15
 end test

--- a/test/regress/coverage-report-xact-cmd.test
+++ b/test/regress/coverage-report-xact-cmd.test
@@ -4,8 +4,8 @@
     Expenses:Food              $50.00
     Assets:Checking
 
-test xact "Grocery Store" Expenses:Food '$25.00' Assets:Checking
-2026/02/13 Grocery Store
+test xact --now 2024/01/16 "Grocery Store" Expenses:Food '$25.00' Assets:Checking
+2024/01/16 Grocery Store
     Expenses:Food                             $25.00
     Assets:Checking
 end test


### PR DESCRIPTION
## Summary
- Use `--now` flag in 3 coverage report regression tests (`coverage-report-draft-cmd.test`, `coverage-report-xact-cmd.test`, `coverage-report-format-funcs.test`) to set deterministic dates instead of relying on `today`
- This fixes CI failures caused by date-dependent output varying across timezones
- Expected output dates are now pinned to fixed values matching the `--now` argument

## Test plan
- [ ] Verify `ctest -R coverage-report-draft-cmd` passes
- [ ] Verify `ctest -R coverage-report-xact-cmd` passes
- [ ] Verify `ctest -R coverage-report-format-funcs` passes
- [ ] Confirm tests pass regardless of system timezone (e.g., UTC, America/Chicago, Asia/Tokyo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)