### PR TITLE
Fix missing std::variant include and boost::variant API remnants

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -117,8 +117,8 @@ inline parse_context_t open_for_reading(const path& pathname, const path& cwd) {
 }
 
 inline path safe_current_path() {
-  boost::system::error_code ec;
-  path cwd = filesystem::current_path(ec);
+  std::error_code ec;
+  path cwd = std::filesystem::current_path(ec);
   if (ec)
     return path("/");
   return cwd;

--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -92,6 +92,8 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <system_error>
+#include <variant>
 #include <vector>
 
 #include <cctype>

--- a/src/times.h
+++ b/src/times.h
@@ -395,10 +395,10 @@ public:
   }
 
   bool begin_has_year() const {
-    if (specifier_or_range.type() == typeid(date_specifier_t))
-      return boost::get<date_specifier_t>(specifier_or_range).has_year();
-    else if (specifier_or_range.type() == typeid(date_range_t))
-      return boost::get<date_range_t>(specifier_or_range).begin_has_year();
+    if (std::holds_alternative<date_specifier_t>(specifier_or_range))
+      return std::get<date_specifier_t>(specifier_or_range).has_year();
+    else if (std::holds_alternative<date_range_t>(specifier_or_range))
+      return std::get<date_range_t>(specifier_or_range).begin_has_year();
     else
       return false;
   }


### PR DESCRIPTION
## Summary

Three minimal fixes for CI failures introduced by the recent C++17 migration PRs:

- **`src/system.hh.in`**: Add `#include <variant>` and `#include <system_error>` alongside the other C++17 stdlib headers (`<any>`, `<optional>`, `<string_view>`). The cpp17-06-variant PR introduced `std::variant` usage throughout the codebase but omitted the corresponding include, causing build failures on platforms where `<variant>` is not transitively included.

- **`src/context.h`**: Replace `boost::system::error_code` with `std::error_code` and `filesystem::current_path(ec)` with `std::filesystem::current_path(ec)` in `safe_current_path()`. The cpp17-07-filesystem PR removed the `boost::filesystem` dependency but this function was not updated, leaving a dangling `boost::system` reference.

- **`src/times.h`**: Fix the `begin_has_year()` method in `date_specifier_or_range_t`, which still used the `boost::variant` API (`.type() == typeid(...)` and `boost::get<>()`) rather than the `std::variant` equivalents (`std::holds_alternative<>` and `std::get<>()`). All other methods in the same class had already been updated.

## Test plan

- [x] Build succeeds locally with `-DBUILD_DEBUG=ON` with no errors
- [ ] CMake CI passes (variant include fixes the `'variant' in namespace 'std' does not name a template type` error)
- [ ] Nix Flake CI passes (context.h fix resolves `'boost::system' has not been declared`, times.h fix resolves `'boost::get' was not declared`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)