### PR TITLE
Add regression test for issue #1035

### DIFF
--- a/test/regress/1035.test
+++ b/test/regress/1035.test
@@ -1,0 +1,20 @@
+; Test that --budget --monthly with no budget defined does not segfault
+; Regression test for GitHub issue #1035
+; "Segfault in ledger::interval_posts::flush --budget --monthly and no budget"
+;
+; When no periodic transactions (~) are defined, using --budget should
+; produce no output and exit cleanly rather than crash with a segfault.
+
+2012/5/14 something
+    me  € 42.00
+    bank
+
+2012/5/15 duh
+    me  € 1
+    me
+
+test --budget --monthly balance -> 0
+end test
+
+test --budget --monthly register -> 0
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for GitHub issue #1035 (segfault in `interval_posts::flush` with `--budget --monthly` and no budget defined)
- The test verifies that using `--budget --monthly` with no periodic transactions (`~` directives) produces empty output and exits cleanly (exit code 0) rather than crashing

## Background

The original issue reported a segfault when running:
```
ledger -f file --budget --monthly balance
```
where no periodic transactions were defined. The crash occurred in `ledger::interval_posts::flush` being called through `ledger::budget_posts::flush` with no budget items to generate.

The underlying crash has already been fixed in the codebase, but no regression test existed to prevent future regressions.

## Test plan

- [x] New test file `test/regress/1035.test` added
- [x] Test runs both `balance` and `register` commands with `--budget --monthly` and no budget defined
- [x] Test passes with exit code 0 and empty output
- [x] `ctest -R 1035` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)