### PR TITLE
cmake: fix ICU include path and sysroot clearing for Nix re-runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,11 @@ cmake_minimum_required(VERSION ${Required_CMake_Version})
 # as sys/resource.h (pulled in by sys/wait.h) use these types unconditionally.
 # Clearing CMAKE_OSX_SYSROOT lets the Nix clang wrapper use its own bundled SDK
 # (which has no conflicting usr/include/c++/v1), resolving the include path conflict.
-if(APPLE AND NOT DEFINED CMAKE_OSX_SYSROOT)
+if(APPLE)
   # Allow the Nix clang wrapper to use its built-in sysroot so that only one
-  # c++/v1 stdint.h wrapper appears in the search path.
+  # c++/v1 stdint.h wrapper appears in the search path.  Apply on every cmake
+  # run (including re-runs with a cached build directory) so that the sysroot
+  # is cleared even when CMAKE_OSX_SYSROOT was previously cached.
   if(DEFINED ENV{NIX_CC} OR "$ENV{NIX_BUILD_TOP}" MATCHES "/nix/store/"
      OR CMAKE_CXX_COMPILER MATCHES "/nix/store/")
     set(CMAKE_OSX_SYSROOT "" CACHE PATH "Cleared: Nix clang uses its own SDK" FORCE)
@@ -208,6 +210,9 @@ endif()
 
 include(FindICU)
 find_package(ICU ${Required_Icu_Version} OPTIONAL_COMPONENTS uc i18n)
+if(ICU_FOUND)
+  include_directories(SYSTEM ${ICU_INCLUDE_DIRS})
+endif()
 
 include(CheckIncludeFiles)
 include(CheckLibraryExists)


### PR DESCRIPTION
## Summary

- **ICU include path missing**: `CMakeLists.txt` linked `${ICU_LIBRARIES}` but never called `include_directories(SYSTEM ${ICU_INCLUDE_DIRS})`, unlike every other dependency (Boost, GMP, MPFR, GPGme). Builds inside nix-shell worked accidentally because the Nix clang wrapper injects ICU headers via `NIX_CFLAGS_COMPILE`; builds using `/usr/bin/c++` (e.g. existing cached build directories) failed with `unicode/coll.h` not found.
- **Sysroot guard broken for re-runs**: The `CMAKE_OSX_SYSROOT` guard added in 396bcb27 used `NOT DEFINED CMAKE_OSX_SYSROOT`, which is always false on re-runs with an existing build directory (the value is already cached). This left stale build directories using `/usr/bin/c++` and the Xcode SDK sysroot instead of the Nix clang wrapper — compounding the ICU issue.

## Test plan

- [ ] Delete existing `build/` directory and run `./acprep debug --output=build` — cmake should detect Nix, set empty `CMAKE_OSX_SYSROOT`, and select the Nix clang wrapper
- [ ] `cd build && make -j$(nproc)` — should compile without `unicode/coll.h` errors
- [ ] `ctest -j$(nproc)` — all 2153 tests should pass
- [ ] Re-run `./acprep debug --output=build` without deleting the build dir — the sysroot should remain cleared (FORCE overrides cached value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)