### PR TITLE
acprep: Explicit CMAKE_OSX_SYSROOT for reproducible macOS builds

### DIFF
--- a/acprep
+++ b/acprep
@@ -741,8 +741,9 @@ class PrepareBuild(CommandLineApp):
                 if sdk_path:
                     self.configure_args.append('-DCMAKE_OSX_SYSROOT=' + sdk_path)
                     self.log.info('Using macOS SDK => ' + sdk_path)
-            except (subprocess.CalledProcessError, FileNotFoundError):
-                pass
+            except (subprocess.CalledProcessError, FileNotFoundError) as e:
+                # xcrun is unavailable or failed; proceed without an explicit macOS SDK sysroot.
+                self.log.debug('Unable to determine macOS SDK via xcrun: %s', e)
 
         if system.startswith('CYGWIN'):
             self.configure_args.append('-G')


### PR DESCRIPTION
This is a rebase of #2640 by @djthorough onto the current master branch, which now includes the `std::variant` include fixes from #2686. The original PR was failing CI because its branch predated those fixes.

## Problem

With multiple SDKs installed (Xcode + CLT), CMake can implicitly select SDKs inconsistently, leading to header mixing errors:

```
error: <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h>
```

## Solution

Use `xcrun` to detect the active macOS SDK and pass it explicitly to CMake via `-DCMAKE_OSX_SYSROOT`, following the [CMake-recommended pattern](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html). Falls back gracefully if `xcrun` is unavailable.

## Changes

- Identical to #2640 but rebased onto current master

Closes #2640