### PR TITLE
fix: include virtual posts in --related output

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -520,7 +520,7 @@ void related_posts::flush() {
       for (post_t* r_post : post->xact->posts) {
         post_t::xdata_t& xdata(r_post->xdata());
         if (!xdata.has_flags(POST_EXT_HANDLED) &&
-            (!xdata.has_flags(POST_EXT_RECEIVED) ? !r_post->has_flags(ITEM_GENERATED | POST_VIRTUAL)
+            (!xdata.has_flags(POST_EXT_RECEIVED) ? !r_post->has_flags(ITEM_GENERATED)
                                                  : also_matching)) {
           xdata.add_flags(POST_EXT_HANDLED);
           item_handler<post_t>::operator()(*r_post);

--- a/test/regress/2013.test
+++ b/test/regress/2013.test
@@ -1,0 +1,15 @@
+2021/01/01 Opening Balance
+    Assets:Bank                  1000.00 EUR
+    Equity:Opening Balances
+
+2021/01/01 Savings for new car
+    [Assets:Savings:Car]          500.00 EUR
+    [Assets:Bank]                -500.00 EUR
+
+test reg car
+21-Jan-01 Savings for new car   [Assets:Savings:Car]     500.00 EUR   500.00 EUR
+end test
+
+test reg car --related
+21-Jan-01 Savings for new car   [Assets:Bank]           -500.00 EUR  -500.00 EUR
+end test


### PR DESCRIPTION
## Summary

- Fixes #2013: Virtual posts were not shown with `--related`
- The `related_posts` filter was excluding virtual postings (`POST_VIRTUAL`) from `--related` output
- Removed `POST_VIRTUAL` from the exclusion mask in `related_posts::flush()` so user-defined virtual postings appear as related postings
- Auto-generated postings (`ITEM_GENERATED`) are still excluded

## Root Cause

In `src/filters.cc`, `related_posts::flush()` used this condition to determine which sibling postings to show:

```cpp
!r_post->has_flags(ITEM_GENERATED | POST_VIRTUAL)
```

This incorrectly excluded virtual postings (those using `[account]` or `(account)` syntax) from the related output. The fix removes `POST_VIRTUAL` from the check, keeping only the `ITEM_GENERATED` exclusion.

## Test plan

- [ ] Added regression test `test/regress/2013.test` with balanced virtual postings
- [ ] `reg car` shows the matched virtual posting
- [ ] `reg car --related` now shows the sibling virtual posting (was empty before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)