### PR TITLE
Fix infinite recursion with --unround and --group-by (issue #518)

### DIFF
--- a/src/item.cc
+++ b/src/item.cc
@@ -388,8 +388,18 @@ value_t get_comment(item_t& item) {
 }
 
 void item_t::define(const symbol_t::kind_t, const string& name, expr_t::ptr_op_t def) {
-  bind_scope_t bound_scope(*scope_t::default_scope, *this);
-  set_tag(name, def->calc(bound_scope));
+  if (defining_)
+    return;
+  defining_ = true;
+  try {
+    bind_scope_t bound_scope(*scope_t::default_scope, *this);
+    set_tag(name, def->calc(bound_scope));
+    defining_ = false;
+  }
+  catch (...) {
+    defining_ = false;
+    throw;
+  }
 }
 
 expr_t::ptr_op_t item_t::lookup(const symbol_t::kind_t kind, const string& name) {

--- a/src/item.h
+++ b/src/item.h
@@ -95,12 +95,15 @@ public:
   optional<string> note;
   optional<position_t> pos;
   optional<string_map> metadata;
+  bool defining_;
 
   item_t(flags_t _flags = ITEM_NORMAL, const optional<string>& _note = none)
-      : supports_flags<uint_least16_t>(_flags), _state(UNCLEARED), note(_note), parent(NULL) {
+      : supports_flags<uint_least16_t>(_flags), _state(UNCLEARED), note(_note), parent(NULL),
+        defining_(false) {
     TRACE_CTOR(item_t, "flags_t, const string&");
   }
-  item_t(const item_t& item) : supports_flags<uint_least16_t>(), scope_t(), parent(NULL) {
+  item_t(const item_t& item)
+      : supports_flags<uint_least16_t>(), scope_t(), parent(NULL), defining_(false) {
     copy_details(item);
     TRACE_CTOR(item_t, "copy");
   }

--- a/test/regress/518.test
+++ b/test/regress/518.test
@@ -1,0 +1,22 @@
+; Regression test for GitHub issue #518:
+; Assertion failure when using --unround with --group-by account
+
+2017-12-23 a
+    Expenses:A  $1
+    Assets
+
+2017-12-25 b
+    Expenses:B  $1
+    Assets
+
+test reg --group-by account --unround
+Assets
+17-Dec-23 a                     Assets                          $-1          $-1
+17-Dec-25 b                     Assets                          $-1          $-2
+
+Expenses:A
+17-Dec-23 a                     Expenses:A                       $1           $1
+
+Expenses:B
+17-Dec-25 b                     Expenses:B                       $1           $1
+end test


### PR DESCRIPTION
## Summary

Fixes #518: assertion failure / stack overflow (infinite recursion) when using \`--unround\` with \`--group-by account\`.

### Root Cause

When \`--unround\` is combined with \`--group-by\`, the \`amount_\` handler becomes a \`merged_expr_t\` that compiles to an expression with \`O_DEFINE\` nodes (e.g. \`__tmp_amount_expr=(...);__tmp_amount_expr\`).

During compilation in a \`bind_scope_t(report, post)\` context (inside \`post_t::add_to_value\`), the \`O_DEFINE\` nodes call \`bind_scope_t::define()\`, which propagates to \`item_t::define()\` on the bound post.  \`item_t::define()\` evaluates the expression to store a tag value, which calls \`fn_amount_expr()\` — the same \`merged_expr_t\` still being compiled (\`compiled=false\`) — causing infinite recursion and stack overflow.

### Fix

Add a per-instance recursion guard (\`defining_\`) to \`item_t::define()\`. When \`define()\` is called re-entrantly on the same item object, the nested call returns immediately, breaking the cycle.

This is safe because:
- Values stored by \`item_t::define()\` via \`set_tag()\` are never accessible through the scope lookup mechanism (\`item_t::lookup()\` only handles a fixed set of named fields, not arbitrary tags)
- Non-recursive uses (e.g. \`--display-amount "abs()"\` with wrong arg count) are unaffected: the guard doesn't trigger and errors propagate normally

## Test plan

- [x] New regression test \`test/regress/518.test\` covers the exact inputs from the issue report
- [x] All existing baseline tests pass (including \`func-abs\`, \`cmd-script\`, etc.)