### PR TITLE
Add regression test for virtual posting multi-commodity bug (#988)

### DIFF
--- a/test/regress/988.test
+++ b/test/regress/988.test
@@ -1,0 +1,11 @@
+; Regression test for issue #988
+; Virtual-only transactions with multiple commodities should not
+; generate non-virtual (real) postings.
+
+2013/09/03  Budget for travel to Mexico
+  [Assets:Budgeted]                       -200.00 USD
+  [Assets:Budgeted]                   -7000.00 MXN
+  [Budget:Travel]
+
+test bal --real
+end test


### PR DESCRIPTION
## Summary
- Add regression test verifying that transactions containing only virtual postings with multiple commodities do not generate spurious non-virtual (real) postings
- This issue was previously fixed but lacked a regression test

## Test plan
- [x] New test `988.test` passes (`bal --real` on virtual-only transaction produces empty output)
- [x] All existing tests continue to pass

Fixes #988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)