### PR TITLE
Replace raw new/delete with make_shared/make_unique

### DIFF
--- a/src/chain.cc
+++ b/src/chain.cc
@@ -45,13 +45,13 @@ post_handler_ptr chain_pre_post_handlers(post_handler_ptr base_handler, report_t
   // anonymize_posts removes all meaningful information from xact payee's and
   // account names, for the sake of creating useful bug reports.
   if (report.HANDLED(anon))
-    handler.reset(new anonymize_posts(handler));
+    handler = std::make_shared<anonymize_posts>(handler);
 
   // This filter_posts will only pass through posts matching the `predicate'.
   if (report.HANDLED(limit_)) {
     DEBUG("report.predicate", "Report predicate expression = " << report.HANDLER(limit_).str());
-    handler.reset(new filter_posts(
-        handler, predicate_t(report.HANDLER(limit_).str(), report.what_to_keep()), report));
+    handler = std::make_shared<filter_posts>(
+        handler, predicate_t(report.HANDLER(limit_).str(), report.what_to_keep()), report);
   }
 
   // budget_posts takes a set of posts from a data file and uses them to
@@ -62,31 +62,31 @@ post_handler_ptr chain_pre_post_handlers(post_handler_ptr base_handler, report_t
   // future balance.
 
   if (report.budget_flags != BUDGET_NO_BUDGET) {
-    budget_posts* budget_handler =
-        new budget_posts(handler, report.terminus.date(), report.budget_flags);
+    auto budget_handler =
+        std::make_shared<budget_posts>(handler, report.terminus.date(), report.budget_flags);
     budget_handler->add_period_xacts(report.session.journal->period_xacts);
-    handler.reset(budget_handler);
+    handler = budget_handler;
 
     // Apply this before the budget handler, so that only matching posts are
     // calculated toward the budget.  The use of filter_posts above will
     // further clean the results so that no automated posts that don't match
     // the filter get reported.
     if (report.HANDLED(limit_))
-      handler.reset(new filter_posts(
-          handler, predicate_t(report.HANDLER(limit_).str(), report.what_to_keep()), report));
+      handler = std::make_shared<filter_posts>(
+          handler, predicate_t(report.HANDLER(limit_).str(), report.what_to_keep()), report);
   } else if (report.HANDLED(forecast_while_)) {
-    forecast_posts* forecast_handler = new forecast_posts(
+    auto forecast_handler = std::make_shared<forecast_posts>(
         handler, predicate_t(report.HANDLER(forecast_while_).str(), report.what_to_keep()), report,
         (report.HANDLED(forecast_years_)
              ? lexical_cast<std::size_t>(report.HANDLER(forecast_years_).value)
              : 5UL));
     forecast_handler->add_period_xacts(report.session.journal->period_xacts);
-    handler.reset(forecast_handler);
+    handler = forecast_handler;
 
     // See above, under budget_posts.
     if (report.HANDLED(limit_))
-      handler.reset(new filter_posts(
-          handler, predicate_t(report.HANDLER(limit_).str(), report.what_to_keep()), report));
+      handler = std::make_shared<filter_posts>(
+          handler, predicate_t(report.HANDLER(limit_).str(), report.what_to_keep()), report);
   }
 
   return handler;
@@ -97,7 +97,7 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler, report_t& re
   post_handler_ptr handler(base_handler);
   predicate_t display_predicate;
   predicate_t only_predicate;
-  display_filter_posts* display_filter = NULL;
+  display_filter_posts* display_filter = nullptr;
 
   expr_t& expr(report.HANDLER(amount_).expr);
   expr.set_context(&report);
@@ -109,30 +109,31 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler, report_t& re
   if (!for_accounts_report) {
     // Make sure only forecast postings which match are allowed through
     if (report.HANDLED(forecast_while_)) {
-      handler.reset(new filter_posts(
+      handler = std::make_shared<filter_posts>(
           handler, predicate_t(report.HANDLER(forecast_while_).str(), report.what_to_keep()),
-          report));
+          report);
     }
 
     // truncate_xacts cuts off a certain number of _xacts_ from being
     // displayed.  It does not affect calculation.
     if (report.HANDLED(head_) || report.HANDLED(tail_))
-      handler.reset(new truncate_xacts(
+      handler = std::make_shared<truncate_xacts>(
           handler, report.HANDLED(head_) ? lexical_cast<int>(report.HANDLER(head_).value) : 0,
-          report.HANDLED(tail_) ? lexical_cast<int>(report.HANDLER(tail_).value) : 0));
+          report.HANDLED(tail_) ? lexical_cast<int>(report.HANDLER(tail_).value) : 0);
 
     // display_filter_posts adds virtual posts to the list to account
     // for changes in value of commodities, which otherwise would affect
     // the running total unpredictably.
-    display_filter = new display_filter_posts(
+    auto display_filter_sp = std::make_shared<display_filter_posts>(
         handler, report, report.HANDLED(revalued) && !report.HANDLED(no_rounding));
-    handler.reset(display_filter);
+    display_filter = display_filter_sp.get();
+    handler = std::move(display_filter_sp);
 
     // filter_posts will only pass through posts matching the
     // `display_predicate'.
     if (report.HANDLED(display_)) {
       display_predicate = predicate_t(report.HANDLER(display_).str(), report.what_to_keep());
-      handler.reset(new filter_posts(handler, display_predicate, report));
+      handler = std::make_shared<filter_posts>(handler, display_predicate, report);
     }
   }
 
@@ -140,8 +141,8 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler, report_t& re
   // in market value of commodities, which otherwise would affect the running
   // total unpredictably.
   if (report.HANDLED(revalued) && (!for_accounts_report || report.HANDLED(unrealized)))
-    handler.reset(new changed_value_posts(handler, report, for_accounts_report,
-                                          report.HANDLED(unrealized), display_filter));
+    handler = std::make_shared<changed_value_posts>(handler, report, for_accounts_report,
+                                                    report.HANDLED(unrealized), display_filter);
 
   // calc_posts computes the running total.  When this appears will determine,
   // for example, whether filtered posts are included or excluded from the
@@ -163,14 +164,14 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler, report_t& re
         report.HANDLER(total_).expr.base_expr == "total" &&
         !wtk.keep_all();
 
-    handler.reset(new calc_posts(handler, expr, calc_running, maintain_stripped, wtk));
+    handler = std::make_shared<calc_posts>(handler, expr, calc_running, maintain_stripped, wtk);
   }
 
   // filter_posts will only pass through posts matching the
   // `secondary_predicate'.
   if (report.HANDLED(only_)) {
     only_predicate = predicate_t(report.HANDLER(only_).str(), report.what_to_keep());
-    handler.reset(new filter_posts(handler, only_predicate, report));
+    handler = std::make_shared<filter_posts>(handler, only_predicate, report);
   }
 
   if (!for_accounts_report) {
@@ -189,27 +190,27 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler, report_t& re
         if (sort_xacts_value.empty()) {
           // Activated from period sorting: use sort_'s expression for
           // within-transaction sorting only, no global sort.
-          handler.reset(new sort_xacts(handler,
-                                       expr_t(report.HANDLER(sort_).str()),
-                                       report));
+          handler = std::make_shared<sort_xacts>(handler,
+                                                  expr_t(report.HANDLER(sort_).str()),
+                                                  report);
           xacts_only = true;
         } else {
           // --sort-xacts given explicitly with its own expression: apply
           // within-transaction sort first, then global sort (from --sort).
-          handler.reset(new sort_xacts(handler,
-                                       expr_t(sort_xacts_value), report));
+          handler = std::make_shared<sort_xacts>(handler,
+                                                  expr_t(sort_xacts_value), report);
         }
       }
 
       if (! xacts_only)
-        handler.reset(new sort_posts(handler,
-                                     report.HANDLER(sort_).str(), report));
+        handler = std::make_shared<sort_posts>(handler,
+                                               report.HANDLER(sort_).str(), report);
     } else if (report.HANDLED(sort_xacts_)) {
       const string& sort_xacts_value =
           report.HANDLER(sort_xacts_).value;
       if (! sort_xacts_value.empty())
-        handler.reset(new sort_xacts(handler,
-                                     expr_t(sort_xacts_value), report));
+        handler = std::make_shared<sort_xacts>(handler,
+                                               expr_t(sort_xacts_value), report);
     }
 
     // collapse_posts causes xacts with multiple posts to appear as xacts
@@ -219,8 +220,9 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler, report_t& re
       if (report.HANDLED(depth_))
         collapse_depth = lexical_cast<int>(report.HANDLER(depth_).str());
 
-      handler.reset(new collapse_posts(handler, report, expr, display_predicate, only_predicate,
-                                       report.HANDLED(collapse_if_zero), collapse_depth));
+      handler = std::make_shared<collapse_posts>(handler, report, expr, display_predicate,
+                                                 only_predicate, report.HANDLED(collapse_if_zero),
+                                                 collapse_depth);
     }
 
     // subtotal_posts combines all the posts it receives into one subtotal
@@ -232,54 +234,54 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler, report_t& re
     // day_of_week_posts is like period_posts, except that it reports
     // all the posts that fall on each subsequent day of the week.
     if (report.HANDLED(equity))
-      handler.reset(new posts_as_equity(handler, report, expr, report.HANDLED(unround)));
+      handler = std::make_shared<posts_as_equity>(handler, report, expr, report.HANDLED(unround));
     else if (report.HANDLED(subtotal))
-      handler.reset(new subtotal_posts(handler, expr));
+      handler = std::make_shared<subtotal_posts>(handler, expr);
   }
 
   if (report.HANDLED(dow))
