### PR TITLE
Fix segfault in 'ledger python' interactive mode

### DIFF
--- a/test/regress/852.py
+++ b/test/regress/852.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Regression test for GitHub issue #852:
+# Running "ledger python" and calling dir(ledger) used to crash with a
+# segfault because Py_Main() loaded readline.so which conflicted with
+# libedit already loaded by ledger.  The fix uses PyRun_InteractiveLoop
+# for interactive mode instead of Py_Main, avoiding the readline conflict.
+
+import ledger
+
+attrs = dir(ledger)
+assert 'Account' in attrs, "Expected 'Account' in dir(ledger)"
+assert 'Amount' in attrs, "Expected 'Amount' in dir(ledger)"
+assert 'Journal' in attrs, "Expected 'Journal' in dir(ledger)"
+assert 'read_journal' in attrs, "Expected 'read_journal' in dir(ledger)"
+
+print("dir(ledger) ok")

--- a/test/regress/852_py.test
+++ b/test/regress/852_py.test
@@ -1,0 +1,3 @@
+test python test/regress/852.py
+dir(ledger) ok
+end test


### PR DESCRIPTION
## Summary

- Fixes issue #852: segfault when running `ledger python` interactively and calling `dir(ledger)`
- Root cause: `Py_Main()` was called after `Py_Initialize()`, causing it to load `readline.so` which conflicted with `libedit` already linked by ledger, producing a crash in `PyOS_Readline`
- Fix: use `PyRun_InteractiveLoop(stdin, \"<stdin>\")` for interactive mode (no arguments), which drives the REPL without the conflicting readline initialization; script execution (`ledger python script.py`) continues to use `Py_Main` unchanged

## Test plan

- [x] Added `test/regress/852_py.test` and `test/regress/852.py` that verify `import ledger` and `dir(ledger)` work without crashing
- [x] All existing Python tests pass (`ctest -R py` — 11/11)
- [x] Build verified with `-DUSE_PYTHON=ON` in nix-shell environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)