### PR TITLE
Fix payee-based Unknown account resolution in automated transactions

### DIFF
--- a/test/regress/1111.test
+++ b/test/regress/1111.test
@@ -1,0 +1,22 @@
+; Test case for issue #1111
+; When an automated transaction creates a posting for an account named
+; "Unknown" and there are payee sub-directives, the payee should be used
+; to resolve the "Unknown" account to the appropriate mapped account.
+
+account Equity:Known
+        payee MyPayee
+
+= expr true
+        Unknown  1
+
+2024/01/01 MyPayee
+        Expenses:Food  $10
+        Assets:Checking
+
+test p --generated
+2024/01/01 MyPayee
+    Expenses:Food                                $10
+    Assets:Checking                             $-10
+    Equity:Known                                 $10
+    Equity:Known                                $-10
+end test


### PR DESCRIPTION
## Summary

Fixes #1111.

When an automated transaction creates a posting for an account named
`Unknown`, `journal_t::register_account` has logic to check
`payees_for_unknown_accounts` - if the originating transaction's payee
matches a pattern, the `Unknown` account is substituted with the mapped
account. This feature was described in [account directives with `payee`
sub-directives](https://ledger-cli.org/doc/ledger3.html#index-payee-subdirective).

However, the resolution never worked for auto-generated posts because
the new posting has not yet been linked to a transaction when
`register_account` is called - `post->xact` is NULL and the payee
lookup is always skipped.

The fix resolves the account before calling `register_account` by
iterating over `payees_for_unknown_accounts` directly in
`extend_xact` where `initial_post->xact` is available.

## Example

```ledger
account Equity:Known
        payee MyPayee

= expr true
        Unknown  1

2024/01/01 MyPayee
        Expenses:Food  $10
        Assets:Checking
```

Before the fix, `ledger p --generated` would show `Unknown` in the
output. After the fix, it correctly shows `Equity:Known`.

## Test plan

- [x] New regression test `test/regress/1111.test` added and passes
- [x] All existing regression tests pass (1124/1124)

🤖 Generated with [Claude Code](https://claude.com/claude-code)