### PR TITLE
fix: use newline separator when combining posting and xact notes

### DIFF
--- a/src/post.cc
+++ b/src/post.cc
@@ -171,7 +171,11 @@ value_t get_payee(post_t& post) {
 value_t get_note(post_t& post) {
   if (post.note || (post.xact && post.xact->note)) {
     string note = post.note ? *post.note : empty_string;
-    note += (post.xact && post.xact->note) ? *post.xact->note : empty_string;
+    if (post.xact && post.xact->note) {
+      if (!note.empty())
+        note += '\n';
+      note += *post.xact->note;
+    }
     return string_value(note);
   } else {
     return NULL_VALUE;

--- a/test/regress/1975.test
+++ b/test/regress/1975.test
@@ -1,0 +1,22 @@
+; Regression test for GitHub issue #1975
+; Notes in format expressions should concatenate consistently
+; using newlines whether combining posting+xact notes or multiple posting notes
+
+; Transaction with both posting and transaction metadata
+2020/12/03 * PayeeA
+  ; Transaction note
+  AccountA        10  ; Tag: value
+  AccountB
+
+; Posting with multiple metadata entries on separate lines
+2020/12/03 * PayeeB
+  AccountA        10  ; Posting note
+                      ; Tag: value
+  AccountB
+
+test reg --format "%P %A %t %N\n" AccountA
+PayeeA AccountA 10  Tag: value
+ Transaction note
+PayeeB AccountA 10  Posting note
+ Tag: value
+end test

--- a/test/regress/coverage-post-account-long.test
+++ b/test/regress/coverage-post-account-long.test
@@ -8,5 +8,6 @@
     Assets:Checking
 
 test reg --format "%(note)\n" Expenses
- PostNote: food purchase TxnNote: important
+ PostNote: food purchase
+ TxnNote: important
 end test


### PR DESCRIPTION
## Summary

Fixes inconsistent note concatenation in `%N` format expressions (issue #1975).

When using `%N` in a format string, the note for a posting combines the posting's own note with the parent transaction's note. Previously these were concatenated without a separator, relying on an incidental leading space from parsing. This was inconsistent with how multiple note lines within a single posting are joined (using `\n`).

- Fix `get_note()` in `src/post.cc` to insert `'\n'` between posting and transaction notes when both are present
- This matches the behavior of `append_note()` which already uses `'\n'` to join multiple metadata entries
- Update existing coverage test that expected the old (inconsistent) behavior
- Add regression test `test/regress/1975.test`

### Before

```
PayeeA AccountA 10  Tag: value Transaction note   ← space separator (incidental)
PayeeB AccountA 10  Posting note                  ← newline separator (explicit)
 Tag: value
```

### After

```
PayeeA AccountA 10  Tag: value                    ← newline separator (consistent)
 Transaction note
PayeeB AccountA 10  Posting note
 Tag: value
```

## Test plan

- [x] New regression test `test/regress/1975.test` passes
- [x] All 1988 existing regression tests pass
- [x] Updated `test/regress/coverage-post-account-long.test` to reflect corrected behavior

Closes #1975

🤖 Generated with [Claude Code](https://claude.com/claude-code)