### PR TITLE
Add regression test for issue #1647: --strict should not warn about built-in tags

### DIFF
--- a/test/regress/1647.test
+++ b/test/regress/1647.test
@@ -1,0 +1,25 @@
+# Regression test for issue #1647
+# --strict should not warn about built-in metadata tags like 'payee'
+# since these are used internally by ledger.
+
+commodity EUR
+
+account A
+account B
+tag foo
+
+2017-05-04 * Foo
+    ; :foo:
+    ; payee: xxx
+    A              10.00 EUR
+    B             -10.00 EUR
+
+test reg --strict
+17-May-04 xxx                   A                         10.00 EUR    10.00 EUR
+          xxx                   B                        -10.00 EUR            0
+end test
+
+test reg --pedantic
+17-May-04 xxx                   A                         10.00 EUR    10.00 EUR
+          xxx                   B                        -10.00 EUR            0
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for issue #1647 which reported that `--strict` and `--pedantic` incorrectly warn about built-in metadata tags like `payee`
- The underlying fix was already applied in commit `ca34e5fd` (pre-registering built-in tags in `journal_t::initialize`), but no regression test was added at that time
- This test ensures the bug does not regress

## Test case

The original issue showed that running:
```
ledger -f d reg --explicit --strict
```

with a journal using `; payee: xxx` metadata would produce:
```
Warning: ".../d", line 10: Unknown metadata tag 'payee'
```

even though `payee` is a built-in ledger tag. The regression test verifies that no such warning is generated.

## Test plan

- [x] `test reg --strict` runs without warnings about `payee`
- [x] `test reg --pedantic` runs without errors about `payee`
- [x] Verified test passes with `python3 test/RegressTests.py --ledger $(which ledger) --sourcepath . test/regress/1647.test`

Fixes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)