### PR TITLE
Add regression test for issue #2296: decimal comma parsing

### DIFF
--- a/test/regress/2296.test
+++ b/test/regress/2296.test
@@ -1,0 +1,16 @@
+; Regression test for GitHub issue #2296: value corruption when converting
+; currencies at high precision with a decimal comma. Without --decimal-comma
+; or a preceding commodity directive, ledger must auto-detect that a comma
+; followed by more than 3 digits is a decimal separator, not a thousands
+; separator.
+
+2023-04-24 sale
+    Bank1    -6005,76 USD @ 4,166728274 PLN
+    Bank2    25024,37 PLN
+
+test bal --exchange PLN
+       -25024,37 PLN  Bank1
+        25024,37 PLN  Bank2
+--------------------
+                   0
+end test


### PR DESCRIPTION
Test verifies that amounts with decimal commas (European format) are correctly parsed without --decimal-comma or a preceding commodity directive. When a comma is followed by more than 3 digits, it is auto-detected as a decimal separator. The test confirms that 4,166728274 PLN is parsed as 4.166728274 (not 4166728274), allowing the transaction to balance correctly.

This regression test captures the exact scenario from issue #2296 where the parser was incorrectly treating high-precision decimal commas as thousands separators. The issue was previously fixed in commit b0fd5fc3.