### PR TITLE
Fix BOOST_REGEX_UNICODE_RUNS check for modern C++ standard libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,6 @@ using namespace boost;
 
 int main() {
   std::string text = \"Активы\";
-  std::basic_string<boost::uint32_t> expr_str = \"Активы\";
   u32regex r = make_u32regex(\"активы\", regex::perl | regex::icase);
   return u32regex_search(text, r) ? 0 : 1;
 }" BOOST_REGEX_UNICODE_RUNS)


### PR DESCRIPTION
## Summary
Removes the unused and non-compilable `std::basic_string<boost::uint32_t>` variable from the CMake BOOST_REGEX_UNICODE_RUNS check. This line fails with modern C++ standard libraries because `char_traits<unsigned int>` is undefined, and UTF-8 string literals cannot initialize a uint32_t string. The actual codebase uses `std::vector<boost::uint32_t>` for UTF-32 storage, not `std::basic_string`.

## Test Results
- All 1402 tests pass
- CMake BOOST_REGEX_UNICODE_RUNS check succeeds
- The remaining check properly validates Boost ICU regex functionality

Fixes #2459