### PR TITLE
Add regression test for issue #2147: segfault with period+automated transactions

### DIFF
--- a/test/regress/2147.test
+++ b/test/regress/2147.test
@@ -1,0 +1,22 @@
+; Issue #2147: Combining repeating transaction with automated transaction
+; that uses payee in predicate segfaults when evaluated against period
+; transaction postings (which have no parent xact).
+
+= expr account =~ /Assets:Inventory/ & payee =~ /DADA/ & comment =~ /Automate/
+    Expenses:Products                  1
+    Assets:Inventory                  -1
+
+~ monthly
+    Expenses:Rent                    $50.00
+    Assets:Checking
+
+2021/01/15 DADA
+    Assets:Inventory                  10 WIDGET ; Automate
+    Assets:Cash                      -10 WIDGET
+
+test bal
+          -10 WIDGET  Assets:Cash
+           10 WIDGET  Expenses:Products
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Adds regression test for issue #2147 (segfault when combining repeating transactions with automated transactions that use `payee` in their predicate)
- The underlying crash was fixed as part of the #1858 fix (PR #2643), which added a null check in `post_t::payee()` before dereferencing `xact`
- This PR adds a dedicated regression test to prevent future regressions

## Root Cause

When automated transaction predicates evaluate expressions on postings from period transactions (`~every month`), those postings have no parent `xact_t` (i.e., `post.xact == NULL`). Accessing `post.payee()` would dereference `xact->payee` without checking for null, causing a segmentation fault.

The fix already in the codebase (`src/post.cc`):
```cpp
return post_payee != "" ? post_payee : xact ? xact->payee : "";
```

## Test plan
- [x] New regression test `test/regress/2147.test` added
- [x] Test passes via `ctest -R RegressTest_2147`
- [x] Test exercises the specific predicate combination from the issue: `account =~`, `payee =~`, and `comment =~` combined with `&`

Closes #2147

🤖 Generated with [Claude Code](https://claude.com/claude-code)