### PR TITLE
Add regression test for segfault on --monthly with no records (#908)

### DIFF
--- a/test/regress/908.test
+++ b/test/regress/908.test
@@ -1,0 +1,11 @@
+; Regression test for issue #908
+; Segfault on register grouping when no records returned
+; An empty ledger file with --monthly and a non-matching filter
+; should return empty output, not segfault.
+
+2015/01/01 Test payee
+    Expenses:Food              $10.00
+    Assets:Checking
+
+test reg --monthly nonexistent
+end test


### PR DESCRIPTION
## Summary
- Add regression test verifying that `--monthly` grouping with a non-matching filter produces empty output instead of segfaulting
- This issue was previously fixed but lacked a regression test

## Test plan
- [x] New test `908.test` passes
- [x] All existing tests continue to pass

Fixes #908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)