### PR TITLE
Use inline static constexpr for class constants; remove dead extern

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -109,7 +109,7 @@ public:
 
   /** Number of places of precision by which values are extended to
       avoid losing precision during division and multiplication. */
-  static const std::size_t extend_by_digits = 6U;
+  inline static constexpr std::size_t extend_by_digits = 6U;
 
   /** If amounts should be streamed using to_fullstring() rather than
       to_string(), so that complete precision is always displayed no matter

--- a/src/commodity.h
+++ b/src/commodity.h
@@ -104,7 +104,7 @@ protected:
     typedef tuple<datetime_t, datetime_t, const commodity_t*> memoized_price_entry;
     typedef std::map<memoized_price_entry, std::optional<price_point_t>> memoized_price_map;
 
-    static const std::size_t max_price_map_size = 8;
+    inline static constexpr std::size_t max_price_map_size = 8;
     mutable memoized_price_map price_map;
 
   public:

--- a/src/context.h
+++ b/src/context.h
@@ -56,7 +56,7 @@ class scope_t;
 
 class parse_context_t {
 public:
-  static const std::size_t MAX_LINE = 4096;
+  inline static constexpr std::size_t MAX_LINE = 4096;
 
   std::shared_ptr<std::istream> stream;
 

--- a/src/unistring.h
+++ b/src/unistring.h
@@ -55,7 +55,7 @@ int mk_wcwidth(boost::uint32_t ucs);
  */
 class unistring {
 public:
-  static const std::size_t npos = static_cast<std::size_t>(-1);
+  inline static constexpr std::size_t npos = static_cast<std::size_t>(-1);
 
   std::vector<boost::uint32_t> utf32chars;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -577,8 +577,6 @@ inline string sha1sum(const string& str,
   return digest_to_hex(message_digest, len);
 }
 
-extern const string version;
-
 enum hash_type_t { NO_HASHES = 0, HASH_SHA512 = 1, HASH_SHA512_Half = 2 };
 
 } // namespace ledger


### PR DESCRIPTION
## Summary

Part 14 of the C++17 modernization series. Depends on #2667.

**`inline static constexpr` for class constants:**

Converts four integral class constants from `static const std::size_t` (C++11 in-class initialization) to `inline static constexpr std::size_t` (preferred C++17 form):

| File | Constant | Value |
|------|----------|-------|
| `context.h` | `MAX_LINE` | 4096 |
| `amount.h` | `extend_by_digits` | 6 |
| `unistring.h` | `npos` | `size_t(-1)` |
| `commodity.h` | `max_price_map_size` | 8 |

`inline` guarantees ODR compliance when the header is included from multiple translation units. `constexpr` implies `const` and enables compile-time constant evaluation at call sites.

**Removes orphaned `extern const string version` declaration** from `utils.h`: this declaration had no corresponding definition anywhere in the codebase and was never referenced. The `--version` flag is handled through the option handler system, not this variable.

## Test plan

- [x] Full build passes: `make -j$(nproc)`
- [x] All 1434 tests pass: `ctest`
- [x] No linker errors (duplicate symbol check): both debug and release builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)