### PR TITLE
Remove unsupported account_amount from man page

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -1199,7 +1199,6 @@ Return the absolute value of the given
 Return the posting's account.
 .It Sy account_base
 Return the base account, i.e. everything after the last account delimiter ':'.
-.\".It Sy account_amount
 .It Sy actual
 .\" Is there a difference between real and actual?
 Return true if the transaction is real, i.e not an automated or virtual


### PR DESCRIPTION
## Summary

- The `account_amount` field was listed in the man page but was never implemented
- The entry had already been commented out with `.\"`; remove the dead comment entirely

Fixes #1606

## Test plan

- No functional change; documentation-only fix
- Verify `account_amount` no longer appears in the rendered man page

🤖 Generated with [Claude Code](https://claude.com/claude-code)