### PR TITLE
Add regression test for segfault with -D flag and no transactions (#754)

### DIFF
--- a/test/regress/754.test
+++ b/test/regress/754.test
@@ -1,0 +1,15 @@
+; Regression test for issue #754
+; Segfault with -D (--daily) flag when no transactions are present.
+; Using interval grouping options (-D, -W, -M, -Y) with an empty journal or
+; with a filter that matches no transactions should produce empty output,
+; not a segfault.
+
+2013/04/01 Someone
+    Expenses:Something     $1,000.00
+    Assets:Checking
+
+test reg -D ^Expense:Something
+end test
+
+test reg --daily ^Expense:Something
+end test


### PR DESCRIPTION
## Summary

- Add regression test for issue #754: segfault when using `-D` (daily interval) grouping with a filter that matches no transactions
- The segfault in `interval_posts::flush()` was caused by calling `all_posts.front()` without checking whether `all_posts` was empty first
- The code fix (adding `all_posts.size() > 0` guard) was already applied in a previous commit; this PR adds the missing regression test to prevent future regressions

## Test plan

- [ ] Run `python test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/754.test` and verify all tests pass
- [ ] Run full test suite: `cd build && ctest -R regress` to verify no regressions

Fixes #754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)