### PR TITLE
Add regression test for issue #1968 (auxdate ignored with tags)

### DIFF
--- a/test/regress/1968.test
+++ b/test/regress/1968.test
@@ -1,0 +1,32 @@
+; Regression test for issue #1968
+; auxdate is ignored when a posting comment also contains a tag
+; https://github.com/ledger/ledger/issues/1968
+;
+; When a posting note contains both an auxiliary date [=YYYY-MM-DD] and a tag
+; (e.g. :foo: or foo :foo:), the auxiliary date should still be honoured.
+
+2020-10-22 * Test
+    Assets:A             5.00 EUR
+    Assets:B            -5.00 EUR ; [=2018-02-02]
+
+2020-10-22 * Test
+    Assets:A             5.00 EUR
+    Assets:B            -5.00 EUR ; [=2018-02-02] :foo:
+
+2020-10-22 * Test
+    Assets:A             5.00 EUR
+    Assets:B            -5.00 EUR ; [=2018-02-02] foo :foo:
+
+; All three postings to Assets:B should show 18-Feb-02 with --effective
+test reg --effective assets:b
+18-Feb-02 Test                  Assets:B                  -5.00 EUR    -5.00 EUR
+18-Feb-02 Test                  Assets:B                  -5.00 EUR   -10.00 EUR
+18-Feb-02 Test                  Assets:B                  -5.00 EUR   -15.00 EUR
+end test
+
+; The two postings with :foo: should be found via has_tag and also show
+; the correct effective date
+test reg --effective -l "has_tag('foo')"
+18-Feb-02 Test                  Assets:B                  -5.00 EUR    -5.00 EUR
+18-Feb-02 Test                  Assets:B                  -5.00 EUR   -10.00 EUR
+end test


### PR DESCRIPTION
## Summary

- Adds `test/regress/1968.test` as a regression test for issue #1968

## Background

Issue #1968 reported that when a posting comment contained both an auxiliary date `[=YYYY-MM-DD]` and a tag (`:foo:` or `foo :foo:`), the auxiliary date was ignored while the tag was correctly parsed.

The root cause was in `item_t::parse_tags()` in `src/item.cc`: date parsing was inside a `if (!strchr(p, ':'))` conditional block, so any comment containing a colon (which tags always do) would skip date extraction entirely.

The fix was already merged via PR #2536 (commit 3429b058): moving the date parsing before the colon check so that dates are always extracted regardless of whether tags are also present.

## Test plan

- [x] Test covers the three cases from the original issue report:
  1. Auxdate only: `; [=2018-02-02]`
  2. Auxdate with colon tag: `; [=2018-02-02] :foo:`
  3. Auxdate with word and colon tag: `; [=2018-02-02] foo :foo:`
- [x] Verifies all three postings show the correct effective date `18-Feb-02` with `--effective`
- [x] Verifies that tags are still parsed correctly (has_tag filter works)
- [x] Test passes with the installed ledger binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)