### PR TITLE
test: add regression test for issue #1994

### DIFF
--- a/test/regress/1994.test
+++ b/test/regress/1994.test
@@ -1,0 +1,12 @@
+; Regression test for issue #1994
+; Resetting a balance with = syntax should work correctly with multiple
+; journal files. The balance assignment in the second file should reset
+; the account balance to the specified amount (1.00 €), regardless of
+; the existing balance from the first file (100.00 €).
+
+test -f $sourcepath/test/regress/1994a.dat -f $sourcepath/test/regress/1994b.dat balance -> 0
+              1.00 €  Assets:Cash
+             -1.00 €  Equity:Opening Balances
+--------------------
+                   0
+end test

--- a/test/regress/1994a.dat
+++ b/test/regress/1994a.dat
@@ -1,0 +1,3 @@
+2020-01-01 * Opening balance
+    Assets:Cash              100.00 €
+    Equity:Opening Balances

--- a/test/regress/1994b.dat
+++ b/test/regress/1994b.dat
@@ -1,0 +1,3 @@
+2020-01-01 * Opening balance
+    Assets:Cash             = 1.00 €
+    Equity:Opening Balances


### PR DESCRIPTION
## Summary

Issue #1994 reported that resetting a balance using the `=` assignment syntax did not work correctly when transactions were split across multiple journal files. For example:

- `journal_1`: `Assets:Cash = 100.00 €`
- `journal_2`: `Assets:Cash = 1.00 €` (intended to reset balance to 1.00 €)

Running `ledger -f journal_1 -f journal_2 balance` produced `101.00 €` instead of the expected `1.00 €`.

This was caused by the xdata cache in `account_t::amount()` being cleared between file reads, so the balance assignment in the second file didn't account for postings from the first file.

The underlying bug was already fixed in PR #2600 (commit `3abdf8d`) which addressed the related issue #1831. That fix introduced `account_t::self_total()` which directly iterates the account's posts list for balance assignment calculations, bypassing the cache entirely.

This PR adds a dedicated regression test to document and verify the correct behavior for the specific scenario described in issue #1994.

## Test plan

- [x] Created `test/regress/1994a.dat` - first journal file with opening balance of 100.00 €
- [x] Created `test/regress/1994b.dat` - second journal file resetting balance to 1.00 €
- [x] Created `test/regress/1994.test` - regression test verifying the balance is correctly reset to 1.00 €
- [x] Verified test passes with `python test/RegressTests.py`

Closes #1994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)