### PR TITLE
Add regression test for #2281

### DIFF
--- a/test/regress/2281.test
+++ b/test/regress/2281.test
@@ -1,0 +1,11 @@
+2022/01/15 Payee
+    expenses:category1  £10
+    expenses:category2  $11
+    assets:debit
+
+test reg --format="%(quoted(filename)),%(quoted(xact.beg_line)),%(quoted(xact.end_line)),%(quoted(date)),%(quoted(payee)),%(quoted(account)),%(quoted(cost))\n"
+"$FILE","1","4","2022/01/15","Payee","expenses:category1","£10"
+"$FILE","1","4","2022/01/15","Payee","expenses:category2","$11"
+"$FILE","1","4","2022/01/15","Payee","assets:debit","$-11"
+"$FILE","1","4","2022/01/15","Payee","assets:debit","£-10"
+end test


### PR DESCRIPTION
Add regression test to verify that auto-balanced postings in multi-commodity transactions retain the source filename.

This test verifies the fix that was implemented in commit c215f6ec, which modified the add_balancing_post logic to call copy_details() on newly created balancing postings. This ensures that position information (including filename) is properly copied from the null posting to generated postings.

The test confirms all auto-balanced postings have correct filename values, addressing the issue where generated postings previously had empty filenames.

Closes #2281