### PR TITLE
fix: check only_collapse_if_zero before displayed_count==1 in report_subtotal

### DIFF
--- a/test/regress/1984.test
+++ b/test/regress/1984.test
@@ -1,0 +1,29 @@
+= !%/^BUDGETED$/ & /^Expenses:Cash$/
+    ; :BUDGETED:
+    (Assets:Budget:Other)                    (-cost)
+
+= !%/^BUDGETED$/ & /^Expenses:/
+    ; :BUDGETED:
+    (Assets:Budget:Other)                    (-cost)
+
+2019/01/01 * Opening Balances
+    ; :BUDGETED:
+    Assets:Checking                       200.00 EUR
+    Equity:Opening Balances              -200.00 EUR
+    [Assets:Budget:Other]                  50.00 EUR
+    [Assets:Checking:Budget]              -50.00 EUR
+
+2019/01/06 * ATM
+    Expenses:Cash                          30.00 EUR
+    Assets:Checking
+
+2019/01/07 * Breakfast
+    Expenses:Cafe                           5.00 EUR
+    Expenses:Cash
+
+2019/01/14 * Books
+    Expenses:Education                     20.00 EUR
+    Assets:Checking
+
+test reg --collapse-if-zero '^Assets:Budget:Other$' --display 'total < 0'
+end test


### PR DESCRIPTION
## Summary

Fixes #1984: Unexpected output when `--display` and `--collapse-if-zero` are used together.

### Root cause

When `--collapse-if-zero` and `--display 'total < 0'` (or any predicate referencing the running total) are combined, `collapse_posts::report_subtotal()` evaluates the display predicate against component posts **before** `calc_posts` has computed running totals.

`get_total()` falls back to `post.amount` when `xdata_->total` is null:
```cpp
value_t get_total(post_t& post) {
  if (post.xdata_ && !post.xdata_->total.is_null())
    return post.xdata_->total;
  // ...
  return post.amount;  // fallback when total not yet computed
}
```

This meant a posting with a negative *amount* could satisfy `total < 0` even when its true running total was positive. For a zero-net transaction (e.g. Breakfast with +5 EUR and -5 EUR), the -5 EUR post passed the predicate, setting `displayed_count = 1`. The `displayed_count == 1` branch then fired — leaking that post to `calc_posts` and corrupting the running total for all subsequent postings.

### Fix

Reorder the branches in `report_subtotal()` so `only_collapse_if_zero` is checked **before** the `displayed_count == 1` optimisation:

- **non-zero subtotal**: pass all component posts through uncollapsed (unchanged behaviour)
- **zero subtotal**: suppress entirely — fall through without outputting anything

The `displayed_count == 1` optimisation is now only applied for regular `--collapse` (when `only_collapse_if_zero` is false).

## Test plan

- [x] New regression test `test/regress/1984.test` reproduces the original scenario
- [x] All 1435 existing tests pass with no regressions
- [x] Manually verified the three cases from the issue produce correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)