### PR TITLE
fix: register apply tag names as known to suppress --strict warnings

### DIFF
--- a/test/regress/2003.test
+++ b/test/regress/2003.test
@@ -1,0 +1,24 @@
+; Regression test for GitHub issue #2003:
+; 'apply tag' with --strict should not warn about the applied tags being
+; unknown, since using 'apply tag' is an explicit declaration of those tags.
+
+commodity $
+
+account Assets:Checking
+account Expenses:Auto
+
+apply tag hastag: true
+apply tag nestedtag: true
+
+2011/01/25 Tom's Used Cars
+    Expenses:Auto                    $ 5,500.00
+    Assets:Checking
+
+end apply tag
+
+test bal --strict -> 0
+         $ -5,500.00  Assets:Checking
+          $ 5,500.00  Expenses:Auto
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- When using `apply tag hastag: true` with `--strict` mode, ledger was generating spurious "Unknown metadata tag" warnings for each transaction and posting in the `apply tag` block
- The root cause: `apply_tag_directive` only pushed the tag onto the apply stack without registering the tag name in `known_tags`, unlike the `tag` directive
- Fix: register tag name(s) as known in `known_tags` when processing `apply tag`, treating it as an implicit tag declaration

## Details

Using `apply tag` is an explicit act that clearly declares the intent to use a tag, so it should be treated as a declaration equivalent to `tag <name>`. This matches what `tag_directive` does (calls `register_metadata` with integer context 0 to auto-register).

All three `apply tag` formats are handled:
- Simple boolean: `apply tag nobudget`
- Value pair: `apply tag hastag: true`
- Colon-delimited: `apply tag :tag1:tag2:`

## Test plan

- [ ] New regression test `test/regress/2003.test` verifies no spurious warnings with `apply tag` + `--strict`
- [ ] All 1431 existing regression tests continue to pass
- [ ] Undeclared inline tags still correctly generate strict-mode warnings

Fixes #2003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)