### PR TITLE
fix: walk larger-unit chain when no direct price found (issue #2017)

### DIFF
--- a/test/regress/2017.test
+++ b/test/regress/2017.test
@@ -1,0 +1,25 @@
+; Test that -X conversion works when a price is defined for an intermediate
+; unit in a conversion chain (issue #2017).
+;
+; Here A reduces to D via B and C, but the P directive only covers B.
+; When ledger stores 1.00 A internally as 1,000,000,000 D (after reduce),
+; it must walk the larger() chain D->C->B to find the price for B and then
+; scale the result correctly.
+
+C 1.00 A = 1000 B
+C 1.00 B = 1000 C
+C 1.00 C = 1000 D
+
+P 2020/01/01 B 5.00 USD
+
+2020/01/02 Test
+    Assets:Holdings    1.00 A
+    Assets:Cash       -1.00 A
+
+test bal -X USD
+                   0  Assets
+         USD-5000.00    Cash
+          USD5000.00    Holdings
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

Fixes #2017 — when a commodity conversion chain is defined using the `C` directive (e.g. `C 1.00 A = 1000 B`, `C 1.00 B = 1000 C`, `C 1.00 C = 1000 D`), amounts are reduced to the smallest unit at parse time via `in_place_reduce()`. When `-X` tries to convert such an amount to a target commodity, it only searched for a price attached to the smallest unit (D).

If a price is defined for an intermediate unit (e.g. `P 2020/01/01 B 5.00 USD`) but not for the smallest unit, the conversion silently returned no value and the amount was left unconverted.

## Root Cause

`amount_t::value()` in `src/amount.cc` calls `commodity().find_price(comm, moment)` for the current commodity only. The `smaller()`/`larger()` chain from `C` directives is **not** added to the price history graph — only explicit `P` directives create graph edges. So Dijkstra in `history.cc` cannot find paths through the conversion chain.

## Fix

After `find_price()` returns nullopt, walk the `larger()` chain (the direction amounts scale *up* toward their parent unit), scaling the amount at each step and retrying `find_price()`. When a price is found for the scaled unit, compute the final value using the scaled amount and return early.

```
Before: 1,000,000,000 D → find_price(USD) → null → no conversion
After:  1,000,000,000 D → scale to 1,000,000 C → find_price(USD) → null
                        → scale to 1,000 B     → find_price(USD) → 5.00 USD
                        → 1,000 B × 5.00 = 5,000.00 USD ✓
```

## Test plan

- [x] New regression test `test/regress/2017.test` covers a 4-level chain where only the intermediate unit B has a USD price
- [x] All 1435 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)