### PR TITLE
Fix --depth breaking --effective date display

### DIFF
--- a/test/regress/2599.test
+++ b/test/regress/2599.test
@@ -1,0 +1,16 @@
+; Regression test for #2599: --depth breaks --effective
+; When using --depth with --effective, effective dates should be preserved
+; rather than collapsing all postings to the original transaction date.
+
+2026/02/04 Insurance
+    expenses:car:insurance          $100.00 ; [=2025/02/04]
+    expenses:car:insurance          $100.00 ; [=2025/03/04]
+    expenses:car:insurance          $100.00 ; [=2025/04/04]
+    assets:bank
+
+test reg --effective --depth 2
+25-Feb-04 Insurance             expenses:car                $100.00      $100.00
+25-Mar-04 Insurance             expenses:car                $100.00      $200.00
+25-Apr-04 Insurance             expenses:car                $100.00      $300.00
+26-Feb-04 Insurance             assets:bank                $-300.00            0
+end test


### PR DESCRIPTION
## Summary

- Fix `--depth` truncation losing effective dates when used with `--effective` (#2599)
- When both flags are active, postings are now grouped by `(effective_date, truncated_account)` so entries with different effective dates are preserved as separate line items
- Added regression test `test/regress/2599.test`

Fixes #2599

## Test plan

- [x] New regression test `2599.test` verifies effective dates preserved with `--depth 2`
- [x] All 1393 existing tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)