### PR TITLE
fix: normalize computed lot prices to display precision (#1032)

### DIFF
--- a/src/pool.cc
+++ b/src/pool.cc
@@ -235,6 +235,12 @@ cost_breakdown_t commodity_pool_t::exchange(const amount_t& amount, const amount
   if (cost.has_annotation())
     per_unit_cost = per_unit_cost.strip_annotations(keep_details_t());
 
+  // Normalize per-unit cost to its display precision so that lot prices
+  // computed from total costs (@@) can be matched against the displayed value
+  // when users reference them explicitly (fixes issue #1032).
+  if (per_unit_cost.has_commodity() && per_unit_cost.keep_precision())
+    per_unit_cost.in_place_roundto(static_cast<int>(per_unit_cost.display_precision()));
+
   DEBUG("commodity.prices.add", "exchange: per-unit-cost = " << per_unit_cost);
 
   // Do not record commodity exchanges where amount's commodity has a

--- a/test/regress/1032.test
+++ b/test/regress/1032.test
@@ -1,0 +1,15 @@
+D 1.00 GBP
+
+2011-01-01 * Opening balance
+    Assets:Investments      48.1716 AAA @@ 86.39 GBP ; @ 1.7934 GBP
+    Equity:Opening balance
+
+2011-12-06 * Sold AAA
+    Assets:Cash
+    Assets:Investments    -48.1716 AAA {1.79338033198 GBP} [2011-01-01]
+
+test bal :inv
+end test
+
+test bal :inv --lots
+end test


### PR DESCRIPTION
## Summary

Fixes #1032 — lots are not recognized as the same when a commodity is bought with `@@` (total cost) notation.

**Root cause:** When buying with `@@`, ledger computes the per-unit price via GMP rational division (e.g. `86.39 / 48.1716 = 215975/120429`). This exact rational is stored as the lot annotation. However, when ledger *displays* it, floating-point rounding at the display precision gives a finite decimal (e.g. `1.79338033198 GBP`). When the user copies that displayed price into a sell transaction (`{1.79338033198 GBP}`), ledger parses it as a *different* rational (`89669016599/50000000000`). Since `mpq_equal()` compares exact rationals, the two lots never match, and the investment account shows a phantom non-zero balance.

**Fix:** In `commodity_pool_t::exchange()` in `src/pool.cc`, after computing the per-unit cost, normalize it to its display precision using `in_place_roundto(display_precision())`. This only fires for computed/divided amounts (guarded by `keep_precision()`), and rounds the GMP rational to the same value a user would type after reading ledger output.

**Previous attempts:** An earlier fix (`a6a58af`) compared annotations using `to_string()` but was reverted (#1907) due to significant performance regression. This fix is targeted at the source of the divergence rather than the comparison, avoiding any performance impact.

## Test plan

- [x] New regression test `test/regress/1032.test` verifies `bal :inv` and `bal :inv --lots` both produce zero balance after buying with `@@` and selling with the displayed lot price
- [x] All 1858 existing regression and baseline tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)