### PR TITLE
Convert nested namespace declarations to C++17 compact syntax

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -41,8 +41,7 @@
  */
 #pragma once
 
-namespace ledger {
-namespace flags {
+namespace ledger::flags {
 
 template <typename T = boost::uint_least8_t, typename U = T>
 class supports_flags {
@@ -141,5 +140,4 @@ public:
   void drop_flags(const flags_t arg) { _flags.drop_flags(arg); }
 };
 
-} // namespace flags
-} // namespace ledger
+} // namespace ledger::flags

--- a/src/pyutils.h
+++ b/src/pyutils.h
@@ -43,8 +43,7 @@
  */
 #pragma once
 
-namespace ledger {
-namespace python {
+namespace ledger::python {
 
 template <typename T, typename TfromPy>
 struct object_from_python {
@@ -126,11 +125,9 @@ PyObject* str_to_py_unicode(const T& str) {
   return object(handle<>(borrowed(uni))).ptr();
 }
 
-} // namespace python
-} // namespace ledger
+} // namespace ledger::python
 
-namespace boost {
-namespace python {
+namespace boost::python {
 
 // Use expr to create the PyObject corresponding to x
 #define BOOST_PYTHON_RETURN_TO_PYTHON_BY_VALUE(T, expr, pytype)                                    \
@@ -166,7 +163,6 @@ namespace python {
   BOOST_PYTHON_RETURN_TO_PYTHON_BY_VALUE(T, expr, pytype)                                          \
   BOOST_PYTHON_ARG_TO_PYTHON_BY_VALUE(T, expr)
 
-} // namespace python
-} // namespace boost
+} // namespace boost::python
 
 // boost::python::register_ptr_to_python< std::shared_ptr<Base> >();

--- a/src/textual_internal.h
+++ b/src/textual_internal.h
@@ -53,8 +53,7 @@
 #include "timelog.h"
 #endif
 
-namespace ledger {
-namespace detail {
+namespace ledger::detail {
 
 typedef std::pair<commodity_t*, amount_t> fixed_rate_t;
 
@@ -202,5 +201,4 @@ void parse_amount_expr(std::istream& in, scope_t& scope, post_t& post, amount_t&
                        const parse_flags_t& flags = PARSE_DEFAULT, const bool defer_expr = false,
                        optional<expr_t>* amount_expr = NULL);
 
-} // namespace detail
-} // namespace ledger
+} // namespace ledger::detail


### PR DESCRIPTION
## Summary

Part 13 of the C++17 modernization series. Depends on #2666.

Converts C++14-style stacked namespace declarations to C++17 compact nested namespace syntax:

```cpp
// Before (C++14)
namespace ledger {
namespace detail {
  // ...
} // namespace detail
} // namespace ledger

// After (C++17)
namespace ledger::detail {
  // ...
} // namespace ledger::detail
```

Files updated:
- `textual_internal.h`: `namespace ledger { namespace detail {` → `namespace ledger::detail {`
- `pyutils.h`: `namespace ledger { namespace python {` → `namespace ledger::python {`
- `pyutils.h`: `namespace boost { namespace python {` → `namespace boost::python {`
- `flags.h`: `namespace ledger { namespace flags {` → `namespace ledger::flags {`

Closing brace comments updated to match. Pure syntactic change — zero runtime impact.

## Test plan

- [x] Full build passes: `make -j$(nproc)`
- [x] All 1434 tests pass: `ctest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)