### PR TITLE
doc: fix commodity pricing example in section 4.5.4

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -1926,14 +1926,14 @@ your function in Python, you can return something like
 that value is always used, regardless of the commodity, the date, or
 the desired target commodity.  For example,
 
-@smallexample @c input:validate
+@smallexample @c input:814A366
 define myfunc_seven(s, d, t) = 7 EUR
 @end smallexample
 
 In order to specify a fixed price, but still valuate that price into
 the target commodity, use something like this:
 
-@smallexample @c input:validate
+@smallexample @c input:814A366
 define myfunc_five(s, d, t) = market(5 EUR, d, t)
 @end smallexample
 
@@ -1941,14 +1941,14 @@ The @code{value} directive sets the valuation used for all commodities
 used in the rest of the data stream.  This is the fallback, if nothing
 more specific is found.
 
-@smallexample @c input:validate
+@smallexample @c input:814A366
 value myfunc_seven
 @end smallexample
 
 You can set a specific valuation function on a per-commodity basis.
 Instead of defining a function, you can also pass a lambda.
 
-@smallexample @c input:validate
+@smallexample @c input:814A366
 commodity $
     value s, d, t -> 6 EUR
 @end smallexample
@@ -1956,7 +1956,7 @@ commodity $
 Each account can also provide a default valuation function for any
 commodities transferred to that account.
 
-@smallexample @c input:validate
+@smallexample @c input:814A366
 account Expenses:Food5
     value myfunc_five
 @end smallexample
@@ -1964,7 +1964,7 @@ account Expenses:Food5
 The metadata field @samp{Value}, if found, overrides the valuation
 function on a transaction-wide or per-posting basis.
 
-@smallexample @c input:validate
+@smallexample @c input:814A366
 = @@XACT and Food
     ; Value:: 8 EUR
     (Equity)                     $1
@@ -2021,16 +2021,11 @@ $ ledger reg -V food
 12-Mar-02 KFC                   Expenses:Food2                2 EUR        2 EUR
 12-Mar-03 KFC                   Expenses:Food3                3 EUR        5 EUR
 12-Mar-04 KFC                   Expenses:Food4                4 EUR        9 EUR
-12-Mar-05 KFC                   Expenses:Food5                   $1           $1
-                                                                           9 EUR
-12-Mar-06 KFC                   Expenses:Food6                   $1           $2
-                                                                           9 EUR
-12-Mar-07 KFC                   Expenses:Food7                1 CAD           $2
-                                                                           1 CAD
-                                                                           9 EUR
-12-Mar-08 XACT                  Expenses:Food8                   $1           $3
-                                                                           1 CAD
-                                                                           9 EUR
+12-Mar-05 KFC                   Expenses:Food5                5 EUR       14 EUR
+12-Mar-06 KFC                   Expenses:Food6                6 EUR       20 EUR
+12-Mar-07 KFC                   Expenses:Food7                7 EUR       27 EUR
+12-Mar-08 XACT                  Expenses:Food8                8 EUR       35 EUR
+12-Mar-09 POST                  (Expenses:Food9)              9 EUR       44 EUR
 @end smallexample
 
 @node Keeping it Consistent, Journal Format, Currency and Commodities, Keeping a Journal


### PR DESCRIPTION
## Summary

Fixes the incomplete example in section 4.5.4 "Complete control over commodity pricing" of the manual. The example describes 7 ways to control commodity valuation but only demonstrated 3 of them in the output.

**Root cause:** The valuation function definitions and automated transactions were marked as `input:validate` (standalone syntax checks only) rather than `input:814A366`, so they were excluded from the runnable example. This meant `ledger reg -V food` ran on the transaction data alone, leaving Food5–Food8 as unconverted amounts (`$1` or `1 CAD`).

**Fix:** Change all six `input:validate` blocks in section 4.5.4 to `input:814A366` so the DocTests runner combines them with the transaction data. Update the expected output to match.

With the complete input, the output now shows each valuation method in sequence:

```
12-Mar-02 KFC    Expenses:Food2    2 EUR    — explicit ((2 EUR)) annotation
12-Mar-03 KFC    Expenses:Food3    3 EUR    — posting-level Value:: metadata
12-Mar-04 KFC    Expenses:Food4    4 EUR    — transaction-level Value:: metadata
12-Mar-05 KFC    Expenses:Food5    5 EUR    — per-account valuation (myfunc_five)
12-Mar-06 KFC    Expenses:Food6    6 EUR    — per-commodity valuation (commodity $)
12-Mar-07 KFC    Expenses:Food7    7 EUR    — global-default valuation (value myfunc_seven)
12-Mar-08 XACT   Expenses:Food8    8 EUR    — automated transaction Value:: metadata
12-Mar-09 POST  (Expenses:Food9)   9 EUR    — automated transaction virtual posting
```

Verified with `python3 test/DocTests.py --ledger $(which ledger) --file doc/ledger3.texi 814A366`.

Closes #2084

## Test plan

- [x] `DocTests.py` test `814A366` passes
- [x] Full `DocTests.py` run shows no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)