### PR TITLE
refactor: convert throw() to noexcept and BOOST_FOREACH to range-for

### DIFF
--- a/src/account.h
+++ b/src/account.h
@@ -178,7 +178,7 @@ public:
         TRACE_CTOR(account_t::xdata_t::details_t, "copy");
       }
       details_t& operator=(const details_t&) = default;
-      ~details_t() throw() { TRACE_DTOR(account_t::xdata_t::details_t); }
+      ~details_t() noexcept { TRACE_DTOR(account_t::xdata_t::details_t); }
 
       details_t& operator+=(const details_t& other);
 
@@ -197,7 +197,7 @@ public:
           family_details(other.family_details), sort_values(other.sort_values) {
       TRACE_CTOR(account_t::xdata_t, "copy");
     }
-    ~xdata_t() throw() { TRACE_DTOR(account_t::xdata_t); }
+    ~xdata_t() noexcept { TRACE_DTOR(account_t::xdata_t); }
   };
 
   // This variable holds optional "extended data" which is usually produced

--- a/src/amount.cc
+++ b/src/amount.cc
@@ -1054,7 +1054,8 @@ bool amount_t::parse(std::istream& in, const parse_flags_t& flags) {
 
   new_quantity->prec = 0;
 
-  BOOST_REVERSE_FOREACH(const char& ch, quant) {
+  for (auto it = quant.rbegin(); it != quant.rend(); ++it) {
+    const char& ch = *it;
     string_index--;
 
     if (ch == '.') {

--- a/src/annotate.h
+++ b/src/annotate.h
@@ -117,7 +117,7 @@ struct keep_details_t {
     TRACE_CTOR(keep_details_t, "copy");
   }
   keep_details_t& operator=(const keep_details_t&) = default;
-  ~keep_details_t() throw() { TRACE_DTOR(keep_details_t); }
+  ~keep_details_t() noexcept { TRACE_DTOR(keep_details_t); }
 
   bool keep_all() const { return keep_price && keep_date && keep_tag && !only_actuals; }
   bool keep_all(const commodity_t& comm) const;

--- a/src/balance.cc
+++ b/src/balance.cc
@@ -55,7 +55,7 @@ balance_t::balance_t(const long val) {
 }
 
 balance_t& balance_t::operator+=(const balance_t& bal) {
-  foreach (const amounts_map::value_type& pair, bal.amounts)
+  for (const amounts_map::value_type& pair : bal.amounts)
     *this += pair.second;
   return *this;
 }
@@ -78,7 +78,7 @@ balance_t& balance_t::operator+=(const amount_t& amt) {
 }
 
 balance_t& balance_t::operator-=(const balance_t& bal) {
-  foreach (const amounts_map::value_type& pair, bal.amounts)
+  for (const amounts_map::value_type& pair : bal.amounts)
     *this -= pair.second;
   return *this;
 }
@@ -113,7 +113,7 @@ balance_t& balance_t::operator*=(const amount_t& amt) {
   } else if (!amt.commodity()) {
     // Multiplying by an amount with no commodity causes all the
     // component amounts to be increased by the same factor.
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second *= amt;
   } else if (amounts.size() == 1) {
     // Multiplying by a commoditized amount is only valid if the sole
@@ -142,7 +142,7 @@ balance_t& balance_t::operator/=(const amount_t& amt) {
   } else if (!amt.commodity()) {
     // Dividing by an amount with no commodity causes all the
     // component amounts to be divided by the same factor.
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second /= amt;
   } else if (amounts.size() == 1) {
     // Dividing by a commoditized amount is only valid if the sole
@@ -165,7 +165,7 @@ optional<balance_t> balance_t::value(const datetime_t& moment,
   balance_t temp;
   bool resolved = false;
 
-  foreach (const amounts_map::value_type& pair, amounts) {
+  for (const amounts_map::value_type& pair : amounts) {
     if (optional<amount_t> val = pair.second.value(moment, in_terms_of)) {
       temp += *val;
       resolved = true;
@@ -220,11 +220,11 @@ balance_t balance_t::strip_annotations(const keep_details_t& what_to_keep) const
   // Fast path: if no amounts have annotations that need stripping,
   // return *this directly to avoid the expensive GMP arithmetic of
   // rebuilding the balance via operator+=.
-  foreach (const amounts_map::value_type& pair, amounts) {
+  for (const amounts_map::value_type& pair : amounts) {
     if (!what_to_keep.keep_all(pair.second.commodity())) {
       // At least one amount needs stripping; fall through to rebuild
       balance_t temp;
-      foreach (const amounts_map::value_type& pair2, amounts)
+      for (const amounts_map::value_type& pair2 : amounts)
         temp += pair2.second.strip_annotations(what_to_keep);
       return temp;
     }
@@ -234,7 +234,7 @@ balance_t balance_t::strip_annotations(const keep_details_t& what_to_keep) const
 }
 
 void balance_t::sorted_amounts(amounts_array& sorted) const {
-  foreach (const amounts_map::value_type& pair, amounts)
+  for (const amounts_map::value_type& pair : amounts)
     if (!pair.second.is_null())
       sorted.push_back(&pair.second);
   std::stable_sort(sorted.begin(), sorted.end(), [](const amount_t* left, const amount_t* right) {
@@ -251,7 +251,7 @@ void balance_t::map_sorted_amounts(function<void(const amount_t&)> fn) const {
     } else {
       amounts_array sorted;
       sorted_amounts(sorted);
-      foreach (const amount_t* amount, sorted)
+      for (const amount_t* amount : sorted)
         fn(*amount);
     }
   }
@@ -275,7 +275,7 @@ struct print_amount_from_balance {
         flags(other.flags) {
     TRACE_CTOR(print_amount_from_balance, "copy");
   }
-  ~print_amount_from_balance() throw() { TRACE_DTOR(print_amount_from_balance); }
+  ~print_amount_from_balance() noexcept { TRACE_DTOR(print_amount_from_balance); }
 
   void operator()(const amount_t& amount) {
     if (amount.is_zero())
@@ -320,7 +320,7 @@ void balance_t::print(std::ostream& out, const int first_width, const int latter
 }
 
 void put_balance(property_tree::ptree& st, const balance_t& bal) {
-  foreach (const balance_t::amounts_map::value_type& pair, bal.amounts)
+  for (const balance_t::amounts_map::value_type& pair : bal.amounts)
     put_amount(st.add("amount", ""), pair.second);
 }
 
@@ -330,7 +330,7 @@ balance_t average_lot_prices(const balance_t& bal) {
   typedef std::map<optional<std::string>, std::pair<amount_t, annotation_t>> balance_map;
   balance_map bycomm;
 
-  foreach (const balance_t::amounts_map::value_type& pair, bal.amounts) {
+  for (const balance_t::amounts_map::value_type& pair : bal.amounts) {
     optional<std::string> sym(pair.first->symbol());
     amount_t quant(pair.second.strip_annotations(keep_details_t()));
 
@@ -362,7 +362,7 @@ balance_t average_lot_prices(const balance_t& bal) {
 
   balance_t result;
 
-  foreach (balance_map::value_type& pair, bycomm) {
+  for (balance_map::value_type& pair : bycomm) {
     amount_t amt(pair.second.first);
     if (!amt.is_realzero()) {
       if (pair.second.second.price)

--- a/src/balance.h
+++ b/src/balance.h
@@ -268,14 +268,14 @@ public:
     return temp;
   }
   void in_place_negate() {
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second.in_place_negate();
   }
   balance_t operator-() const { return negated(); }
 
   balance_t abs() const {
     balance_t temp;
-    foreach (const amounts_map::value_type& pair, amounts)
+    for (const amounts_map::value_type& pair : amounts)
       temp += pair.second.abs();
     return temp;
   }
@@ -286,7 +286,7 @@ public:
     return temp;
   }
   void in_place_round() {
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second.in_place_round();
   }
 
@@ -297,7 +297,7 @@ public:
   }
 
   void in_place_roundto(int places) {
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second.in_place_roundto(places);
   }
 
@@ -307,7 +307,7 @@ public:
     return temp;
   }
   void in_place_truncate() {
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second.in_place_truncate();
   }
 
@@ -317,7 +317,7 @@ public:
     return temp;
   }
   void in_place_floor() {
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second.in_place_floor();
   }
 
@@ -327,7 +327,7 @@ public:
     return temp;
   }
   void in_place_ceiling() {
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second.in_place_ceiling();
   }
 
@@ -337,7 +337,7 @@ public:
     return temp;
   }
   void in_place_unround() {
-    foreach (amounts_map::value_type& pair, amounts)
+    for (amounts_map::value_type& pair : amounts)
       pair.second.in_place_unround();
   }
 
@@ -350,7 +350,7 @@ public:
     // A temporary must be used here because reduction may cause
     // multiple component amounts to collapse to the same commodity.
     balance_t temp;
-    foreach (const amounts_map::value_type& pair, amounts)
+    for (const amounts_map::value_type& pair : amounts)
       temp += pair.second.reduced();
     *this = temp;
   }
@@ -364,7 +364,7 @@ public:
     // A temporary must be used here because unreduction may cause
     // multiple component amounts to collapse to the same commodity.
     balance_t temp;
-    foreach (const amounts_map::value_type& pair, amounts)
+    for (const amounts_map::value_type& pair : amounts)
       temp += pair.second.unreduced();
     *this = temp;
   }
@@ -396,7 +396,7 @@ public:
     if (is_empty())
       return false;
 
-    foreach (const amounts_map::value_type& pair, amounts)
+    for (const amounts_map::value_type& pair : amounts)
       if (pair.second.is_nonzero())
         return true;
     return false;
@@ -406,7 +406,7 @@ public:
     if (is_empty())
       return true;
 
-    foreach (const amounts_map::value_type& pair, amounts)
+    for (const amounts_map::value_type& pair : amounts)
       if (!pair.second.is_zero())
         return false;
     return true;
@@ -416,7 +416,7 @@ public:
     if (is_empty())
       return true;
 
-    foreach (const amounts_map::value_type& pair, amounts)
+    for (const amounts_map::value_type& pair : amounts)
       if (!pair.second.is_realzero())
         return false;
     return true;
@@ -468,7 +468,7 @@ public:
 
   balance_t number() const {
     balance_t temp;
-    foreach (const amounts_map::value_type& pair, amounts)
+    for (const amounts_map::value_type& pair : amounts)
       temp += pair.second.number();
     return temp;
   }
@@ -534,7 +534,7 @@ public:
   void dump(std::ostream& out) const {
     out << "BALANCE(";
     bool first = true;
-    foreach (const amounts_map::value_type& pair, amounts) {
+    for (const amounts_map::value_type& pair : amounts) {
       if (first)
         first = false;
       else
@@ -545,7 +545,7 @@ public:
   }
 
   bool valid() const {
-    foreach (const amounts_map::value_type& pair, amounts)
+    for (const amounts_map::value_type& pair : amounts)
       if (!pair.second.valid()) {
         DEBUG("ledger.validate", "balance_t: ! pair.second.valid()");
         return false;

--- a/src/commodity.cc
+++ b/src/commodity.cc
@@ -261,7 +261,7 @@ bool is_reserved_token(const char* buf) {
 } // namespace
 
 bool commodity_t::symbol_needs_quotes(const string& symbol) {
-  foreach (char ch, symbol)
+  for (char ch : symbol)
     if (invalid_chars[static_cast<unsigned char>(ch)])
       return true;
 

--- a/src/compare.h
+++ b/src/compare.h
@@ -66,7 +66,7 @@ public:
   compare_items(const compare_items& other) : sort_order(other.sort_order), report(other.report) {
     TRACE_CTOR(compare_items, "copy");
   }
-  ~compare_items() throw() { TRACE_DTOR(compare_items); }
+  ~compare_items() noexcept { TRACE_DTOR(compare_items); }
 
   void find_sort_values(std::list<sort_value_t>& sort_values, scope_t& scope);
 

--- a/src/convert.cc
+++ b/src/convert.cc
@@ -86,7 +86,7 @@ value_t convert_command(call_scope_t& args) {
   try {
     while (xact_t* xact = reader.read_xact(report.HANDLED(rich_data))) {
       if (report.HANDLED(invert)) {
-        foreach (post_t* post, xact->posts)
+        for (post_t* post : xact->posts)
           post->amount.in_place_negate();
       }
 

--- a/src/csv.cc
+++ b/src/csv.cc
@@ -166,7 +166,7 @@ xact_t* csv_reader::read_xact(bool rich_data) {
 
     case FIELD_PAYEE: {
       bool found = false;
-      foreach (payee_alias_mapping_t& value, context.journal->payee_alias_mappings) {
+      for (payee_alias_mapping_t& value : context.journal->payee_alias_mappings) {
         DEBUG("csv.mappings", "Looking for payee mapping: " << value.first);
         if (value.first.match(field)) {
           xact->payee = value.second;
@@ -228,7 +228,7 @@ xact_t* csv_reader::read_xact(bool rich_data) {
 
   // Translate the account name, if we have enough information to do so
 
-  foreach (account_mapping_t& value, context.journal->payees_for_unknown_accounts) {
+  for (account_mapping_t& value : context.journal->payees_for_unknown_accounts) {
     if (value.first.match(xact->payee)) {
       post->account = value.second;
       break;

--- a/src/draft.cc
+++ b/src/draft.cc
@@ -63,7 +63,7 @@ void draft_t::xact_template_t::dump(std::ostream& out) const {
   if (posts.empty()) {
     out << std::endl << _("<Posting copied from last related transaction>") << std::endl;
   } else {
-    foreach (const post_template_t& post, posts) {
+    for (const post_template_t& post : posts) {
       out << std::endl << _f("[Posting \"%1%\"]") % (post.from ? _("from") : _("to")) << std::endl;
 
       if (post.account_mask)
@@ -193,7 +193,7 @@ void draft_t::parse_args(const value_t& args) {
     if (tmpl->posts.size() > 1 && tmpl->posts.back().account_mask && !tmpl->posts.back().amount)
       tmpl->posts.back().from = true;
 
-    foreach (xact_template_t::post_template_t& post_tmpl, tmpl->posts) {
+    for (xact_template_t::post_template_t& post_tmpl : tmpl->posts) {
       if (post_tmpl.from)
         has_only_to = false;
       else
@@ -312,7 +312,7 @@ xact_t* draft_t::insert(journal_t& journal) {
     if (matching) {
       DEBUG("draft.xact", "Template had no postings, copying from match");
 
-      foreach (post_t* post, matching->posts) {
+      for (post_t* post : matching->posts) {
         added->add_post(new post_t(*post));
         added->posts.back()->set_state(item_t::UNCLEARED);
       }
@@ -324,7 +324,7 @@ xact_t* draft_t::insert(journal_t& journal) {
     DEBUG("draft.xact", "Template had postings");
 
     bool any_post_has_amount = false;
-    foreach (xact_template_t::post_template_t& post, tmpl->posts) {
+    for (xact_template_t::post_template_t& post : tmpl->posts) {
       if (post.amount) {
         DEBUG("draft.xact", "  and at least one has an amount specified");
         any_post_has_amount = true;
@@ -332,7 +332,7 @@ xact_t* draft_t::insert(journal_t& journal) {
       }
     }
 
-    foreach (xact_template_t::post_template_t& post, tmpl->posts) {
+    for (xact_template_t::post_template_t& post : tmpl->posts) {
       unique_ptr<post_t> new_post;
 
       commodity_t* found_commodity = NULL;
@@ -341,7 +341,7 @@ xact_t* draft_t::insert(journal_t& journal) {
         if (post.account_mask) {
           DEBUG("draft.xact", "Looking for matching posting based on account mask");
 
-          foreach (post_t* x, matching->posts) {
+          for (post_t* x : matching->posts) {
             if (post.account_mask->match(x->account->fullname())) {
               new_post.reset(new post_t(*x));
               DEBUG("draft.xact", "Founding posting from line " << x->pos->beg_line);
@@ -402,7 +402,7 @@ xact_t* draft_t::insert(journal_t& journal) {
           // commodity used in that account
           for (xacts_list::reverse_iterator j = journal.xacts.rbegin(); j != journal.xacts.rend();
                j++) {
-            foreach (post_t* x, (*j)->posts) {
+            for (post_t* x : (*j)->posts) {
               if (x->account == acct && !x->amount.is_null()) {
                 new_post.reset(new post_t(*x));
                 DEBUG("draft.xact", "Found account in journal postings, setting new posting");

--- a/src/draft.h
+++ b/src/draft.h
@@ -67,7 +67,7 @@ class draft_t : public expr_base_t<value_t> {
       optional<amount_t> cost;
 
       post_template_t() : from(false) { TRACE_CTOR(post_template_t, ""); }
-      ~post_template_t() throw() { TRACE_DTOR(post_template_t); }
+      ~post_template_t() noexcept { TRACE_DTOR(post_template_t); }
     };
 
     std::list<post_template_t> posts;
@@ -79,7 +79,7 @@ class draft_t : public expr_base_t<value_t> {
       TRACE_CTOR(xact_template_t, "copy");
     }
     xact_template_t& operator=(const xact_template_t&) = default;
-    ~xact_template_t() throw() { TRACE_DTOR(xact_template_t); }
+    ~xact_template_t() noexcept { TRACE_DTOR(xact_template_t); }
 
     void dump(std::ostream& out) const;
   };
@@ -92,7 +92,7 @@ public:
       parse_args(args);
     TRACE_CTOR(draft_t, "value_t");
   }
-  virtual ~draft_t() throw() { TRACE_DTOR(draft_t); }
+  virtual ~draft_t() noexcept { TRACE_DTOR(draft_t); }
 
   void parse_args(const value_t& args);
 

--- a/src/error.h
+++ b/src/error.h
@@ -81,8 +81,8 @@ string source_context(const path& file, const std::istream::pos_type pos,
 #define DECLARE_EXCEPTION(name, kind)                                                              \
   class name : public kind {                                                                       \
   public:                                                                                          \
-    explicit name(const string& why) throw() : kind(why) {}                                        \
-    virtual ~name() throw() {}                                                                     \
+    explicit name(const string& why) noexcept : kind(why) {}                                        \
+    virtual ~name() noexcept {}                                                                     \
   }
 
 struct error_count {

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -76,11 +76,11 @@ expr_t& expr_t::operator=(const expr_t& _expr) {
   return *this;
 }
 
-expr_t::operator bool() const throw() {
+expr_t::operator bool() const noexcept {
   return ptr.get() != NULL;
 }
 
-expr_t::ptr_op_t expr_t::get_op() throw() {
+expr_t::ptr_op_t expr_t::get_op() noexcept {
   return ptr;
 }
 
@@ -236,7 +236,7 @@ void merged_expr_t::compile(scope_t& scope) {
     std::ostringstream buf;
 
     buf << "__tmp_" << term << "=(" << term << "=(" << base_expr << ")";
-    foreach (const string& expr, exprs) {
+    for (const string& expr : exprs) {
       if (merge_operator == ";")
         buf << merge_operator << term << "=" << expr;
       else

--- a/src/expr.h
+++ b/src/expr.h
@@ -86,9 +86,9 @@ public:
 
   expr_t& operator=(const expr_t& _expr);
 
-  virtual operator bool() const throw() override;
+  virtual operator bool() const noexcept override;
 
-  ptr_op_t get_op() throw();
+  ptr_op_t get_op() noexcept;
 
   void parse(const string& str, const parse_flags_t& flags = PARSE_DEFAULT) {
     std::istringstream stream(str);

--- a/src/exprbase.h
+++ b/src/exprbase.h
@@ -102,9 +102,9 @@ public:
     return *this;
   }
 
-  virtual operator bool() const throw() { return !str.empty(); }
+  virtual operator bool() const noexcept { return !str.empty(); }
 
-  virtual string text() const throw() { return str; }
+  virtual string text() const noexcept { return str; }
   void set_text(const string& txt) {
     str = txt;
     compiled = false;

--- a/src/filters.h
+++ b/src/filters.h
@@ -448,7 +448,7 @@ public:
       : item_handler<post_t>(handler), also_matching(_also_matching) {
     TRACE_CTOR(related_posts, "post_handler_ptr, const bool");
   }
-  virtual ~related_posts() throw() { TRACE_DTOR(related_posts); }
+  virtual ~related_posts() noexcept { TRACE_DTOR(related_posts); }
 
   virtual void flush() override;
   virtual void operator()(post_t& post) override {
@@ -599,7 +599,7 @@ protected:
           must_balance(av.must_balance) {
       TRACE_CTOR(acct_value_t, "copy");
     }
-    ~acct_value_t() throw() { TRACE_DTOR(acct_value_t); }
+    ~acct_value_t() noexcept { TRACE_DTOR(acct_value_t); }
   };
 
   typedef std::map<string, acct_value_t> values_map;
@@ -665,7 +665,7 @@ public:
     create_accounts();
     TRACE_CTOR(interval_posts, "post_handler_ptr, expr_t&, date_interval_t, bool, bool");
   }
-  virtual ~interval_posts() throw() { TRACE_DTOR(interval_posts); }
+  virtual ~interval_posts() noexcept { TRACE_DTOR(interval_posts); }
 
   void create_accounts() { empty_account = &temps.create_account(_("<None>")); }
 
@@ -712,7 +712,7 @@ public:
     create_accounts();
     TRACE_CTOR(posts_as_equity, "post_handler_ptr, expr_t&");
   }
-  virtual ~posts_as_equity() throw() { TRACE_DTOR(posts_as_equity); }
+  virtual ~posts_as_equity() noexcept { TRACE_DTOR(posts_as_equity); }
 
   void create_accounts() {
     equity_account = &temps.create_account(_("Equity"));
@@ -802,7 +802,7 @@ public:
       : subtotal_posts(handler, amount_expr) {
     TRACE_CTOR(day_of_week_posts, "post_handler_ptr, bool");
   }
-  virtual ~day_of_week_posts() throw() { TRACE_DTOR(day_of_week_posts); }
+  virtual ~day_of_week_posts() noexcept { TRACE_DTOR(day_of_week_posts); }
 
   virtual void flush() override;
   virtual void operator()(post_t& post) override {
@@ -865,7 +865,7 @@ public:
       : generate_posts(handler), flags(_flags), terminus(_terminus) {
     TRACE_CTOR(budget_posts, "post_handler_ptr, date_t, uint_least8_t");
   }
-  virtual ~budget_posts() throw() { TRACE_DTOR(budget_posts); }
+  virtual ~budget_posts() noexcept { TRACE_DTOR(budget_posts); }
 
   void report_budget_items(const date_t& date);
 
@@ -885,7 +885,7 @@ public:
         forecast_years(_forecast_years) {
     TRACE_CTOR(forecast_posts, "post_handler_ptr, predicate_t, scope_t&, std::size_t");
   }
-  virtual ~forecast_posts() throw() { TRACE_DTOR(forecast_posts); }
+  virtual ~forecast_posts() noexcept { TRACE_DTOR(forecast_posts); }
 
   virtual void add_post(const date_interval_t& period, post_t& post) override;
   virtual void flush() override;
@@ -907,7 +907,7 @@ class inject_posts : public item_handler<post_t> {
 public:
   inject_posts(post_handler_ptr handler, const string& tag_list, account_t* master);
 
-  virtual ~inject_posts() throw() {
+  virtual ~inject_posts() noexcept {
     TRACE_DTOR(inject_posts);
     handler.reset();
   }

--- a/src/flags.h
+++ b/src/flags.h
@@ -58,7 +58,7 @@ public:
     TRACE_CTOR(supports_flags, "copy");
   }
   supports_flags(const flags_t& arg) : _flags(arg) { TRACE_CTOR(supports_flags, "const flags_t&"); }
-  ~supports_flags() throw() { TRACE_DTOR(supports_flags); }
+  ~supports_flags() noexcept { TRACE_DTOR(supports_flags); }
 
   supports_flags& operator=(const supports_flags& other) {
     _flags = other._flags;
@@ -90,7 +90,7 @@ public:
     TRACE_CTOR(basic_t, "const U&");
     supports_flags<T, U>::set_flags(static_cast<T>(bits));
   }
-  ~basic_t() throw() { TRACE_DTOR(basic_t); }
+  ~basic_t() noexcept { TRACE_DTOR(basic_t); }
 
   basic_t(const basic_t& other) : supports_flags<T, U>(other) { TRACE_CTOR(basic_t, "copy"); }
   basic_t& operator=(const basic_t& other) {
@@ -130,7 +130,7 @@ public:
   delegates_flags(supports_flags<T>& arg) : _flags(arg) {
     TRACE_CTOR(delegates_flags, "const supports_flags<T>&");
   }
-  ~delegates_flags() throw() { TRACE_DTOR(delegates_flags); }
+  ~delegates_flags() noexcept { TRACE_DTOR(delegates_flags); }
 
   flags_t flags() const { return _flags.flags(); }
   bool has_flags(const flags_t arg) const { return _flags.has_flags(arg); }

--- a/src/format.h
+++ b/src/format.h
@@ -66,10 +66,10 @@ class format_t : public expr_base_t<string>, public noncopyable {
     variant<string, expr_t> data;
     scoped_ptr<struct element_t> next;
 
-    element_t() throw() : supports_flags<>(), type(STRING), min_width(0), max_width(0) {
+    element_t() noexcept : supports_flags<>(), type(STRING), min_width(0), max_width(0) {
       TRACE_CTOR(element_t, "");
     }
-    ~element_t() throw() { TRACE_DTOR(element_t); }
+    ~element_t() noexcept { TRACE_DTOR(element_t); }
 
     element_t& operator=(const element_t& elem) {
       if (this != &elem) {

--- a/src/generate.h
+++ b/src/generate.h
@@ -101,7 +101,7 @@ class generate_posts_iterator
 public:
   generate_posts_iterator(session_t& _session, unsigned int _seed = 0, std::size_t _quantity = 100);
 
-  virtual ~generate_posts_iterator() throw() { TRACE_DTOR(generate_posts_iterator); }
+  virtual ~generate_posts_iterator() noexcept { TRACE_DTOR(generate_posts_iterator); }
 
   virtual void increment();
 

--- a/src/global.cc
+++ b/src/global.cc
@@ -415,7 +415,7 @@ void global_scope_t::normalize_session_options() {
   INFO("Initialization file is " << HANDLER(init_file_).str());
   INFO("Price database is " << session().HANDLER(price_db_).str());
 
-  foreach (const path& pathname, session().HANDLER(file_).data_files)
+  for (const path& pathname : session().HANDLER(file_).data_files)
     INFO("Journal file is " << pathname.string());
 }
 

--- a/src/history.cc
+++ b/src/history.cc
@@ -293,7 +293,7 @@ void commodity_history_impl_t::map_prices(function<void(datetime_t, const amount
 
     const price_map_t& prices(get(ratiomap, edge));
 
-    foreach (const price_map_t::value_type& pair, prices) {
+    for (const price_map_t::value_type& pair : prices) {
       const datetime_t& when(pair.first);
 
       DEBUG("history.map", "Price " << pair.second << " on " << when);
@@ -482,7 +482,7 @@ template <class Name>
 class label_writer {
 public:
   label_writer(Name _name) : name(_name) { TRACE_CTOR(label_writer<Name>, "Name"); }
-  ~label_writer() throw() { TRACE_DTOR(label_writer<Name>); }
+  ~label_writer() noexcept { TRACE_DTOR(label_writer<Name>); }
 
   template <class VertexOrEdge>
   void operator()(std::ostream& out, const VertexOrEdge& v) const {

--- a/src/item.cc
+++ b/src/item.cc
@@ -57,7 +57,7 @@ bool item_t::has_tag(const string& tag, bool) const {
 
 bool item_t::has_tag(const mask_t& tag_mask, const optional<mask_t>& value_mask, bool) const {
   if (metadata) {
-    foreach (const string_map::value_type& data, *metadata) {
+    for (const string_map::value_type& data : *metadata) {
       if (tag_mask.match(data.first)) {
         if (!value_mask)
           return true;
@@ -85,7 +85,7 @@ optional<value_t> item_t::get_tag(const string& tag, bool) const {
 optional<value_t> item_t::get_tag(const mask_t& tag_mask, const optional<mask_t>& value_mask,
                                   bool) const {
   if (metadata) {
-    foreach (const string_map::value_type& data, *metadata) {
+    for (const string_map::value_type& data : *metadata) {
       if (tag_mask.match(data.first) &&
           (!value_mask ||
            (data.second.first && value_mask->match(data.second.first->to_string())))) {
@@ -566,7 +566,7 @@ string item_context(const item_t& item, const string& desc) {
 }
 
 void put_metadata(property_tree::ptree& st, const item_t::string_map& metadata) {
-  foreach (const item_t::string_map::value_type& pair, metadata) {
+  for (const item_t::string_map::value_type& pair : metadata) {
     if (pair.second.first) {
       property_tree::ptree& vt(st.add("value", ""));
       vt.put("<xmlattr>.key", pair.first);

--- a/src/item.h
+++ b/src/item.h
@@ -60,7 +60,7 @@ struct position_t {
     *this = pos;
     TRACE_CTOR(position_t, "copy");
   }
-  ~position_t() throw() { TRACE_DTOR(position_t); }
+  ~position_t() noexcept { TRACE_DTOR(position_t); }
 
   position_t& operator=(const position_t& pos) {
     if (this != &pos) {

--- a/src/iterators.cc
+++ b/src/iterators.cc
@@ -83,7 +83,7 @@ struct create_price_xact {
       : journal(_journal), account(_account), temps(_temps), xact_temps(_xact_temps) {
     TRACE_CTOR(create_price_xact, "journal_t&, account_t *, temporaries_t&, xacts_list&");
   }
-  ~create_price_xact() throw() { TRACE_DTOR(create_price_xact); }
+  ~create_price_xact() noexcept { TRACE_DTOR(create_price_xact); }
 
   void operator()(const datetime_t& date, const amount_t& price) {
     xact_t* xact;
@@ -104,7 +104,7 @@ struct create_price_xact {
 
     bool post_already_exists = false;
 
-    foreach (post_t* post, xact->posts) {
+    for (post_t* post : xact->posts) {
       if (post->date() == date.date() && post->amount == price) {
         post_already_exists = true;
         break;
@@ -140,7 +140,7 @@ void posts_commodities_iterator::reset(journal_t& journal) {
     commodities.insert(&comm.referent());
   }
 
-  foreach (commodity_t* comm, commodities)
+  for (commodity_t* comm : commodities)
     comm->map_prices(create_price_xact(journal, journal.master->find_account(comm->symbol()), temps,
                                        xact_temps));
 
@@ -194,7 +194,7 @@ void sorted_accounts_iterator::push_back(account_t& account) {
 
 #if DEBUG_ON
     if (SHOW_DEBUG("account.sorted")) {
-      foreach (account_t* acct, accounts_list.back())
+      for (account_t* acct : accounts_list.back())
         DEBUG("account.sorted", "Account (flat): " << acct->fullname());
     }
 #endif
@@ -207,21 +207,21 @@ void sorted_accounts_iterator::push_back(account_t& account) {
 }
 
 void sorted_accounts_iterator::push_all(account_t& account, accounts_deque_t& deque) {
-  foreach (accounts_map::value_type& pair, account.accounts) {
+  for (accounts_map::value_type& pair : account.accounts) {
     deque.push_back(pair.second);
     push_all(*pair.second, deque);
   }
 }
 
 void sorted_accounts_iterator::sort_accounts(account_t& account, accounts_deque_t& deque) {
-  foreach (accounts_map::value_type& pair, account.accounts)
+  for (accounts_map::value_type& pair : account.accounts)
     deque.push_back(pair.second);
 
   std::stable_sort(deque.begin(), deque.end(), compare_items<account_t>(sort_cmp, report));
 
 #if DEBUG_ON
   if (SHOW_DEBUG("account.sorted")) {
-    foreach (account_t* acct, deque)
+    for (account_t* acct : deque)
       DEBUG("account.sorted", "Account: " << acct->fullname());
   }
 #endif

--- a/src/iterators.h
+++ b/src/iterators.h
@@ -60,7 +60,7 @@ public:
   iterator_facade_base(const iterator_facade_base& i) : m_node(i.m_node) {
     TRACE_CTOR(iterator_facade_base, "copy");
   }
-  ~iterator_facade_base() throw() { TRACE_DTOR(iterator_facade_base); }
+  ~iterator_facade_base() noexcept { TRACE_DTOR(iterator_facade_base); }
 
   explicit iterator_facade_base(node_base p) : m_node(p) {}
 
@@ -95,7 +95,7 @@ public:
         posts_i(i.posts_i), posts_end(i.posts_end), posts_uninitialized(i.posts_uninitialized) {
     TRACE_CTOR(xact_posts_iterator, "copy");
   }
-  ~xact_posts_iterator() throw() { TRACE_DTOR(xact_posts_iterator); }
+  ~xact_posts_iterator() noexcept { TRACE_DTOR(xact_posts_iterator); }
 
   void reset(xact_t& xact) {
     posts_i = xact.posts.begin();
@@ -136,7 +136,7 @@ public:
         xacts_i(i.xacts_i), xacts_end(i.xacts_end), xacts_uninitialized(i.xacts_uninitialized) {
     TRACE_CTOR(xacts_iterator, "copy");
   }
-  ~xacts_iterator() throw() { TRACE_DTOR(xacts_iterator); }
+  ~xacts_iterator() noexcept { TRACE_DTOR(xacts_iterator); }
 
   void reset(journal_t& journal);
 
@@ -165,7 +165,7 @@ public:
         xacts(i.xacts), posts(i.posts) {
     TRACE_CTOR(journal_posts_iterator, "copy");
   }
-  ~journal_posts_iterator() throw() { TRACE_DTOR(journal_posts_iterator); }
+  ~journal_posts_iterator() noexcept { TRACE_DTOR(journal_posts_iterator); }
 
   void reset(journal_t& journal);
 
@@ -193,7 +193,7 @@ public:
         temps(i.temps) {
     TRACE_CTOR(posts_commodities_iterator, "copy");
   }
-  ~posts_commodities_iterator() throw() { TRACE_DTOR(posts_commodities_iterator); }
+  ~posts_commodities_iterator() noexcept { TRACE_DTOR(posts_commodities_iterator); }
 
   void reset(journal_t& journal);
 
@@ -217,7 +217,7 @@ public:
         accounts_i(i.accounts_i), accounts_end(i.accounts_end) {
     TRACE_CTOR(basic_accounts_iterator, "copy");
   }
-  ~basic_accounts_iterator() throw() { TRACE_DTOR(basic_accounts_iterator); }
+  ~basic_accounts_iterator() noexcept { TRACE_DTOR(basic_accounts_iterator); }
 
   void increment();
 
@@ -255,7 +255,7 @@ public:
         sorted_accounts_end(i.sorted_accounts_end) {
     TRACE_CTOR(sorted_accounts_iterator, "copy");
   }
-  ~sorted_accounts_iterator() throw() { TRACE_DTOR(sorted_accounts_iterator); }
+  ~sorted_accounts_iterator() noexcept { TRACE_DTOR(sorted_accounts_iterator); }
 
   void increment();
 

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -68,10 +68,10 @@ journal_t::~journal_t() {
 
   // Don't bother unhooking each xact's posts from the accounts they refer to,
   // because all accounts are about to be deleted.
-  foreach (xact_t* xact, xacts)
+  for (xact_t* xact : xacts)
     checked_delete(xact);
 
-  foreach (period_xact_t* xact, period_xacts)
+  for (period_xact_t* xact : period_xacts)
     checked_delete(xact);
 
   // Clear auto_xacts before deleting master to avoid use-after-free:
@@ -131,7 +131,7 @@ account_t* journal_t::register_account(const string& name, post_t* post,
   // If the account name being registered is "Unknown", check whether
   // the payee indicates an account that should be used.
   if (result->name == _("Unknown")) {
-    foreach (account_mapping_t& value, payees_for_unknown_accounts) {
+    for (account_mapping_t& value : payees_for_unknown_accounts) {
       if (post && post->xact && value.first.match(post->xact->payee)) {
         result = value.second;
         break;
@@ -248,7 +248,7 @@ bool journal_t::payee_not_registered(const string& name) {
 string journal_t::translate_payee_name(const string& name) {
   string payee;
 
-  foreach (payee_alias_mapping_t& value, payee_alias_mappings) {
+  for (payee_alias_mapping_t& value : payee_alias_mappings) {
     if (value.first.match(name)) {
       payee = value.second;
       break;
@@ -318,7 +318,7 @@ void check_all_metadata(journal_t& journal, variant<int, xact_t*, post_t*> conte
   post_t* post = context.which() == 2 ? boost::get<post_t*>(context) : NULL;
 
   if ((xact || post) && (xact ? xact->metadata : post->metadata)) {
-    foreach (const item_t::string_map::value_type& pair, xact ? *xact->metadata : *post->metadata) {
+    for (const item_t::string_map::value_type& pair : xact ? *xact->metadata : *post->metadata) {
       const string& key(pair.first);
 
       const optional<value_t>& value = pair.second.first;
@@ -356,7 +356,7 @@ bool journal_t::add_xact(xact_t* xact) {
   extend_xact(xact);
   check_all_metadata(*this, xact);
 
-  foreach (post_t* post, xact->posts) {
+  for (post_t* post : xact->posts) {
     extend_post(*post, *this);
     check_all_metadata(*this, post);
   }
@@ -372,7 +372,7 @@ bool journal_t::add_xact(xact_t* xact) {
     if (!result.second) {
       // This UUID has been seen before; apply any postings which the
       // earlier version may have deferred.
-      foreach (post_t* post, xact->posts) {
+      for (post_t* post : xact->posts) {
         account_t* acct = post->account;
         if (acct->deferred_posts) {
           auto i = acct->deferred_posts->find(uuid);
@@ -419,7 +419,7 @@ bool journal_t::add_xact(xact_t* xact) {
 }
 
 void journal_t::extend_xact(xact_base_t* xact) {
-  foreach (unique_ptr<auto_xact_t>& auto_xact, auto_xacts)
+  for (unique_ptr<auto_xact_t>& auto_xact : auto_xacts)
     auto_xact->extend_xact(*xact, *current_context);
 }
 
@@ -481,15 +481,15 @@ std::size_t journal_t::read(parse_context_stack_t& context, hash_type_t hash_typ
 }
 
 bool journal_t::has_xdata() {
-  foreach (xact_t* xact, xacts)
+  for (xact_t* xact : xacts)
     if (xact->has_xdata())
       return true;
 
-  foreach (unique_ptr<auto_xact_t>& xact, auto_xacts)
+  for (unique_ptr<auto_xact_t>& xact : auto_xacts)
     if (xact->has_xdata())
       return true;
 
-  foreach (period_xact_t* xact, period_xacts)
+  for (period_xact_t* xact : period_xacts)
     if (xact->has_xdata())
       return true;
 
@@ -500,15 +500,15 @@ bool journal_t::has_xdata() {
 }
 
 void journal_t::clear_xdata() {
-  foreach (xact_t* xact, xacts)
+  for (xact_t* xact : xacts)
     if (!xact->has_flags(ITEM_TEMP))
       xact->clear_xdata();
 
-  foreach (unique_ptr<auto_xact_t>& xact, auto_xacts)
+  for (unique_ptr<auto_xact_t>& xact : auto_xacts)
     if (!xact->has_flags(ITEM_TEMP))
       xact->clear_xdata();
 
-  foreach (period_xact_t* xact, period_xacts)
+  for (period_xact_t* xact : period_xacts)
     if (!xact->has_flags(ITEM_TEMP))
       xact->clear_xdata();
 
@@ -521,7 +521,7 @@ bool journal_t::valid() const {
     return false;
   }
 
-  foreach (const xact_t* xact, xacts)
+  for (const xact_t* xact : xacts)
     if (!xact->valid()) {
       DEBUG("ledger.validate", "journal_t: xact not valid");
       return false;

--- a/src/journal.h
+++ b/src/journal.h
@@ -78,7 +78,7 @@ public:
         : filename(info.filename), modtime(info.modtime), from_stream(info.from_stream) {
       TRACE_CTOR(journal_t::fileinfo_t, "copy");
     }
-    ~fileinfo_t() throw() { TRACE_DTOR(journal_t::fileinfo_t); }
+    ~fileinfo_t() noexcept { TRACE_DTOR(journal_t::fileinfo_t); }
   };
 
   account_t* master;

--- a/src/lookup.cc
+++ b/src/lookup.cc
@@ -113,7 +113,7 @@ std::pair<xact_t*, account_t*> lookup_probable_account(const string& ident,
     char_positions_map positions;
 
     // Walk each letter in the source identifier
-    foreach (const uint32_t& ch, lowered_ident.utf32chars) {
+    for (const uint32_t& ch : lowered_ident.utf32chars) {
       int addend = 0;
       bool added_bonus = false;
       std::size_t value_len = value_key.length();
@@ -248,7 +248,7 @@ std::pair<xact_t*, account_t*> lookup_probable_account(const string& ident,
     DEBUG("lookup.account",
           "Payee: " << std::setw(5) << std::right << (*si).second << " - " << (*si).first->payee);
 
-    foreach (post_t* post, (*si).first->posts) {
+    for (post_t* post : (*si).first->posts) {
       if (!post->has_flags(ITEM_TEMP | ITEM_GENERATED) && post->account != ref_account &&
           !post->account->has_flags(ACCOUNT_TEMP | ACCOUNT_GENERATED)) {
         account_use_map::iterator x = account_usage.find(post->account);
@@ -264,7 +264,7 @@ std::pair<xact_t*, account_t*> lookup_probable_account(const string& ident,
   if (account_usage.size() > 0) {
 #if DEBUG_ON
     if (SHOW_DEBUG("lookup.account")) {
-      foreach (const account_use_pair& value, account_usage) {
+      for (const account_use_pair& value : account_usage) {
         DEBUG("lookup.account", "Account: " << value.second << " - " << value.first->fullname());
       }
     }

--- a/src/mask.h
+++ b/src/mask.h
@@ -80,7 +80,7 @@ public:
   mask_t() : expr() { TRACE_CTOR(mask_t, ""); }
   mask_t(const mask_t& m) : expr(m.expr) { TRACE_CTOR(mask_t, "copy"); }
   mask_t& operator=(const mask_t&) = default;
-  ~mask_t() throw() { TRACE_DTOR(mask_t); }
+  ~mask_t() noexcept { TRACE_DTOR(mask_t); }
 
   mask_t& operator=(const string& other);
   mask_t& assign_glob(const string& other);

--- a/src/option.cc
+++ b/src/option.cc
@@ -46,7 +46,7 @@ op_bool_tuple find_option(scope_t& scope, const string& name) {
     throw_(option_error, _f("Illegal option --%1%") % name);
   }
 
-  foreach (char ch, name) {
+  for (char ch : name) {
     if (ch == '-')
       *p++ = '_';
     else
@@ -215,7 +215,7 @@ strings_list process_arguments(strings_list args, scope_t& scope) {
         option_queue.push_back(op_bool_char_tuple(opt.first, opt.second, c));
       }
 
-      foreach (op_bool_char_tuple& o, option_queue) {
+      for (op_bool_char_tuple& o : option_queue) {
         const char* value = NULL;
         if (o.truth && ++i != args.end()) {
           value = (*i).c_str();

--- a/src/output.cc
+++ b/src/output.cc
@@ -186,7 +186,7 @@ std::pair<std::size_t, std::size_t> format_accounts::mark_accounts(account_t& ac
   std::size_t visited = 0;
   std::size_t to_display = 0;
 
-  foreach (accounts_map::value_type& pair, account.accounts) {
+  for (accounts_map::value_type& pair : account.accounts) {
     std::pair<std::size_t, std::size_t> i = mark_accounts(*pair.second, flat);
     visited += i.first;
     to_display += i.second;
@@ -229,7 +229,7 @@ void format_accounts::flush() {
 
   std::size_t displayed = 0;
 
-  foreach (account_t* account, posted_accounts)
+  for (account_t* account : posted_accounts)
     displayed += post_account(*account, report.HANDLED(flat));
 
   if (displayed > 1 && !report.HANDLED(no_total) && !report.HANDLED(percent)) {
@@ -261,7 +261,7 @@ namespace {
       accounts.insert(
           report_accounts::accounts_report_map::value_type(&account, 0));
 
-    foreach (accounts_map::value_type& pair, account.accounts)
+    for (accounts_map::value_type& pair : account.accounts)
       collect_known_accounts(*pair.second, accounts);
   }
 } // namespace
@@ -281,7 +281,7 @@ void report_accounts::flush() {
 
   collect_known_accounts(*report.session.journal->master, accounts);
 
-  foreach (accounts_pair& entry, accounts) {
+  for (accounts_pair& entry : accounts) {
     if (do_prepend_format) {
       bind_scope_t bound_scope(report, *entry.first);
       out.width(static_cast<std::streamsize>(prepend_width));
@@ -305,7 +305,7 @@ void report_accounts::operator()(post_t& post) {
 void report_payees::flush() {
   std::ostream& out(report.output_stream);
 
-  foreach (payees_pair& entry, payees) {
+  for (payees_pair& entry : payees) {
     if (report.HANDLED(count))
       out << entry.second << ' ';
     out << entry.first << '\n';
@@ -323,7 +323,7 @@ void report_payees::operator()(post_t& post) {
 void report_tags::flush() {
   std::ostream& out(report.output_stream);
 
-  foreach (tags_pair& entry, tags) {
+  for (tags_pair& entry : tags) {
     if (report.HANDLED(count))
       out << entry.second << ' ';
     out << entry.first << '\n';
@@ -333,7 +333,7 @@ void report_tags::flush() {
 void report_tags::gather_metadata(item_t& item) {
   if (!item.metadata)
     return;
-  foreach (const item_t::string_map::value_type& data, *item.metadata) {
+  for (const item_t::string_map::value_type& data : *item.metadata) {
     string tag(data.first);
     if (report.HANDLED(values) && data.second.first)
       tag += ": " + data.second.first.get().to_string();
@@ -354,7 +354,7 @@ void report_tags::operator()(post_t& post) {
 void report_commodities::flush() {
   std::ostream& out(report.output_stream);
 
-  foreach (commodities_pair& entry, commodities) {
+  for (commodities_pair& entry : commodities) {
     if (report.HANDLED(count))
       out << entry.second << ' ';
     out << *entry.first << '\n';

--- a/src/parser.h
+++ b/src/parser.h
@@ -87,7 +87,7 @@ class expr_t::parser_t : public noncopyable {
 
 public:
   parser_t() : use_lookahead(false) { TRACE_CTOR(parser_t, ""); }
-  ~parser_t() throw() { TRACE_DTOR(parser_t); }
+  ~parser_t() noexcept { TRACE_DTOR(parser_t); }
 
   ptr_op_t parse(std::istream& in, const parse_flags_t& flags = PARSE_DEFAULT,
                  const optional<string>& original_string = boost::none);

--- a/src/post.cc
+++ b/src/post.cc
@@ -352,7 +352,7 @@ value_t fn_any(call_scope_t& args) {
   post_t& post(args.context<post_t>());
   expr_t::ptr_op_t expr(args.get<expr_t::ptr_op_t>(0));
 
-  foreach (post_t* p, post.xact->posts) {
+  for (post_t* p : post.xact->posts) {
     bind_scope_t bound_scope(args, *p);
     if (p == &post && args.has(1) && !args.get<bool>(1)) {
       // If the user specifies any(EXPR, false), and the context is a
@@ -369,7 +369,7 @@ value_t fn_all(call_scope_t& args) {
   post_t& post(args.context<post_t>());
   expr_t::ptr_op_t expr(args.get<expr_t::ptr_op_t>(0));
 
-  foreach (post_t* p, post.xact->posts) {
+  for (post_t* p : post.xact->posts) {
     bind_scope_t bound_scope(args, *p);
     if (p == &post && args.has(1) && !args.get<bool>(1)) {
       // If the user specifies any(EXPR, false), and the context is a
@@ -533,7 +533,7 @@ amount_t post_t::resolve_expr(scope_t& scope, expr_t& expr) {
 
 std::size_t post_t::xact_id() const {
   std::size_t id = 1;
-  foreach (post_t* p, xact->posts) {
+  for (post_t* p : xact->posts) {
     if (p == this)
       return id;
     id++;
@@ -544,7 +544,7 @@ std::size_t post_t::xact_id() const {
 
 std::size_t post_t::account_id() const {
   std::size_t id = 1;
-  foreach (post_t* p, account->posts) {
+  for (post_t* p : account->posts) {
     if (p == this)
       return id;
     id++;

--- a/src/post.h
+++ b/src/post.h
@@ -177,7 +177,7 @@ public:
           date(other.date), account(other.account), sort_values(other.sort_values) {
       TRACE_CTOR(post_t::xdata_t, "copy");
     }
-    ~xdata_t() throw() { TRACE_DTOR(post_t::xdata_t); }
+    ~xdata_t() noexcept { TRACE_DTOR(post_t::xdata_t); }
   };
 
   // This variable holds optional "extended data" which is usually produced

--- a/src/print.cc
+++ b/src/print.cc
@@ -156,7 +156,7 @@ void print_xact(report_t& report, std::ostream& out, xact_t& xact) {
   out << '\n';
 
   if (xact.metadata) {
-    foreach (const item_t::string_map::value_type& data, *xact.metadata) {
+    for (const item_t::string_map::value_type& data : *xact.metadata) {
       if (!data.second.second) {
         out << "    ; ";
         if (data.second.first)
@@ -177,13 +177,13 @@ void print_xact(report_t& report, std::ostream& out, xact_t& xact) {
 
   // Find the longest account name to line up all amounts when account names
   // are long
-  foreach (post_t* post, xact.posts) {
+  for (post_t* post : xact.posts) {
     unistring name = format_account_name(xact, post).str();
     if (account_width < name.length())
       account_width = name.length();
   }
 
-  foreach (post_t* post, xact.posts) {
+  for (post_t* post : xact.posts) {
     index++;
 
     if (!report.HANDLED(generated) &&
@@ -297,7 +297,7 @@ void print_xacts::flush() {
   std::ostream& out(report.output_stream);
 
   bool first = true;
-  foreach (xact_t* xact, xacts) {
+  for (xact_t* xact : xacts) {
     if (first)
       first = false;
     else

--- a/src/pstream.h
+++ b/src/pstream.h
@@ -66,7 +66,7 @@ class ptristream : public std::istream {
 
       TRACE_CTOR(ptrinbuf, "char *, std::size_t");
     }
-    ~ptrinbuf() throw() { TRACE_DTOR(ptrinbuf); }
+    ~ptrinbuf() noexcept { TRACE_DTOR(ptrinbuf); }
 
   protected:
     virtual int_type underflow() override {

--- a/src/ptree.cc
+++ b/src/ptree.cc
@@ -57,19 +57,19 @@ void format_ptree::flush() {
                               Ledger_VERSION_PATCH));
 
   property_tree::ptree& ct(pt.put("ledger.commodities", ""));
-  foreach (const commodities_pair& pair, commodities)
+  for (const commodities_pair& pair : commodities)
     put_commodity(ct.add("commodity", ""), *pair.second, true);
 
   property_tree::ptree& at(pt.put("ledger.accounts", ""));
   put_account(at.add("account", ""), *report.session.journal->master, account_visited_p);
 
   property_tree::ptree& tt(pt.put("ledger.transactions", ""));
-  foreach (const xact_t* xact, transactions) {
+  for (const xact_t* xact : transactions) {
     property_tree::ptree& t(tt.add("transaction", ""));
     put_xact(t, *xact);
 
     property_tree::ptree& post_tree(t.put("postings", ""));
-    foreach (const post_t* post, xact->posts)
+    for (const post_t* post : xact->posts)
       if (post->has_xdata() && post->xdata().has_flags(POST_EXT_VISITED))
         put_post(post_tree.add("posting", ""), *post);
   }

--- a/src/py_commodity.cc
+++ b/src/py_commodity.cc
@@ -102,8 +102,8 @@ commodity_t* py_pool_getitem(commodity_pool_t& pool, const string& symbol) {
 
 list py_pool_keys(commodity_pool_t& pool) {
   list keys;
-  BOOST_REVERSE_FOREACH(const commodity_pool_t::commodities_map::value_type& pair,
-                        pool.commodities) {
+  for (auto it = pool.commodities.rbegin(); it != pool.commodities.rend(); ++it) {
+    const auto& pair = *it;
     keys.insert(0, pair.first);
   }
   return keys;

--- a/src/py_journal.cc
+++ b/src/py_journal.cc
@@ -186,7 +186,7 @@ shared_ptr<collector_wrapper> py_query(journal_t& journal, const string& query) 
     coll->report.normalize_options("register");
 
     value_t args;
-    foreach (const string& arg, remaining)
+    for (const string& arg : remaining)
       args.push_back(string_value(arg));
     coll->report.parse_query_args(args, "@Journal.query");
 

--- a/src/pyinterp.cc
+++ b/src/pyinterp.cc
@@ -462,7 +462,7 @@ object convert_value_to_python(const value_t& val) {
     return object(val);
   case value_t::SEQUENCE: { // a vector of value_t objects
     list arglist;
-    foreach (const value_t& elem, val.as_sequence())
+    for (const value_t& elem : val.as_sequence())
       arglist.append(elem);
     return arglist;
   }
@@ -507,7 +507,7 @@ value_t python_interpreter_t::functor_t::operator()(call_scope_t& args) {
       // jww (2009-11-05): What about a single argument which is a sequence,
       // rather than a sequence of arguments?
       if (args.value().is_sequence())
-        foreach (const value_t& value, args.value().as_sequence())
+        for (const value_t& value : args.value().as_sequence())
           arglist.append(convert_value_to_python(value));
       else
         arglist.append(convert_value_to_python(args.value()));

--- a/src/pyinterp.h
+++ b/src/pyinterp.h
@@ -122,7 +122,7 @@ public:
     functor_t(const functor_t& other) : func(other.func), name(other.name) {
       TRACE_CTOR(functor_t, "copy");
     }
-    virtual ~functor_t() throw() { TRACE_DTOR(functor_t); }
+    virtual ~functor_t() noexcept { TRACE_DTOR(functor_t); }
     virtual value_t operator()(call_scope_t& args);
   };
 

--- a/src/query.h
+++ b/src/query.h
@@ -107,7 +107,7 @@ public:
       token_t(const token_t& tok) : kind(tok.kind), value(tok.value) {
         TRACE_CTOR(query_t::lexer_t::token_t, "copy");
       }
-      ~token_t() throw() { TRACE_DTOR(query_t::lexer_t::token_t); }
+      ~token_t() noexcept { TRACE_DTOR(query_t::lexer_t::token_t); }
 
       token_t& operator=(const token_t& tok) {
         if (this != &tok) {
@@ -243,7 +243,7 @@ public:
       TRACE_CTOR(query_t::lexer_t, "copy");
     }
     lexer_t& operator=(const lexer_t&) = default;
-    ~lexer_t() throw() { TRACE_DTOR(query_t::lexer_t); }
+    ~lexer_t() noexcept { TRACE_DTOR(query_t::lexer_t); }
 
     token_t next_token(token_t::kind_t tok_context = token_t::UNKNOWN);
     void push_token(token_t tok) {
@@ -288,7 +288,7 @@ protected:
     parser_t(const parser_t& other) : args(other.args), lexer(other.lexer) {
       TRACE_CTOR(query_t::parser_t, "copy");
     }
-    ~parser_t() throw() { TRACE_DTOR(query_t::parser_t); }
+    ~parser_t() noexcept { TRACE_DTOR(query_t::parser_t); }
 
     expr_t::ptr_op_t parse(bool subexpression = false) {
       return parse_query_expr(lexer_t::token_t::TOK_ACCOUNT, subexpression);

--- a/src/report.cc
+++ b/src/report.cc
@@ -313,7 +313,7 @@ struct posts_flusher {
   posts_flusher(post_handler_ptr _handler, report_t& _report) : handler(_handler), report(_report) {
     TRACE_CTOR(posts_flusher, "post_handler_ptr, report_t&");
   }
-  ~posts_flusher() throw() { TRACE_DTOR(posts_flusher); }
+  ~posts_flusher() noexcept { TRACE_DTOR(posts_flusher); }
 
   void operator()(const value_t&) { report.session.journal->clear_xdata(); }
 };
@@ -687,7 +687,7 @@ value_t report_t::fn_quoted(call_scope_t& args) {
 
   out << '"';
   string arg(args.get<string>(0));
-  foreach (const char ch, arg) {
+  for (const char ch : arg) {
     if (ch == '"')
       out << "\\\"";
     else
@@ -703,7 +703,7 @@ value_t report_t::fn_quoted_rfc(call_scope_t& args) {
 
   out << '"';
   string arg(args.get<string>(0));
-  foreach (const char ch, arg) {
+  for (const char ch : arg) {
     if (ch == '"')
       out << '"' << '"';
     else
@@ -718,7 +718,7 @@ value_t report_t::fn_join(call_scope_t& args) {
   std::ostringstream out;
 
   string arg(args.get<string>(0));
-  foreach (const char ch, arg) {
+  for (const char ch : arg) {
     if (ch != '\n')
       out << ch;
     else
@@ -828,7 +828,7 @@ value_t report_t::fn_nail_down(call_scope_t& args) {
 
   case value_t::BALANCE: {
     balance_t tmp;
-    foreach (const balance_t::amounts_map::value_type& pair, arg0.as_balance_lval().amounts) {
+    for (const balance_t::amounts_map::value_type& pair : arg0.as_balance_lval().amounts) {
       call_scope_t inner_args(*args.parent);
       inner_args.push_back(pair.second);
       inner_args.push_back(arg1);
@@ -839,7 +839,7 @@ value_t report_t::fn_nail_down(call_scope_t& args) {
 
   case value_t::SEQUENCE: {
     value_t tmp;
-    foreach (value_t& value, arg0.as_sequence_lval()) {
+    for (value_t& value : arg0.as_sequence_lval()) {
       call_scope_t inner_args(*args.parent);
       inner_args.push_back(value);
       inner_args.push_back(arg1);

--- a/src/report.h
+++ b/src/report.h
@@ -1035,7 +1035,7 @@ public:
       : handler(other.handler), report(other.report), whence(other.whence) {
     TRACE_CTOR(reporter, "copy");
   }
-  ~reporter() throw() { TRACE_DTOR(reporter); }
+  ~reporter() noexcept { TRACE_DTOR(reporter); }
 
   value_t operator()(call_scope_t& args) {
     if (args.size() > 0)

--- a/src/scope.h
+++ b/src/scope.h
@@ -60,7 +60,7 @@ struct symbol_t {
   symbol_t(const symbol_t& sym) : kind(sym.kind), name(sym.name), definition(sym.definition) {
     TRACE_CTOR(symbol_t, "copy");
   }
-  ~symbol_t() throw() { TRACE_DTOR(symbol_t); }
+  ~symbol_t() noexcept { TRACE_DTOR(symbol_t); }
 
   bool operator<(const symbol_t& sym) const { return kind < sym.kind || name < sym.name; }
   bool operator==(const symbol_t& sym) const { return kind == sym.kind || name == sym.name; }
@@ -88,7 +88,7 @@ public:
 class empty_scope_t : public scope_t {
 public:
   empty_scope_t() { TRACE_CTOR(empty_scope_t, ""); }
-  ~empty_scope_t() throw() { TRACE_DTOR(empty_scope_t); }
+  ~empty_scope_t() noexcept { TRACE_DTOR(empty_scope_t); }
 
   virtual string description() override { return _("<empty>"); }
   virtual expr_t::ptr_op_t lookup(const symbol_t::kind_t, const string&) override { return NULL; }
@@ -498,7 +498,7 @@ public:
   value_scope_t(scope_t& _parent, const value_t& _value) : child_scope_t(_parent), value(_value) {
     TRACE_CTOR(value_scope_t, "scope_t&, value_t");
   }
-  ~value_scope_t() throw() { TRACE_DTOR(value_scope_t); }
+  ~value_scope_t() noexcept { TRACE_DTOR(value_scope_t); }
 
   virtual string description() override { return parent->description(); }
 

--- a/src/select.cc
+++ b/src/select.cc
@@ -177,7 +177,7 @@ value_t select_command(call_scope_t& args) {
       bool saw_account = false;
 
       std::size_t cols_needed = 0;
-      foreach (const value_t& column, columns.to_sequence()) {
+      for (const value_t& column : columns.to_sequence()) {
         string ident;
         if (get_principal_identifiers(as_expr(column), ident)) {
           if (ident == "date" || ident == "aux_date") {
@@ -242,7 +242,7 @@ value_t select_command(call_scope_t& args) {
       if (!report.HANDLED(total_width_))
         report.HANDLER(total_width_).value = to_string(total_width);
 
-      foreach (const value_t& column, columns.to_sequence()) {
+      for (const value_t& column : columns.to_sequence()) {
         if (first)
           first = false;
         else

--- a/src/session.cc
+++ b/src/session.cc
@@ -139,7 +139,7 @@ std::size_t session_t::read_data(const string& master_account) {
     }
   }
 
-  foreach (const path& pathname, HANDLER(file_).data_files) {
+  for (const path& pathname : HANDLER(file_).data_files) {
     if (pathname == "-" || pathname == "/dev/stdin") {
       // To avoid problems with stdin and pipes, etc., we read the entire
       // file in beforehand into a memory buffer, and then parcel it out

--- a/src/stats.cc
+++ b/src/stats.cc
@@ -61,7 +61,7 @@ value_t report_statistics(call_scope_t& args) {
 
   out << _("  Files these postings came from:") << std::endl;
 
-  foreach (const path& pathname, statistics.filenames)
+  for (const path& pathname : statistics.filenames)
     if (!pathname.empty())
       out << "    " << pathname.string() << std::endl;
   out << std::endl;

--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -145,7 +145,6 @@
 #include <boost/filesystem/directory.hpp>
 #include <boost/filesystem/path.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/function.hpp>
 

--- a/src/temps.cc
+++ b/src/temps.cc
@@ -112,7 +112,7 @@ account_t& temporaries_t::create_account(const string& name, account_t* parent) 
 
 void temporaries_t::clear() {
   if (post_temps) {
-    foreach (post_t& post, *post_temps) {
+    for (post_t& post : *post_temps) {
       if (!post.xact->has_flags(ITEM_TEMP))
         post.xact->remove_post(&post);
 
@@ -126,7 +126,7 @@ void temporaries_t::clear() {
     xact_temps->clear();
 
   if (acct_temps) {
-    foreach (account_t& acct, *acct_temps) {
+    for (account_t& acct : *acct_temps) {
       if (acct.parent && !acct.parent->has_flags(ACCOUNT_TEMP))
         acct.parent->remove_account(&acct);
     }

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -90,7 +90,7 @@ public:
 
   template <typename T>
   void get_applications(std::vector<T>& result) {
-    foreach (application_t& state, apply_stack) {
+    for (application_t& state : apply_stack) {
       if (state.value.type() == typeid(T))
         result.push_back(boost::get<T>(state.value));
     }
@@ -100,7 +100,7 @@ public:
 
   template <typename T>
   optional<T> get_application() {
-    foreach (application_t& state, apply_stack) {
+    for (application_t& state : apply_stack) {
       if (state.value.type() == typeid(T))
         return boost::get<T>(state.value);
     }
@@ -242,7 +242,7 @@ void instance_t::parse() {
         for (instance_t* instance = parent; instance; instance = instance->parent)
           instances.push_front(instance);
 
-        foreach (instance_t* instance, instances)
+        for (instance_t* instance : instances)
           add_error_context(_f("In file included from %1%") % instance->context.location());
       }
       add_error_context(_f("While parsing file %1%") % context.location());
@@ -596,7 +596,7 @@ void instance_t::automated_xact_directive(char* line) {
   if (command == "enable" || command == "disable") {
     DEBUG("textual.autoxact", command << " automated transaction matching '" << name << "'");
     bool enabled = command == "enable";
-    foreach (unique_ptr<auto_xact_t>& xact, context.journal->auto_xacts) {
+    for (unique_ptr<auto_xact_t>& xact : context.journal->auto_xacts) {
       if (xact->name && name_mask.match(xact->name.get())) {
         DEBUG("textual.autoxact", command << "d '" << xact->name.get() << "'");
         xact->enabled = enabled;
@@ -646,7 +646,7 @@ void instance_t::automated_xact_directive(char* line) {
       throw parse_error(_("Expected predicate after '='"));
     }
 
-    foreach (unique_ptr<auto_xact_t>& xact, context.journal->auto_xacts) {
+    for (unique_ptr<auto_xact_t>& xact : context.journal->auto_xacts) {
       if (xact->name && name == xact->name.get()) {
         throw_(parse_error, _f("Automated transaction with name '%1%' already exists") % name);
       }
@@ -1540,7 +1540,7 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
         if (!post->amount.has_annotation()) {
           std::vector<fixed_rate_t> rates;
           get_applications<fixed_rate_t>(rates);
-          foreach (fixed_rate_t& rate, rates) {
+          for (fixed_rate_t& rate : rates) {
             if (*rate.first == post->amount.commodity()) {
               annotation_t details(rate.second);
               details.add_flags(ANNOTATION_PRICE_FIXATED);
@@ -1848,7 +1848,7 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
 
     std::vector<string> tags;
     get_applications<string>(tags);
-    foreach (string& tag, tags)
+    for (string& tag : tags)
       post->parse_tags(tag.c_str(), *context.scope, true);
 
     string post_payee = post->payee_from_tag();
@@ -2048,7 +2048,7 @@ xact_t* instance_t::parse_xact(char* line, std::streamsize len, account_t* accou
   if (xact->_state == item_t::UNCLEARED) {
     item_t::application_t result = item_t::CLEARED;
 
-    foreach (post_t * post, xact->posts) {
+    for (post_t * post : xact->posts) {
       if (post->_state == item_t::UNCLEARED) {
         result = item_t::UNCLEARED;
         break;
@@ -2065,7 +2065,7 @@ xact_t* instance_t::parse_xact(char* line, std::streamsize len, account_t* accou
 
     std::vector<string> tags;
     get_applications<string>(tags);
-    foreach (string& tag, tags)
+    for (string& tag : tags)
       xact->parse_tags(tag.c_str(), *context.scope, false);
 
     TRACE_STOP(xact_details, 1);

--- a/src/timelog.cc
+++ b/src/timelog.cc
@@ -151,10 +151,10 @@ void time_log_t::close() {
   if (!time_xacts.empty()) {
     std::list<account_t*> accounts;
 
-    foreach (time_xact_t& time_xact, time_xacts)
+    for (time_xact_t& time_xact : time_xacts)
       accounts.push_back(time_xact.account);
 
-    foreach (account_t* account, accounts) {
+    for (account_t* account : accounts) {
       DEBUG("timelog", "Clocking out from account " << account->fullname());
       context.count += clock_out_from_timelog(
           time_xacts, time_xact_t(none, CURRENT_TIME(), false, account), context);
@@ -165,7 +165,7 @@ void time_log_t::close() {
 
 void time_log_t::clock_in(time_xact_t event) {
   if (!time_xacts.empty()) {
-    foreach (time_xact_t& time_xact, time_xacts) {
+    for (time_xact_t& time_xact : time_xacts) {
       if (event.account == time_xact.account)
         throw parse_error(_("Cannot double check-in to the same account"));
     }

--- a/src/timelog.h
+++ b/src/timelog.h
@@ -74,7 +74,7 @@ public:
     TRACE_CTOR(time_xact_t, "copy");
   }
   time_xact_t& operator=(const time_xact_t&) = default;
-  ~time_xact_t() throw() { TRACE_DTOR(time_xact_t); }
+  ~time_xact_t() noexcept { TRACE_DTOR(time_xact_t); }
 };
 
 class time_log_t : public boost::noncopyable {

--- a/src/times.cc
+++ b/src/times.cc
@@ -192,7 +192,7 @@ date_t parse_date_mask_routine(const char* date_str, date_io_t& io, date_traits_
 }
 
 date_t parse_date_mask(const char* date_str, date_traits_t* traits = NULL) {
-  foreach (shared_ptr<date_io_t>& reader, readers) {
+  for (shared_ptr<date_io_t>& reader : readers) {
     date_t when = parse_date_mask_routine(date_str, *reader.get(), traits);
     if (!when.is_not_a_date())
       return when;
@@ -411,7 +411,7 @@ class date_parser_t {
       token_t(const token_t& tok) : kind(tok.kind), value(tok.value) {
         TRACE_CTOR(date_parser_t::lexer_t::token_t, "copy");
       }
-      ~token_t() throw() { TRACE_DTOR(date_parser_t::lexer_t::token_t); }
+      ~token_t() noexcept { TRACE_DTOR(date_parser_t::lexer_t::token_t); }
 
       token_t& operator=(const token_t& tok) {
         if (this != &tok) {
@@ -644,7 +644,7 @@ class date_parser_t {
         : begin(other.begin), end(other.end), token_cache(other.token_cache) {
       TRACE_CTOR(date_parser_t::lexer_t, "copy");
     }
-    ~lexer_t() throw() { TRACE_DTOR(date_parser_t::lexer_t); }
+    ~lexer_t() noexcept { TRACE_DTOR(date_parser_t::lexer_t); }
 
     token_t next_token();
     void push_token(token_t tok) {
@@ -668,7 +668,7 @@ public:
   date_parser_t(const date_parser_t& parser) : arg(parser.arg), lexer(parser.lexer) {
     TRACE_CTOR(date_parser_t, "copy");
   }
-  ~date_parser_t() throw() { TRACE_DTOR(date_parser_t); }
+  ~date_parser_t() noexcept { TRACE_DTOR(date_parser_t); }
 
   date_interval_t parse();
 
@@ -1875,11 +1875,11 @@ void times_shutdown() {
 
     readers.clear();
 
-    foreach (datetime_io_map::value_type& pair, temp_datetime_io)
+    for (datetime_io_map::value_type& pair : temp_datetime_io)
       checked_delete(pair.second);
     temp_datetime_io.clear();
 
-    foreach (date_io_map::value_type& pair, temp_date_io)
+    for (date_io_map::value_type& pair : temp_date_io)
       checked_delete(pair.second);
     temp_date_io.clear();
 

--- a/src/times.h
+++ b/src/times.h
@@ -125,7 +125,7 @@ struct date_traits_t {
       : has_year(traits.has_year), has_month(traits.has_month), has_day(traits.has_day) {
     TRACE_CTOR(date_traits_t, "copy");
   }
-  ~date_traits_t() throw() { TRACE_DTOR(date_traits_t); }
+  ~date_traits_t() noexcept { TRACE_DTOR(date_traits_t); }
 
   date_traits_t& operator=(const date_traits_t& traits) {
     has_year = traits.has_year;
@@ -151,7 +151,7 @@ struct date_duration_t {
   date_duration_t(const date_duration_t& dur) : quantum(dur.quantum), length(dur.length) {
     TRACE_CTOR(date_duration_t, "copy");
   }
-  ~date_duration_t() throw() { TRACE_DTOR(date_duration_t); }
+  ~date_duration_t() noexcept { TRACE_DTOR(date_duration_t); }
 
   date_t add(const date_t& date) const {
     switch (quantum) {
@@ -262,7 +262,7 @@ public:
     TRACE_CTOR(date_specifier_t, "copy");
   }
   date_specifier_t& operator=(const date_specifier_t&) = default;
-  ~date_specifier_t() throw() { TRACE_DTOR(date_specifier_t); }
+  ~date_specifier_t() noexcept { TRACE_DTOR(date_specifier_t); }
 
   date_t begin() const;
   date_t end() const;
@@ -315,7 +315,7 @@ public:
         end_inclusive(other.end_inclusive) {
     TRACE_CTOR(date_range_t, "date_range_t");
   }
-  ~date_range_t() throw() { TRACE_DTOR(date_range_t); }
+  ~date_range_t() noexcept { TRACE_DTOR(date_range_t); }
 
   optional<date_t> begin() const {
     if (range_begin)
@@ -371,7 +371,7 @@ public:
   date_specifier_or_range_t(const date_range_t& range) : specifier_or_range(range) {
     TRACE_CTOR(date_specifier_or_range_t, "date_range_t");
   }
-  ~date_specifier_or_range_t() throw() { TRACE_DTOR(date_specifier_or_range_t); }
+  ~date_specifier_or_range_t() noexcept { TRACE_DTOR(date_specifier_or_range_t); }
 
   optional<date_t> begin() const {
     if (specifier_or_range.type() == typeid(date_specifier_t))
@@ -429,7 +429,7 @@ public:
     TRACE_CTOR(date_interval_t, "copy");
   }
   date_interval_t& operator=(const date_interval_t&) = default;
-  ~date_interval_t() throw() { TRACE_DTOR(date_interval_t); }
+  ~date_interval_t() noexcept { TRACE_DTOR(date_interval_t); }
 
   bool operator==(const date_interval_t& other) const {
     return (start == other.start && (!start || *start == *other.start));

--- a/src/token.h
+++ b/src/token.h
@@ -99,7 +99,7 @@ struct expr_t::token_t : public noncopyable {
   std::size_t length;
 
   explicit token_t() : kind(UNKNOWN), length(0) { TRACE_CTOR(expr_t::token_t, ""); }
-  ~token_t() throw() { TRACE_DTOR(expr_t::token_t); }
+  ~token_t() noexcept { TRACE_DTOR(expr_t::token_t); }
 
   token_t& operator=(const token_t& other) {
     if (&other == this)

--- a/src/unistring.h
+++ b/src/unistring.h
@@ -77,7 +77,7 @@ public:
 
   std::size_t width() const {
     std::size_t width = 0;
-    foreach (const boost::uint32_t& ch, utf32chars) {
+    for (const boost::uint32_t& ch : utf32chars) {
       width += mk_wcwidth(ch);
     }
     return width;
@@ -150,7 +150,7 @@ public:
 
   std::size_t find(const boost::uint32_t __s, std::size_t __pos = 0) const {
     std::size_t idx = 0;
-    foreach (const boost::uint32_t& ch, utf32chars) {
+    for (const boost::uint32_t& ch : utf32chars) {
       if (idx >= __pos && ch == __s)
         return idx;
       idx++;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -143,7 +143,7 @@ inline void add_to_count_map(object_count_map& the_map, const char* name, std::s
 std::size_t current_memory_size() {
   std::size_t memory_size = 0;
 
-  foreach (const object_count_map::value_type& pair, *live_memory_count)
+  for (const object_count_map::value_type& pair : *live_memory_count)
     memory_size += pair.second.second;
 
   return memory_size;
@@ -321,7 +321,7 @@ void stream_memory_size(std::ostream& out, std::size_t size) {
 }
 
 void report_count_map(std::ostream& out, object_count_map& the_map) {
-  foreach (object_count_map::value_type& pair, the_map) {
+  for (object_count_map::value_type& pair : the_map) {
     out << "  " << std::right << std::setw(18);
     stream_commified_number(out, pair.second.first);
     out << "  " << std::right << std::setw(7);
@@ -334,7 +334,7 @@ void report_count_map(std::ostream& out, object_count_map& the_map) {
 std::size_t current_objects_size() {
   std::size_t objects_size = 0;
 
-  foreach (const object_count_map::value_type& pair, *live_object_count)
+  for (const object_count_map::value_type& pair : *live_object_count)
     objects_size += pair.second.second;
 
   return objects_size;
@@ -411,7 +411,7 @@ void report_memory(std::ostream& out, bool report_all) {
   if (live_memory->size() > 0) {
     out << "Live memory:" << std::endl;
 
-    foreach (const memory_map::value_type& pair, *live_memory) {
+    for (const memory_map::value_type& pair : *live_memory) {
       out << "  " << std::right << std::setw(18) << pair.first << "  " << std::right
           << std::setw(7);
       stream_memory_size(out, pair.second.second);
@@ -432,7 +432,7 @@ void report_memory(std::ostream& out, bool report_all) {
   if (live_objects->size() > 0) {
     out << "Live objects:" << std::endl;
 
-    foreach (const objects_map::value_type& pair, *live_objects) {
+    for (const objects_map::value_type& pair : *live_objects) {
       out << "  " << std::right << std::setw(18) << pair.first << "  " << std::right
           << std::setw(7);
       stream_memory_size(out, pair.second.second);

--- a/src/utils.h
+++ b/src/utils.h
@@ -406,7 +406,6 @@ inline void check_for_signal() {
  */
 /*@{*/
 
-#define foreach BOOST_FOREACH
 using std::unique_ptr;
 
 namespace ledger {

--- a/src/value.cc
+++ b/src/value.cc
@@ -107,7 +107,7 @@ value_t::operator bool() const {
   }
   case SEQUENCE:
     if (!as_sequence().empty()) {
-      foreach (const value_t& value, as_sequence()) {
+      for (const value_t& value : as_sequence()) {
         if (value)
           return true;
       }
@@ -289,7 +289,7 @@ value_t value_t::number() const {
   case SEQUENCE:
     if (!as_sequence().empty()) {
       value_t temp;
-      foreach (const value_t& value, as_sequence())
+      for (const value_t& value : as_sequence())
         temp += value.number();
       return temp;
     }
@@ -921,7 +921,7 @@ bool value_t::is_less_than(const value_t& val) const {
     case INTEGER:
     case AMOUNT: {
       bool no_amounts = true;
-      foreach (const balance_t::amounts_map::value_type& pair, as_balance().amounts) {
+      for (const balance_t::amounts_map::value_type& pair : as_balance().amounts) {
         if (pair.second >= val)
           return false;
         no_amounts = false;
@@ -969,7 +969,7 @@ bool value_t::is_less_than(const value_t& val) const {
     case INTEGER:
     case AMOUNT: {
       bool no_amounts = true;
-      foreach (const value_t& value, as_sequence()) {
+      for (const value_t& value : as_sequence()) {
         if (value >= val)
           return false;
         no_amounts = false;
@@ -1062,7 +1062,7 @@ bool value_t::is_greater_than(const value_t& val) const {
     case INTEGER:
     case AMOUNT: {
       bool no_amounts = true;
-      foreach (const balance_t::amounts_map::value_type& pair, as_balance().amounts) {
+      for (const balance_t::amounts_map::value_type& pair : as_balance().amounts) {
         if (pair.second <= val)
           return false;
         no_amounts = false;
@@ -1110,7 +1110,7 @@ bool value_t::is_greater_than(const value_t& val) const {
     case INTEGER:
     case AMOUNT: {
       bool no_amounts = true;
-      foreach (const value_t& value, as_sequence()) {
+      for (const value_t& value : as_sequence()) {
         if (value <= val)
           return false;
         no_amounts = false;
@@ -1379,7 +1379,7 @@ void value_t::in_place_negate() {
     as_balance_lval().in_place_negate();
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_negate();
     return;
   default:
@@ -1415,7 +1415,7 @@ void value_t::in_place_not() {
     set_boolean(as_string().empty());
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_not();
     return;
   default:
@@ -1509,7 +1509,7 @@ value_t value_t::value(const datetime_t& moment, const commodity_t* in_terms_of)
 
   case SEQUENCE: {
     value_t temp;
-    foreach (const value_t& value, as_sequence())
+    for (const value_t& value : as_sequence())
       temp.push_back(value.value(moment, in_terms_of));
     return temp;
   }
@@ -1527,7 +1527,7 @@ value_t value_t::exchange_commodities(const std::string& commodities, const bool
                                       const datetime_t& moment) {
   if (type() == SEQUENCE) {
     value_t temp;
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       temp.push_back(value.exchange_commodities(commodities, add_prices, moment));
     return temp;
   }
@@ -1545,7 +1545,7 @@ value_t value_t::exchange_commodities(const std::string& commodities, const bool
   typedef tokenizer<char_separator<char>> tokenizer;
   tokenizer tokens(commodities, char_separator<char>(","));
 
-  foreach (const string& name, tokens) {
+  for (const string& name : tokens) {
     string target_name = name;
     string source_name;
 
@@ -1578,7 +1578,7 @@ value_t value_t::exchange_commodities(const std::string& commodities, const bool
   }
 
   std::size_t index = 0;
-  foreach (commodity_t* comm, comms) {
+  for (commodity_t* comm : comms) {
     switch (type()) {
     case AMOUNT:
       DEBUG("commodity.exchange", "We have an amount: " << as_amount_lval());
@@ -1605,7 +1605,7 @@ value_t value_t::exchange_commodities(const std::string& commodities, const bool
       bool repriced = false;
 
       DEBUG("commodity.exchange", "We have a balance: " << as_balance_lval());
-      foreach (const balance_t::amounts_map::value_type& pair, as_balance_lval().amounts) {
+      for (const balance_t::amounts_map::value_type& pair : as_balance_lval().amounts) {
         DEBUG("commodity.exchange", "We have a balance amount of commodity: "
                                         << pair.first->symbol()
                                         << " == " << pair.second.commodity().symbol());
@@ -1659,7 +1659,7 @@ void value_t::in_place_reduce() {
     as_balance_lval().in_place_reduce();
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_reduce();
     return;
   default:
@@ -1678,7 +1678,7 @@ void value_t::in_place_unreduce() {
     as_balance_lval().in_place_unreduce();
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_unreduce();
     return;
   default:
@@ -1722,7 +1722,7 @@ void value_t::in_place_round() {
     as_balance_lval().in_place_round();
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_round();
     return;
   default:
@@ -1745,7 +1745,7 @@ void value_t::in_place_roundto(int places) {
     as_balance_lval().in_place_roundto(places);
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_roundto(places);
     return;
   default:
@@ -1764,7 +1764,7 @@ void value_t::in_place_truncate() {
     as_balance_lval().in_place_truncate();
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_truncate();
     return;
   default:
@@ -1786,7 +1786,7 @@ void value_t::in_place_floor() {
     as_balance_lval().in_place_floor();
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_floor();
     return;
   default:
@@ -1808,7 +1808,7 @@ void value_t::in_place_ceiling() {
     as_balance_lval().in_place_ceiling();
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_ceiling();
     return;
   default:
@@ -1830,7 +1830,7 @@ void value_t::in_place_unround() {
     as_balance_lval().in_place_unround();
     return;
   case SEQUENCE:
-    foreach (value_t& value, as_sequence_lval())
+    for (value_t& value : as_sequence_lval())
       value.in_place_unround();
     return;
   default:
@@ -1889,7 +1889,7 @@ value_t value_t::strip_annotations(const keep_details_t& what_to_keep) const {
 
   case SEQUENCE: {
     sequence_t temp;
-    foreach (const value_t& value, as_sequence())
+    for (const value_t& value : as_sequence())
       temp.push_back(new value_t(value.strip_annotations(what_to_keep)));
     return temp;
   }
@@ -2010,7 +2010,7 @@ void value_t::print(std::ostream& _out, const int first_width, const int latter_
   case SEQUENCE: {
     out << '(';
     bool first = true;
-    foreach (const value_t& value, as_sequence()) {
+    for (const value_t& value : as_sequence()) {
       if (first)
         first = false;
       else
@@ -2081,7 +2081,7 @@ void value_t::dump(std::ostream& out, const bool relaxed) const {
 
   case STRING:
     out << '"';
-    foreach (const char& ch, as_string()) {
+    for (const char& ch : as_string()) {
       switch (ch) {
       case '"':
         out << "\\\"";
@@ -2114,7 +2114,7 @@ void value_t::dump(std::ostream& out, const bool relaxed) const {
   case SEQUENCE: {
     out << '(';
     bool first = true;
-    foreach (const value_t& value, as_sequence()) {
+    for (const value_t& value : as_sequence()) {
       if (first)
         first = false;
       else
@@ -2204,7 +2204,7 @@ void put_value(property_tree::ptree& pt, const value_t& value) {
 
   case value_t::SEQUENCE: {
     property_tree::ptree& st(pt.add("sequence", ""));
-    foreach (const value_t& member, value.as_sequence())
+    for (const value_t& member : value.as_sequence())
       put_value(st, member);
     break;
   }


### PR DESCRIPTION
## Summary

**Stacked on #2592 (Phase-2).** Merge Phase-2 first.

- Replace all 67 deprecated `throw()` exception specifications with `noexcept`
- Convert all 219 `BOOST_FOREACH` / `foreach` macro invocations to C++11 range-based for loops

## Details

### throw() → noexcept
The `throw()` dynamic exception specification was deprecated in C++11 and removed in C++20. All instances are replaced with `noexcept`, which has stronger optimization semantics (the compiler can assume no exceptions escape, enabling better code generation).

### BOOST_FOREACH → range-for
The `foreach` macro (aliased from `BOOST_FOREACH`) is replaced with native C++11 range-based for loops throughout the codebase. This eliminates the Boost.Foreach dependency and produces clearer, more idiomatic code. Both `foreach(T x, container)` and `foreach(T& x, container)` patterns are handled, preserving const-correctness and reference semantics.

## Test plan
- [ ] All 1,390+ regression tests pass
- [ ] Build succeeds with C++17 and C++20 standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)