### PR TITLE
test: add regression test for #1212 (print --generated unparsable dates)

### DIFF
--- a/test/regress/1212.test
+++ b/test/regress/1212.test
@@ -1,0 +1,22 @@
+; Regression test for issue #1212:
+; "print --generated output unparsable with multiple commodities"
+;
+; When a transaction uses multiple commodities (e.g., USD and EUR) without an
+; explicit cost, ledger automatically computes a lot price annotation. The
+; print command with --generated should output this annotation with a date in
+; YYYY/MM/DD format (parseable) rather than YY-Mon-DD format (unparseable).
+;
+; The bug was that `print --generated` produced output like:
+;   Foo  10.00 USD {1.10 EUR} [00-Jan-01]
+; which could not be parsed back by ledger due to the invalid date format.
+; The fix ensures the date is written in the standard YYYY/MM/DD format.
+
+2000/01/01
+    Foo  10.00 USD
+    Bar  -11.00 EUR
+
+test print --generated -> 0
+2000/01/01 <Unspecified payee>
+    Foo                                 10.00 USD {1.10 EUR} [2000/01/01]
+    Bar                                   -11.00 EUR
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for GitHub issue #1212 / Bugzilla BZ#1212
- The bug: `print --generated` with multiple commodities produced lot date annotations in `%y-%b-%d` format (e.g., `[00-Jan-01]`), which could not be parsed back by ledger
- The fix was already applied in an earlier commit (by Oleg Bulatov, changing `annotation_t::print` to use `FMT_WRITTEN` instead of `FMT_PRINTED`)
- This PR adds the missing regression test to prevent future regressions

## Test plan

- [x] New regression test `test/regress/1212.test` verifies `print --generated` on a multi-commodity transaction outputs dates in parseable `YYYY/MM/DD` format
- [x] Test passes: `ctest -R 1212` succeeds
- [x] Verified the output (`10.00 USD {1.10 EUR} [2000/01/01]`) can be successfully re-parsed by ledger

Fixes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)