### PR TITLE
Fix parsing of European-style decimal amounts with zero integer part

### DIFF
--- a/test/regress/1888.test
+++ b/test/regress/1888.test
@@ -1,0 +1,24 @@
+; Regression test for issue #1888
+;
+; Rounding error when using multipliers with European-style decimal notation
+; (comma as decimal separator). The issue was that amounts like "0,075" were
+; incorrectly parsed as 75 instead of 0.075.
+
+= Tax:Amount
+  Tax:Amount        -0,0815
+  Tax:sometax        0,075
+  Tax:othertax       0,0065
+
+2020-01-06 Client billed
+  Client           $  -1596,00
+  Tax:Amount       $    130,08
+  Assets:Bank      $   1465,92
+
+test reg
+20-Jan-06 Client billed         Client                   $ -1596,00   $ -1596,00
+                                Tax:Amount                 $ 130,08   $ -1465,92
+                                Assets:Bank               $ 1465,92            0
+                                Tax:Amount                 $ -10,60     $ -10,60
+                                Tax:sometax                  $ 9,76      $ -0,85
+                                Tax:othertax                 $ 0,85            0
+end test

--- a/test/regress/1888_negative.test
+++ b/test/regress/1888_negative.test
@@ -1,0 +1,15 @@
+; Regression test for issue #1888 (negative amounts)
+;
+; Verify that negative European-style decimal amounts like "-0,075" are
+; parsed correctly as -0.075, not -75.
+
+2020-01-07 Test negative European decimal
+  Assets:Test    EUR -0,075
+  Equity         EUR  0,075
+
+test bal
+          EUR -0,075  Assets:Test
+           EUR 0,075  Equity
+--------------------
+                   0
+end test


### PR DESCRIPTION
Fixes #1888

When parsing amounts like "0,075" (European-style decimal notation), the
code incorrectly treated the comma as a thousands separator, resulting in
the value being parsed as 75 instead of 0.075.

This fix adds a check for when the integer part before the comma is all
zeros (e.g., "0,075", "00,075"). In such cases, the comma is treated
as a decimal separator rather than a thousands separator.

The fix preserves the correct parsing of thousands separators for amounts
like "1,000" where the integer part is non-zero.