### PR TITLE
Add regression test for issue #1195 (segfault in trim_ws with invalid apply fixed syntax)

### DIFF
--- a/test/regress/1195.test
+++ b/test/regress/1195.test
@@ -1,0 +1,13 @@
+apply fixed
+
+€ 0.9000
+
+end
+
+test -f - bal -> 2
+__ERROR__
+While parsing file "", line 1:
+Error: Directive 'apply fixed' requires an argument
+While parsing file "", line 5:
+Error: 'end' or 'end apply' found, but no enclosing 'apply' directive
+end test


### PR DESCRIPTION
## Summary

- Adds regression test `test/regress/1195.test` for the segfault reported in issue #1195
- The crash occurred when `apply fixed` was used with no argument, causing `apply_rate_directive` to be called with a NULL pointer, which then passed it to `trim_ws` (which calls `strlen` on a NULL pointer)
- The code fix was already applied via earlier commits: the null check in `apply_directive` (added for #553/#1854) and the defensive null check in `apply_rate_directive` (added for #1221)
- This PR adds the missing regression test using the exact input from the original bug report

## Test plan

- [x] New regression test `test/regress/1195.test` verifies that `apply fixed` with no argument produces a clear error message instead of segfaulting
- [x] Test uses the exact input from the issue report: `apply fixed` alone on a line followed by `€ 0.9000` and `end`
- [x] Test verified passing with current codebase

Closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)