### PR TITLE
Fix truncated() to work with amounts in value expressions

### DIFF
--- a/src/report.cc
+++ b/src/report.cc
@@ -725,8 +725,18 @@ value_t report_t::fn_abs(call_scope_t& args) {
 }
 
 value_t report_t::fn_truncated(call_scope_t& args) {
+  value_t& val = args[0];
+  // If no width argument is provided, do numeric truncation for amounts and
+  // balances (used in automated transaction expressions like truncated(amount)).
+  // If a width argument is provided, do string display truncation (used by the
+  // select command for column width formatting).
+  if (!args.has(1)) {
+    if (val.is_amount() || val.is_balance() || val.is_long()) {
+      return val.truncated();
+    }
+  }
   return string_value(format_t::truncate(
-      args.get<string>(0),
+      val.to_string(),
       (args.has<int>(1) && args.get<int>(1) > 0) ? static_cast<std::size_t>(args.get<int>(1)) : 0,
       args.has<int>(2) ? static_cast<std::size_t>(args.get<int>(2)) : 0));
 }

--- a/test/regress/685.test
+++ b/test/regress/685.test
@@ -1,0 +1,12 @@
+= /Expenses:Bug Fixes/
+  (Liabilities:Refactoring)  (truncated(amount * 0.01))
+
+2012/03/09 Test Transaction
+    Expenses:Bug Fixes    4.44 USD
+    Assets:Code
+
+test reg
+12-Mar-09 Test Transaction      Expenses:Bug Fixes         4.44 USD     4.44 USD
+                                Assets:Code               -4.44 USD            0
+                                (Liabilit:Refactoring)     0.04 USD     0.04 USD
+end test


### PR DESCRIPTION
## Summary

- `truncated(amount)` in automated transactions (and other value expressions) previously failed with "Amount expressions must result in a simple amount" because `fn_truncated` always treated its argument as a string and returned a string value
- Fix dispatches on the argument type: when given an amount, balance, or integer, it now calls `value_t::truncated()` to truncate to the commodity's display precision
- When given a string (the original display-formatting use case with `truncated(payee, width)`), the existing string column truncation behaviour is preserved

## Test plan

- [x] New regression test `test/regress/685.test` verifies `truncated(amount * 0.01)` works in an automated transaction
- [x] Existing `register` command default format uses `truncated(payee, int(payee_width))` — confirmed still works
- [x] 1852/1853 regression tests pass (pre-existing `coverage-select-accounts` failure unrelated to this change)

Fixes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)