-    handler.reset(new day_of_week_posts(handler, expr));
+    handler = std::make_shared<day_of_week_posts>(handler, expr);
   else if (report.HANDLED(by_payee))
-    handler.reset(new by_payee_posts(handler, expr));
+    handler = std::make_shared<by_payee_posts>(handler, expr);
 
   // interval_posts groups posts together based on a time period, such as
   // weekly or monthly.
   if (report.HANDLED(period_))
-    handler.reset(new interval_posts(handler, expr, report.HANDLER(period_).str(),
-                                     report.HANDLED(exact), report.HANDLED(empty),
-                                     report.HANDLED(align_intervals)));
+    handler = std::make_shared<interval_posts>(handler, expr, report.HANDLER(period_).str(),
+                                               report.HANDLED(exact), report.HANDLED(empty),
+                                               report.HANDLED(align_intervals));
 
   if (report.HANDLED(date_))
-    handler.reset(new transfer_details(handler, transfer_details::SET_DATE,
-                                       report.session.journal->master, report.HANDLER(date_).str(),
-                                       report));
+    handler = std::make_shared<transfer_details>(handler, transfer_details::SET_DATE,
+                                                 report.session.journal->master,
+                                                 report.HANDLER(date_).str(), report);
 
   if (report.HANDLED(account_)) {
-    handler.reset(new transfer_details(handler, transfer_details::SET_ACCOUNT,
-                                       report.session.journal->master,
-                                       report.HANDLER(account_).str(), report));
+    handler = std::make_shared<transfer_details>(handler, transfer_details::SET_ACCOUNT,
+                                                 report.session.journal->master,
+                                                 report.HANDLER(account_).str(), report);
   } else if (report.HANDLED(pivot_)) {
     string pivot = report.HANDLER(pivot_).str();
     pivot = string("\"") + pivot + ":\" + tag(\"" + pivot + "\")";
-    handler.reset(new transfer_details(handler, transfer_details::SET_ACCOUNT,
-                                       report.session.journal->master, pivot, report));
+    handler = std::make_shared<transfer_details>(handler, transfer_details::SET_ACCOUNT,
+                                                 report.session.journal->master, pivot, report);
   }
 
   if (report.HANDLED(payee_))
