### PR TITLE
Add regression test for issue #2054 (balance assertion erroneously passes with = 0)

### DIFF
--- a/test/regress/2054.test
+++ b/test/regress/2054.test
@@ -1,0 +1,17 @@
+2021-08-26   Example transaction
+  Account-A         $1.00
+  Account-B               = 0
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 3:
+While balancing transaction from "$FILE", lines 1-3:
+> 2021-08-26   Example transaction
+>   Account-A         $1.00
+>   Account-B               = 0
+Unbalanced remainder is:
+               $1.00
+Amount to balance against:
+               $1.00
+Error: Transaction does not balance
+end test


### PR DESCRIPTION
## Summary

- Adds regression test `test/regress/2054.test` for GitHub issue #2054

## Background

Issue #2054 reported that a balance assignment of `= 0` (bare zero, no commodity) on a posting with no prior balance was silently accepted instead of failing with a balance error.

Example that should fail but previously passed:
```
2021-08-26   Example transaction
  Account-A         $1.00
  Account-B               = 0
```

The root cause was that when computing the difference between the assigned amount and the current account balance, a zero diff caused the posting to be left as null. This null posting was then auto-balanced by the transaction balancer, silently accepting an incorrect transaction.

## Fix

The fix was already applied in commit 051e4ab1 ("Do not treat balance assignments with 0 diff as a null posting"), which assigns `amt - amt` (zero with the correct commodity) explicitly instead of leaving the posting null. This causes the transaction to correctly fail to balance.

This PR adds a regression test to prevent future regressions of this behavior.

## Test plan

- [x] New regression test `test/regress/2054.test` passes
- [x] Test confirms the error message matches expected output
- [x] Test verifies exit code is 1 (failure)

Closes #2054

🤖 Generated with [Claude Code](https://claude.com/claude-code)