### PR TITLE
Add regression test for issue #849

### DIFF
--- a/test/regress/849.test
+++ b/test/regress/849.test
@@ -1,0 +1,28 @@
+; Segmentation fault with --unbudgeted when all accounts are budgeted (BZ#849)
+; This issue is related to BZ#730 - both caused by interval_posts::flush()
+; attempting to access all_posts.front() when the deque is empty.
+;
+; When using --unbudgeted with all accounts budgeted, no posts pass through
+; to interval_posts, resulting in an empty all_posts deque. Without proper
+; size checking, this causes a segfault when combined with -M (monthly intervals).
+
+~ monthly
+    Expenses     $10.00
+    Assets
+
+2012/01/01 Test Transaction
+    Expenses     $10.00
+    Assets
+
+test -M reg --unbudgeted
+end test
+
+test -M bal --unbudgeted
+end test
+
+; Also test with --unbudgeted alone (no interval)
+test reg --unbudgeted
+end test
+
+test bal --unbudgeted
+end test


### PR DESCRIPTION
## Summary

This PR adds a regression test for issue #849, which reported a segmentation fault when using `--unbudgeted` with `-M` (monthly intervals) when all accounts are budgeted.

## Background

Issue #849 is a specific case of issue #730, which was fixed in commit 0a0f2f0d (2014) by @afh.

The root cause was in `interval_posts::flush()` attempting to access `all_posts.front()` without checking if the deque was empty. When using `--unbudgeted` with all accounts
budgeted, no posts pass through the `budget_posts` filter, resulting in an empty `all_posts` deque.

## Changes

- Added `test/regress/849.test` with test cases covering:
  - `--unbudgeted -M reg` (the original failing case)
  - `--unbudgeted -M bal` (also affected)
  - `--unbudgeted reg` (without intervals)
  - `--unbudgeted bal` (without intervals)

## Verification

The fix from commit 0a0f2f0d added proper size checking before accessing `all_posts.front()`, preventing the segfault. This regression test verifies that the fix works correctly
for the specific `--unbudgeted` scenario and prevents future regressions.

All tests pass:
```
$ python test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/849.test
....
OK (4)
```

## Related Issues

- Fixes #849
- Related to #730 (root cause fix)
- Related to #1080, #1084 (other duplicates of #730)