### PR TITLE
Fix balance assignments with multiple files (#1831)

### DIFF
--- a/src/account.cc
+++ b/src/account.cc
@@ -660,6 +660,20 @@ value_t account_t::amount(const optional<bool> real_only, const optional<expr_t&
   }
 }
 
+value_t account_t::self_total(bool real_only) const {
+  value_t result;
+  std::set<const post_t*> seen;
+  for (const post_t* post : posts) {
+    if (!seen.insert(post).second)
+      continue;
+    if (real_only && post->has_flags(POST_VIRTUAL))
+      continue;
+    if (!post->amount.is_null())
+      add_or_set_value(result, post->amount);
+  }
+  return result;
+}
+
 value_t account_t::total(const optional<expr_t&>& expr) const {
   if (!(xdata_ && xdata_->family_details.calculated)) {
     const_cast<account_t&>(*this).xdata().family_details.calculated = true;

--- a/src/account.h
+++ b/src/account.h
@@ -221,6 +221,7 @@ public:
 
   value_t amount(const optional<bool> real_only = false,
                  const optional<expr_t&>& expr = none) const;
+  value_t self_total(bool real_only = false) const;
   value_t total(const optional<expr_t&>& expr = none) const;
 
   const xdata_t::details_t& self_details(bool gather_all = true) const;

--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -562,7 +562,7 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
 
         value_t account_total(
             post->account
-                ->amount(!(post->has_flags(POST_VIRTUAL) || post->has_flags(POST_IS_TIMELOG))));
+                ->self_total(!(post->has_flags(POST_VIRTUAL) || post->has_flags(POST_IS_TIMELOG))));
         if (strip)
           account_total = account_total.strip_annotations(keep_details_t());
 
@@ -638,8 +638,8 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
               // and lot date) so that the assigned amount retains them.
               value_t ann_total(
                   post->account
-                      ->amount(!(post->has_flags(POST_VIRTUAL) ||
-                                 post->has_flags(POST_IS_TIMELOG))));
+                      ->self_total(!(post->has_flags(POST_VIRTUAL) ||
+                                     post->has_flags(POST_IS_TIMELOG))));
               balance_t ann_diff = amt;
               switch (ann_total.type()) {
               case value_t::AMOUNT:

--- a/test/regress/1831_1.test
+++ b/test/regress/1831_1.test
@@ -1,0 +1,20 @@
+; Regression test for issue #1831
+; Balance assignments should produce correct results regardless of
+; whether transactions are in one file or split across multiple files.
+; This test verifies the single-file case works correctly.
+
+2018-01-01 Initial assignment
+  Assets:Cash             10000.00 EUR
+  Equity
+
+2019-01-01 Dummy expense
+  Assets:Cash              -100.00 EUR
+  Expenses
+
+2020-01-01 Reassignment
+  Assets:Cash           = 10000.00 EUR
+  Equity
+
+test bal Assets:Cash
+        10000.00 EUR  Assets:Cash
+end test

--- a/test/regress/1831_2.test
+++ b/test/regress/1831_2.test
@@ -1,0 +1,8 @@
+; Regression test for issue #1831
+; Balance assignments with multiple files: the balance assignment in the
+; second file should account for transactions from the first file.
+; Assets:Cash should be 10000.00 EUR (not 20000.00 EUR).
+
+test -f $sourcepath/test/regress/1831_2a.dat -f $sourcepath/test/regress/1831_2b.dat bal Assets:Cash -> 0
+        10000.00 EUR  Assets:Cash
+end test

--- a/test/regress/1831_2a.dat
+++ b/test/regress/1831_2a.dat
@@ -1,0 +1,3 @@
+2018-01-01 Initial assignment
+  Assets:Cash             10000.00 EUR
+  Equity

--- a/test/regress/1831_2b.dat
+++ b/test/regress/1831_2b.dat
@@ -1,0 +1,7 @@
+2019-01-01 Dummy expense
+  Assets:Cash              -100.00 EUR
+  Expenses
+
+2020-01-01 Reassignment
+  Assets:Cash           = 10000.00 EUR
+  Equity


### PR DESCRIPTION
## Summary
- Fix balance assignments (`= amount`) producing incorrect results when transactions are split across multiple journal files
- Add `account_t::self_total()` method that directly iterates the account's posts list to compute running balance, independent of the xdata cache that gets cleared between file reads
- The old code path used `account_t::amount()` which depends on xdata; when xdata was cleared between files, it returned NULL_VALUE (zero), causing the balance assignment to compute the wrong diff

## Test plan
- [x] Added regression test `1831_1.test` for single-file balance assignments (verifies no regression)
- [x] Added regression test `1831_2.test` with separate `.dat` files testing multi-file balance assignments
- [x] All 1394 existing tests pass (including the previously-fragile `2031_a` timelog test)
- [x] Manual verification: `ledger -f sample1.dat -f sample2.dat bal` now produces correct 10000.00 EUR instead of incorrect 20000.00 EUR

Fixes #1831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)