### PR TITLE
Replace boost::filesystem with std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ set(Ledger_TEST_TIMEZONE "America/Chicago")
 
 enable_testing()
 
-add_compile_definitions(BOOST_FILESYSTEM_NO_DEPRECATED)
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard")
 if(CYGWIN)
   add_compile_options(-U__STRICT_ANSI__)
@@ -165,7 +164,7 @@ endif()
 
 # Set BOOST_ROOT to help CMake to find the right Boost version
 find_package(Boost ${Required_Boost_Version}
-  REQUIRED date_time filesystem iostreams regex unit_test_framework
+  REQUIRED date_time iostreams regex unit_test_framework
   ${BOOST_PYTHON} OPTIONAL_COMPONENTS nowide
   CONFIG)
 

--- a/src/context.h
+++ b/src/context.h
@@ -101,7 +101,7 @@ public:
 
 inline parse_context_t open_for_reading(const path& pathname, const path& cwd) {
   path filename = resolve_path(pathname);
-  filename = filesystem::absolute(filename, cwd);
+  filename = filename.is_absolute() ? filename : std::filesystem::absolute(cwd / filename);
   if (!exists(filename) || is_directory(filename))
     throw_(std::runtime_error, _f("Cannot read journal file %1%") % filename);
 

--- a/src/journal.h
+++ b/src/journal.h
@@ -71,7 +71,10 @@ public:
 
     fileinfo_t() : from_stream(true) { TRACE_CTOR(journal_t::fileinfo_t, ""); }
     fileinfo_t(const path& _filename) : filename(_filename), from_stream(false) {
-      modtime = posix_time::from_time_t(last_write_time(*filename));
+      auto ftime = std::filesystem::last_write_time(*filename);
+      auto sctp = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+          ftime - decltype(ftime)::clock::now() + std::chrono::system_clock::now());
+      modtime = posix_time::from_time_t(std::chrono::system_clock::to_time_t(sctp));
       TRACE_CTOR(journal_t::fileinfo_t, "const path&");
     }
     fileinfo_t(const fileinfo_t& info)

--- a/src/pyinterp.cc
+++ b/src/pyinterp.cc
@@ -228,7 +228,7 @@ object python_interpreter_t::import_option(const string& str) {
 
   if (contains(str, ".py")) {
     path& cwd(parsing_context.get_current().current_directory);
-    path parent(filesystem::absolute(file, cwd).parent_path());
+    path parent((file.is_absolute() ? file : std::filesystem::absolute(cwd / file)).parent_path());
     DEBUG("python.interp", "Adding " << parent << " to PYTHONPATH");
     paths.insert(0, parent.string());
     sys_dict["path"] = paths;

--- a/src/session.h
+++ b/src/session.h
@@ -53,7 +53,7 @@ class xact_t;
 
 struct ComparePaths {
   bool operator()(const path& p1, const path& p2) const {
-    return p1 < p2 && !boost::filesystem::equivalent(p1, p2);
+    return p1 < p2 && !std::filesystem::equivalent(p1, p2);
   }
 };
 

--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -140,11 +140,7 @@
 #include <boost/date_time/posix_time/posix_time_io.hpp>
 #include <boost/date_time/gregorian/gregorian_io.hpp>
 
-#include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/directory.hpp>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 #include <boost/format.hpp>
 #include <boost/function.hpp>

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -181,11 +181,11 @@ void instance_t::include_directive(char* line) {
 
   bool files_found = false;
   if (exists(parent_path)) {
-    filesystem::directory_iterator end;
+    std::filesystem::directory_iterator end;
 
     // Sort parent_path since on some file systems it is unsorted.
     std::vector<path> sorted_parent_path;
-    std::copy(filesystem::directory_iterator(parent_path), filesystem::directory_iterator(),
+    std::copy(std::filesystem::directory_iterator(parent_path), std::filesystem::directory_iterator(),
               std::back_inserter(sorted_parent_path));
     std::sort(sorted_parent_path.begin(), sorted_parent_path.end());
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -65,10 +65,10 @@ typedef gregorian::date date;
 typedef gregorian::date_duration date_duration;
 typedef posix_time::seconds seconds;
 
-typedef boost::filesystem::path path;
-typedef boost::filesystem::ifstream ifstream;
-typedef boost::filesystem::ofstream ofstream;
-typedef boost::filesystem::filesystem_error filesystem_error;
+using path = std::filesystem::path;
+using ifstream = std::ifstream;
+using ofstream = std::ofstream;
+using filesystem_error = std::filesystem::filesystem_error;
 } // namespace ledger
 
 /*@}*/


### PR DESCRIPTION
## Summary

Part 7 of the C++17 modernization series. Depends on #2660.

- Replaces `boost::filesystem` with `std::filesystem` throughout the codebase
- Updates `src/utils.h` type aliases (`path`, `ifstream`, `ofstream`) — note: `std::filesystem` does not provide `ifstream`/`ofstream`; these are `std::ifstream`/`std::ofstream`
- Adapts `filesystem::absolute(path, base)` (Boost) → conditional `base / path` + `std::filesystem::absolute(path)` (C++17 takes only one argument)
- Converts `std::filesystem::file_time_type` to `ptime` using the clock-difference trick (C++17's file clock is implementation-defined)
- Removes `filesystem` from Boost `find_package` requirements in `CMakeLists.txt`
- Removes `BOOST_FILESYSTEM_NO_DEPRECATED` compile definition

## Test plan

- [x] Full build passes: `make -j$(nproc)`
- [x] All 1434 tests pass: `ctest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)