### PR TITLE
Fix issue #1642: add regression test for --dc -X crash

### DIFF
--- a/test/regress/1642.test
+++ b/test/regress/1642.test
@@ -1,0 +1,18 @@
+; Regression test for GitHub issue #1642: crash when using --dc -X with one-sided transactions
+; "Cannot abs an uninitialized value" error when display_total has only debit or only credit.
+;
+; This is the same underlying bug as issue #2359, where the --dc option creates a sequence
+; for display_amount and display_total with (debit, credit) elements. When combined with -X,
+; currency conversion can result in only one element in the sequence. The get_at() calls in
+; the format expression would then return VOID for the missing element, causing abs() to fail.
+
+2017/12/01 Opening Balance
+    Assets:Something              $ 100.00
+    Equity:Opening Balances
+
+test bal --dc -X '$'
+      $ 100.00              0       $ 100.00  Assets:Something
+             0       $ 100.00      $ -100.00  Equity:Opening Balances
+--------------------------------------------
+      $ 100.00       $ 100.00              0
+end test


### PR DESCRIPTION
## Summary

Adds a regression test for GitHub issue #1642, which reported a crash when using `ledger --dc -X` with transactions containing only one-sided entries (debits or credits).

## Background

Issue #1642 and #2359 describe the same bug. The fix was already applied in commit fb95bbdb (which addressed #2359), but issue #1642 remained open without a dedicated regression test.

## Root Cause

The `--dc` option creates a sequence `(debit, credit)` for `display_amount` and `display_total`. When combined with `-X` for currency conversion, this sequence can be reduced to fewer elements than expected. Without proper guards, `get_at()` calls in format expressions would return VOID for missing elements, causing `abs()` to fail with "Cannot abs an uninitialized value".

## Fix

The fix (in fb95bbdb) added `|| 0` fallbacks to all `get_at()` calls in the `--dc` format expressions in `src/report.h`, ensuring uninitialized values default to zero instead of crashing.

## Changes

- **test/regress/1642.test**: New regression test verifying that `bal --dc -X '$'` works correctly with simple one-sided transactions

## Test Plan

```bash
python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1642.test
```

Test passes, confirming the fix is working.

Fixes #1642