### PR TITLE
Explicit CMAKE_OSX_SYSROOT for reproducible macOS builds

### DIFF
--- a/acprep
+++ b/acprep
@@ -732,6 +732,18 @@ class PrepareBuild(CommandLineApp):
         if self.options.python:
             self.configure_args.append('-DUSE_PYTHON=1')
 
+        if system == 'Darwin':
+            import subprocess
+            try:
+                result = subprocess.run(['xcrun', '--sdk', 'macosx', '--show-sdk-path'],
+                                      capture_output=True, text=True, check=True)
+                sdk_path = result.stdout.strip()
+                if sdk_path:
+                    self.configure_args.append('-DCMAKE_OSX_SYSROOT=' + sdk_path)
+                    self.log.info('Using macOS SDK => ' + sdk_path)
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                pass
+
         if system.startswith('CYGWIN'):
             self.configure_args.append('-G')
             self.configure_args.append('Unix Makefiles')


### PR DESCRIPTION
# Explicit CMAKE_OSX_SYSROOT for macOS Builds

## Problem

With multiple SDKs (Xcode + CLT), CMake implicitly selects SDKs inconsistently:

```
error: <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h>
```

Root cause: Headers from `/Applications/Xcode.app/...` mixed with `/Library/Developer/CommandLineTools/...`

## Solution

```python
if system == 'Darwin':
    import subprocess
    try:
        result = subprocess.run(['xcrun', '--sdk', 'macosx', '--show-sdk-path'],
                              capture_output=True, text=True, check=True)
        sdk_path = result.stdout.strip()
        if sdk_path:
            self.configure_args.append('-DCMAKE_OSX_SYSROOT=' + sdk_path)
            self.log.info('Using macOS SDK => ' + sdk_path)
    except (subprocess.CalledProcessError, FileNotFoundError):
        pass
```

## Evidence

### 1. CMake Official Docs

> "In order to pass an explicit macOS SDK via the compiler's `-isysroot` flag, users may configure their build tree with `-DCMAKE_OSX_SYSROOT=macosx`, **or `export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"` in their environment**."

— https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html

> "If not set explicitly... the compiler is expected to choose a default macOS SDK on its own."

— *ibid.*

### 2. Homebrew Does This

PR [#10595](https://github.com/Homebrew/brew/pull/10595) added explicit SDK handling:

```ruby
# Library/Homebrew/shims/super/cc
@sysroot = ENV["HOMEBREW_SDKROOT"]

if sysroot
  args << "-isysroot#{sysroot}" << "--sysroot=#{sysroot}"
end
```

Source: https://raw.githubusercontent.com/Homebrew/brew/master/Library/Homebrew/shims/super/cc

## Testing

Verified on macOS with Xcode 16 + CLT (multiple SDKs installed):

```
$ ./acprep debug
acprep: INFO: Using macOS SDK => /Applications/Xcode.app/.../MacOSX26.2.sdk
acprep: INFO: Setting up build flavor => debug
...
[100%] Built target ledger

$ ./ledger --version
Ledger 3.4.1-20251025 (Debug)
```

- ✅ Build succeeds with explicit SDK selection
- ✅ SDK path logged for transparency  
- ✅ Graceful fallback if `xcrun` unavailable

## Summary

| Before | After |
|--------|-------|
| Implicit SDK selection | Explicit via `CMAKE_OSX_SYSROOT` |
| Build varies by environment | Deterministic builds |
| Silent SDK choice | Logged SDK path |

Implements the [CMake-recommended pattern](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html), following [Homebrew](https://github.com/Homebrew/brew/pull/10595) and Xcode project conventions.
