### PR TITLE
Add regression test for issue #964 (balance report with lot-priced currencies)

### DIFF
--- a/test/regress/964.test
+++ b/test/regress/964.test
@@ -1,0 +1,35 @@
+; Regression test for issue #964
+; Balance report with lot-priced multi-currency transaction and -X conversion
+;
+; A transaction involving currency lots with differing cost basis and
+; current price should not produce spurious Equity:Capital Gains entries
+; in the balance report, and the total should balance to zero.
+;
+; The original bug showed:
+;   $6.45  Equity:Capital Gains  (spurious entry)
+;   $6.46  total (incorrect, did not balance)
+;
+; After the fix (also resolves #712), no Equity:Capital Gains is generated
+; automatically, and the balance correctly sums to zero.
+
+2012/08/22 Payment
+    Accrued                       €208.00  {=$1.3109}     @ $1.2798689
+    Expenses                      €4.16    {=$1.2798689}  @ $1.2798689
+    Assets                        $-271.54
+    Income:Currency Conversion    $-6.45
+
+test bal -X $
+             $272.67  Accrued
+            $-271.54  Assets
+               $5.32  Expenses
+              $-6.45  Income:Currency Conversion
+--------------------
+                   0
+end test
+
+test reg -X $
+12-Aug-22 Payment               Accrued                     $272.67      $272.67
+                                Expenses                      $5.32      $277.99
+                                Assets                     $-271.54        $6.45
+                                In:Currency Conversion       $-6.45            0
+end test


### PR DESCRIPTION
## Summary

- Adds `test/regress/964.test` as an explicit regression test for issue #964
- Issue #964 reported that `bal -X $` on a transaction with lot-priced multi-currency postings produced a spurious `Equity:Capital Gains` entry and an incorrect non-zero total

## Root Cause

The underlying bug (auto-generating incorrect `Equity:Capital Gains` entries from lot annotations) was fixed as part of issue #712. The existing `CAE63F5C-c.test` was updated at that time to reflect the correct post-fix output, but no issue-numbered regression test was ever created for #964.

## Fix

This PR adds `test/regress/964.test` which:
1. Documents the original buggy behavior in comments (spurious `$6.45 Equity:Capital Gains` and wrong `$6.46` total)
2. Verifies that `bal -X $` correctly shows all four original accounts without any synthetic entries, with the total summing to zero
3. Verifies that `reg -X $` likewise produces consistent output

## Test plan

- [x] `test/regress/964.test` passes with `bal -X $` test (balance sums to zero, no spurious Equity:Capital Gains)
- [x] `test/regress/964.test` passes with `reg -X $` test (register shows correct running totals)
- [x] Existing `CAE63F5C-b.test` and `CAE63F5C-c.test` still pass unchanged

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)