### PR TITLE
Fix #2010: commodity alias names should work when quoted

### DIFF
--- a/test/regress/2010.test
+++ b/test/regress/2010.test
@@ -1,0 +1,33 @@
+; Regression test for issue #2010: commodity alias mustn't be in quotes
+; Tests that quoted alias names in commodity directives work correctly.
+; Prior to the fix, 'alias "BBB1"' would store the alias as '"BBB1"'
+; (including the surrounding quotes) instead of 'BBB1', causing lookups
+; to fail.
+
+commodity "AAA1"
+    alias "BBB1"
+
+2024/01/01 Test Quoted Alias
+    Expenses:Food    10 "BBB1"
+    Assets:Cash
+
+; Also verify that quoted and unquoted alias forms are equivalent when
+; the commodity symbol does not end in a digit.
+
+commodity AAAX
+    alias "BBBX"
+
+2024/01/02 Test Non-Numeric Alias
+    Income:Salary    -20 BBBX
+    Assets:Bank
+
+test bal
+            -10 AAA1
+             20 AAAX  Assets
+             20 AAAX    Bank
+            -10 AAA1    Cash
+             10 AAA1  Expenses:Food
+            -20 AAAX  Income:Salary
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

Fixes #2010: commodity alias names specified with surrounding quotes were not being recognized correctly.

The bug was that `alias "BBB1"` in a commodity directive stored the alias key as `"BBB1"` (including the surrounding double-quote characters), while `alias BBB1` stored it as `BBB1`. This meant that lookups for `BBB1` would fail to find the alias, causing the quoted commodity to be treated as an unknown commodity rather than an alias for the declared one.

The fix strips surrounding quotes from the alias name before registering it, making `alias "BBB1"` behave identically to `alias BBB1`.

## Changes

- **src/textual_directives.cc** (previously `src/textual.cc`): Strip surrounding quotes from alias names in `commodity_alias_directive()`, matching how commodity names themselves are parsed.
- **test/regress/2010.test**: New regression test verifying that quoted commodity aliases resolve correctly to their target commodity.

## Test plan

- [x] New regression test `test/regress/2010.test` passes
- [x] Existing commodity alias tests continue to pass
- [x] `commodity "AAA1"` + `alias "BBB1"` now works the same as `alias BBB1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)