-    handler.reset(new transfer_details(handler, transfer_details::SET_PAYEE,
-                                       report.session.journal->master, report.HANDLER(payee_).str(),
-                                       report));
+    handler = std::make_shared<transfer_details>(handler, transfer_details::SET_PAYEE,
+                                                 report.session.journal->master,
+                                                 report.HANDLER(payee_).str(), report);
 
   // related_posts will pass along all posts related to the post received.  If
   // the `related_all' handler is on, then all the xact's posts are passed;
   // meaning that if one post of an xact is to be printed, all the post for
   // that xact will be printed.
   if (report.HANDLED(related))
-    handler.reset(new related_posts(handler, report.HANDLED(related_all)));
+    handler = std::make_shared<related_posts>(handler, report.HANDLED(related_all));
 
   if (report.HANDLED(inject_))
-    handler.reset(
-        new inject_posts(handler, report.HANDLED(inject_).str(), report.session.journal->master));
+    handler = std::make_shared<inject_posts>(handler, report.HANDLED(inject_).str(),
+                                             report.session.journal->master);
 
   return handler;
 }


### PR DESCRIPTION
## Summary

Part 4 of the C++17 modernization series. Depends on #2657.

- Replaces `new T(...)` + manual `shared_ptr` construction with `std::make_shared<T>(...)`
- Replaces `new T(...)` + manual `unique_ptr` construction with `std::make_unique<T>(...)`
- Eliminates several raw `new` allocations where ownership is immediately transferred to a smart pointer
- `make_shared` is also more efficient: it performs a single allocation for the object and its control block

This does not address `checked_delete` or the pool allocators, which serve different purposes.

## Test plan

- [x] Full build passes: `make -j$(nproc)`
- [x] All 1434 tests pass: `ctest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)