### PR TITLE
fix: propagate pending state to auto-generated postings

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -904,11 +904,14 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context) {
             new_post->add_flags(POST_COST_CALCULATED);
           }
 
-          // A Cleared transaction implies all of its automatic posting are cleared
-          // CPR 2012/10/23
+          // A Cleared or Pending transaction implies all of its automatic
+          // postings carry the same state. CPR 2012/10/23
           if (xact.state() == item_t::CLEARED) {
             DEBUG("xact.extend.cleared", "CLEARED");
             new_post->set_state(item_t::CLEARED);
+          } else if (xact.state() == item_t::PENDING) {
+            DEBUG("xact.extend.cleared", "PENDING");
+            new_post->set_state(item_t::PENDING);
           }
 
           new_post->add_flags(ITEM_GENERATED);

--- a/test/regress/1973.test
+++ b/test/regress/1973.test
@@ -1,0 +1,18 @@
+; Test that auto-generated postings inherit pending state from the transaction
+; GitHub issue #1973: No way to catch state flags in automated transaction
+
+= /Food/
+    (Budget:Food)              (amount * 0.10)
+
+2024/01/15 ! Pending Grocery Store
+    Expenses:Food              $50.00
+    Assets:Checking
+
+test reg --pending --columns=80 -> 0
+24-Jan-15 Pending Grocery Store Expenses:Food                $50.00       $50.00
+                                Assets:Checking             $-50.00            0
+                                (Budget:Food)                 $5.00        $5.00
+end test
+
+test reg --cleared --columns=80 -> 0
+end test


### PR DESCRIPTION
## Summary

- Auto-generated postings from automated transactions now correctly inherit the `pending` (`!`) state from the matched transaction
- Previously, only `cleared` (`*`) state was propagated; pending state was silently dropped, causing auto-generated postings to be omitted by `--pending` filters
- The fix extends `auto_xact_t::extend_xact` in `src/xact.cc` to also set `PENDING` state on generated postings, consistent with the existing `CLEARED` handling

## Test plan

- [ ] New regression test `test/regress/1973.test` verifies that `--pending` includes auto-generated postings when the matched transaction is pending
- [ ] `test/regress/1973.test` also verifies `--cleared` correctly excludes them
- [ ] Existing tests `coverage-auto-xact-cleared.test`, `coverage-edge-pending-cleared.test`, `coverage-item-pending-filter.test` all continue to pass

Fixes #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)