### PR TITLE
Fix Homebrew build with Python support (issue #2267)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -244,6 +244,12 @@ if(USE_PYTHON)
       set(_ledger_python_module_name "ledger${CMAKE_SHARED_LIBRARY_SUFFIX}")
     endif()
 
+    # Allow packagers to override where the Python module is installed.
+    # By default this uses Python's site-packages, but systems like Homebrew
+    # may need to install under CMAKE_INSTALL_PREFIX instead.
+    set(LEDGER_PYTHON_INSTALL_DIR "${Python_SITEARCH}" CACHE PATH
+      "Directory to install the ledger Python module into")
+
     # FIXME: symlink would be sufficient:
     # maybe using install(CODE "...") and
     # execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink ...).
@@ -254,7 +260,7 @@ if(USE_PYTHON)
       $<TARGET_FILE:libledger> "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}")
     install(
       FILES "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}"
-      DESTINATION ${Python_SITEARCH})
+      DESTINATION "${LEDGER_PYTHON_INSTALL_DIR}")
   else()
     message(WARNING "Python_SITEARCH not set. Will not install python module.")
   endif()


### PR DESCRIPTION
## Summary

Fix Homebrew build failures when compiling Ledger with Python support by allowing packagers to override the Python module install directory.

## Problem

When building with `brew --build-from-source` and Python enabled, CMake tries to install `ledger.so` to the system Python's `site-packages` directory (an absolute path outside Homebrew's install prefix), causing "Operation not permitted" errors.

## Solution

Add `LEDGER_PYTHON_INSTALL_DIR` cache variable that defaults to `Python_SITEARCH` but can be overridden. Packagers like Homebrew can now pass `-DLEDGER_PYTHON_INSTALL_DIR` to install the module under their target directory.

Fixes #2267

🤖 Generated with [Claude Code](https://claude.com/claude-code)