### PR TITLE
Fix fuzzer PCH/PIE mismatch causing Fuzz CI failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,7 @@ if(ENABLE_FUZZING)
   target_link_libraries(journal_fuzzer libledger)
 
   if(PRECOMPILE_SYSTEM_HH)
-    target_precompile_headers(journal_fuzzer REUSE_FROM libledger)
+    target_precompile_headers(journal_fuzzer PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
   endif()
 
   add_custom_target(fuzz


### PR DESCRIPTION
## Summary

- The `journal_fuzzer` target was reusing the PCH from `libledger` via `REUSE_FROM`, but `libledger` is a static library compiled without `-fpie`, while `journal_fuzzer` is an executable compiled with `-fsanitize=fuzzer,address,undefined` which affects PIE settings on Ubuntu
- Clang enforces strict PCH compatibility and rejects a PCH where the `is pie` flag differs from the consuming translation unit, producing the error: `error: is pie differs in PCH file vs. current file`
- Fix: compile a fresh PCH for `journal_fuzzer` using `PRIVATE` instead of `REUSE_FROM`, so the PCH is built with the fuzzer's own compile flags

This has been failing in the nightly Fuzz CI since at least February 16, 2026.

## Test plan

- [ ] Trigger the Fuzz workflow manually after merge to confirm the build succeeds
- [ ] Verify `journal_fuzzer` compiles without PCH errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)