### PR TITLE
Fix #1182: Improve error message for '=' divider lines

### DIFF
--- a/test/regress/1182_2.test
+++ b/test/regress/1182_2.test
@@ -13,5 +13,5 @@ __ERROR__
 While parsing file "$FILE", line 5:
 While parsing automated transaction:
 > ============
-Error: note operator not followed by argument
+Error: Lines beginning with '=' are automated transactions, not dividers; for a comment or divider line, use ';' instead
 end test


### PR DESCRIPTION
## Summary

Fixes #1182 - When a user writes a line of `=` characters (e.g., `============`) as a visual divider in a journal file, Ledger now gives a helpful error message instead of a cryptic "note operator not followed by argument" error.

### Root Cause

Lines beginning with `=` are automated transaction headers. When the predicate consists entirely of `=` characters, the query parser throws a low-level expression error ("note operator not followed by argument") that doesn't explain the problem to the user.

### Fix

Added a check in `automated_xact_directive` that detects when the predicate after the leading `=` consists only of `=` characters (optionally followed by whitespace and/or a `;` comment). In that case, a clear error is thrown:

```
Error: Lines beginning with '=' are automated transactions, not dividers; for a comment or divider line, use ';' instead
```

### Edge Cases Handled

- `=` alone (empty predicate): still gives the original "Expected predicate after '='" message
- `= Expenses` (valid account predicate): unaffected
- `== Expenses` (note filter): unaffected  
- `============` and `==========`: now give the helpful error
- `============ ; comment`: now gives the helpful error

## Test plan

- [x] `test/regress/1182_1.test` - single `=` gives "Expected predicate after '='"
- [x] `test/regress/1182_2.test` - `============` gives improved error message (updated)
- [x] `test/regress/1182_3.test` - valid auto-transaction with `has_tag()` still works
- [x] All other regression tests unaffected (failures are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)