### PR TITLE
Replace fallthrough comments with [[fallthrough]]; add [[maybe_unused]]

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -358,7 +358,7 @@ void handle_value(const value_t& value, account_t* account, xact_t* xact, tempor
   case value_t::BOOLEAN:
   case value_t::INTEGER:
     temp.in_place_cast(value_t::AMOUNT);
-    // fall through...
+    [[fallthrough]];
 
   case value_t::AMOUNT:
     post.amount = temp.as_amount();
@@ -798,7 +798,7 @@ void changed_value_posts::output_intermediate_prices(post_t& post, const date_t&
     case value_t::BOOLEAN:
     case value_t::INTEGER:
       last_total.in_place_cast(value_t::AMOUNT);
-      // fall through...
+      [[fallthrough]];
 
     case value_t::AMOUNT:
       temp.amount = last_total.as_amount();
@@ -831,7 +831,7 @@ void changed_value_posts::output_intermediate_prices(post_t& post, const date_t&
 
   case value_t::AMOUNT:
     display_total.in_place_cast(value_t::BALANCE);
-    // fall through...
+    [[fallthrough]];
 
   case value_t::BALANCE: {
     price_map_t all_prices;

--- a/src/format.cc
+++ b/src/format.cc
@@ -674,7 +674,7 @@ string format_t::truncate(const unistring& ustr, const std::size_t width,
       }
       break;
     }
-    // fall through...
+    [[fallthrough]];
 
   case TRUNCATE_TRAILING:
     // This method truncates at the end (the default).

--- a/src/mask.cc
+++ b/src/mask.cc
@@ -204,7 +204,7 @@ mask_t& mask_t::assign_glob(string_view pat) {
         re_pat += pat[++i];
         break;
       }
-      // fallthrough...
+      [[fallthrough]];
     default:
       re_pat += pat[i];
       break;

--- a/src/op.cc
+++ b/src/op.cc
@@ -153,7 +153,7 @@ expr_t::ptr_op_t expr_t::op_t::compile(scope_t& scope, const int depth, scope_t*
         scope_ptr->define(symbol_t::FUNCTION, left()->left()->as_ident(), node);
         break;
       }
-      // fall through...
+      [[fallthrough]];
 
     default:
       throw_(compile_error, _("Invalid function definition"));

--- a/src/option.h
+++ b/src/option.h
@@ -359,8 +359,8 @@ public:
   vartype var;                                                                                     \
   name##option_t() : option_t<type>(#name), var value
 
-#define DO() virtual void handler_thunk(const optional<string>& whence) override
-#define DO_(var) virtual void handler_thunk(const optional<string>& whence, const string& var) override
+#define DO() virtual void handler_thunk([[maybe_unused]] const optional<string>& whence) override
+#define DO_(var) virtual void handler_thunk([[maybe_unused]] const optional<string>& whence, [[maybe_unused]] const string& var) override
 
 #define END(name) name##handler
 

--- a/src/py_session.cc
+++ b/src/py_session.cc
@@ -50,7 +50,7 @@ journal_t* py_read_journal_from_string(const string& data) {
   return python_session->read_journal_from_string(data);
 }
 
-PyObject* py_error_context(const session_t& session) {
+PyObject* py_error_context([[maybe_unused]] const session_t& session) {
   return str_to_py_unicode(error_context());
 }
 void py_close_journal_files() {

--- a/src/query.cc
+++ b/src/query.cc
@@ -160,7 +160,7 @@ resume:
   case '\\':
     consume_next = true;
     ++arg_i;
-    // fall through...
+    [[fallthrough]];
   default: {
     string ident;
     for (; arg_i != arg_end; ++arg_i) {
@@ -184,7 +184,7 @@ resume:
           consume_next = true;
         if (!consume_next && tok_context == token_t::TOK_EXPR)
           goto test_ident;
-        // fall through...
+        [[fallthrough]];
       case '(':
       case '&':
       case '|':
@@ -195,7 +195,7 @@ resume:
       case '=':
         if (!consume_next && tok_context != token_t::TOK_EXPR)
           goto test_ident;
-      // fall through...
+        [[fallthrough]];
       default:
         ident.push_back(*arg_i);
         break;

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -200,7 +200,7 @@ xact_t* instance_t::read_next_directive(bool& error_flag, xact_t* previous_xact)
   case '@':
   case '!':
     line++;
-    // fall through...
+    [[fallthrough]];
   default: // some other directive
     if (!general_directive(line)) {
       switch (line[0]) {


### PR DESCRIPTION
## Summary

Part 11 of the C++17 modernization series. Depends on #2664.

**`[[fallthrough]]`** replaces all `// fall through...` and `// fallthrough...` comments in switch statements:
- `format.cc`: `ABBREVIATE` case falls through to `TRUNCATE_TRAILING` when abbreviation is disabled
- `mask.cc`: `case '\\'` falls through to `default` in glob-to-regex conversion
- `filters.cc`: `BOOLEAN`/`INTEGER` → cast to `AMOUNT` → fall through (×2); `AMOUNT` → cast to `BALANCE` → fall through in revalued filter
- `textual.cc`: `'@'`/`'!'` directive handler increments line pointer, falls through to `default`
- `query.cc`: three fallthrough cases in the token parser
- `op.cc`: function-definition case falls through to error `default`

**`[[maybe_unused]]`** suppresses intentional unused-parameter warnings:
- `option.h`: `DO()` and `DO_()` macros generate `handler_thunk()` virtual overrides; `whence` (and sometimes the named `var` parameter) are intentionally unused in many option bodies that only call side effects
- `py_session.cc`: `py_error_context()` takes a `session_t&` required by the Python binding ABI but doesn't use it

## Test plan

- [x] Full build passes: `make -j$(nproc)`
- [x] All 1434 tests pass: `ctest`
- [x] Build with `-Wunused-parameter` produces no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)