### PR TITLE
Fix !include case-sensitivity on case-sensitive filesystems

### DIFF
--- a/src/mask.cc
+++ b/src/mask.cc
@@ -386,7 +386,17 @@ mask_t& mask_t::assign_glob(string_view pat) {
     }
     }
   }
-  return (*this = re_pat);
+  // Filename glob matching must be case-sensitive so that !include respects
+  // filesystem case-sensitivity (issue #1660).  Unlike operator= which uses
+  // icase for account/payee query matching, globs are used exclusively for
+  // file name matching where case matters.
+#if HAVE_BOOST_REGEX_UNICODE
+  expr = boost::make_u32regex(re_pat.c_str(), boost::regex::perl);
+#else
+  expr.assign(re_pat.c_str(), boost::regex::perl);
+#endif
+  VERIFY(valid());
+  return *this;
 }
 
 } // namespace ledger

--- a/test/regress/1660.dat
+++ b/test/regress/1660.dat
@@ -1,0 +1,3 @@
+2024/01/01 Payee
+    Expenses:Food    $10.00
+    Assets:Cash

--- a/test/regress/1660.test
+++ b/test/regress/1660.test
@@ -1,0 +1,12 @@
+; Regression test for issue #1660: !include should be case-sensitive.
+; Including a filename with wrong case (1660.DAT vs 1660.dat) must fail
+; on case-sensitive filesystems and should not silently match a
+; differently-cased file via the glob matching logic.
+
+include 1660.DAT
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 6:
+Error: File to include was not found: "$sourcepath/test/regress/1660.DAT"
+end test


### PR DESCRIPTION
## Summary

- `assign_glob()` compiled its glob pattern by calling `operator=()`, which always adds `boost::regex::icase`, making `!include` treat filenames as case-insensitive even on case-sensitive (e.g. Linux) filesystems.
- Fixed by compiling the glob regex directly with `boost::regex::perl` (no `icase`) so filename matching respects the case specified by the user.
- Account/payee query patterns continue to use `icase` via `operator=()`.

Fixes #1660.

## Test plan

- [x] New regression test `test/regress/1660.test` verifies that `!include 1660.DAT` fails when only `1660.dat` exists, instead of silently matching it.
- [x] Existing glob-based include tests (`1662.test`) still pass — correct-case includes continue to work.
- [x] Full regression suite passes (1869 tests, 1 pre-existing failure unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)