### PR TITLE
Fix rounding in per-unit price annotation balance checking (issue #1125)

### DIFF
--- a/test/regress/1125.test
+++ b/test/regress/1125.test
@@ -1,0 +1,16 @@
+; Regression test for issue #1125: per-unit price annotations (@) must round
+; each posting's cost to the commodity's precision independently before summing
+; into the balance, not accumulate full-precision (unrounded) intermediate values.
+;
+; Post 1: 0.50 bread @ $3.99 = $1.995, rounds to $2.00
+; Post 2: 1.50 bread @ $4.99 = $7.485, rounds to $7.49
+; Sum of rounded costs: $2.00 + $7.49 = $9.49, which matches Assets: -$9.49
+
+2015-07-02 Buying some bread
+    Expenses            0.50 bread @ $3.99
+    Expenses            1.50 bread @ $4.99
+    Assets              -$9.49
+
+test bal --flat --no-total Expenses
+          2.00 bread  Expenses
+end test


### PR DESCRIPTION
## Summary

Fixes #1125: When a transaction has multiple postings with per-unit price annotations (`@`), each posting's cost should be independently rounded to the price's decimal precision before the balance is checked — matching real-world accounting practice where line-item costs are individually rounded.

### Problem

A transaction like:

```
2015-07-02 Buying some bread
    Expenses    0.50 bread @ $3.99   ; 0.50 × 3.99 = 1.995 → rounds to $2.00
    Expenses    1.50 bread @ $4.99   ; 1.50 × 4.99 = 7.485 → rounds to $7.49
    Assets      -$9.49               ; sum of rounded amounts
```

was rejected with "Transaction does not balance" because Ledger accumulated the exact costs ($1.995 + $7.485 = $9.480) and compared against $9.490, finding a $0.010 discrepancy.

### Fix

Before throwing the balance error, `xact_base_t::finalize()` now checks whether the residual balance is *exactly* explained by rounding each per-unit (`@`) annotated cost to its price's decimal precision:

```
price_prec = cost.precision() - amount.precision()
adj = Σ (round(cost, price_prec) - cost)
if balance + adj == 0, accept the transaction
```

This fires only when all postings have explicit amounts (no null posting), leaving the exact-arithmetic path for auto-computed posting amounts completely unchanged.

## Test plan

- [x] New regression test `test/regress/1125.test` covers the exact scenario from the issue
- [x] All previously-passing tests continue to pass
- [x] Pre-existing failures (`LedgerUtilTests`, `coverage-wave3-precommands`) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)