### PR TITLE
Add regression test for print amount alignment (#934)

### DIFF
--- a/test/regress/934.test
+++ b/test/regress/934.test
@@ -1,0 +1,14 @@
+; Regression test for issue #934
+; "ledger print" should properly align amounts
+
+2015/01/01 Test
+    Expenses:Food:Groceries             $12.50
+    Expenses:Food:Dining Out           $123.45
+    Assets:Checking
+
+test print
+2015/01/01 Test
+    Expenses:Food:Groceries                   $12.50
+    Expenses:Food:Dining Out                 $123.45
+    Assets:Checking
+end test


### PR DESCRIPTION
## Summary
- Add regression test verifying that `ledger print` properly aligns amounts in its output
- This issue was previously fixed but lacked a regression test

## Test plan
- [x] New test `934.test` passes with properly aligned output
- [x] All existing tests continue to pass

Fixes #934.

🤖 Generated with [Claude Code](https://claude.com/claude-code)