### PR TITLE
Add regression test for issue #1644

### DIFF
--- a/test/regress/1644.test
+++ b/test/regress/1644.test
@@ -1,0 +1,36 @@
+; Regression test for issue #1644: effective date in posting note is ignored
+; when a colon follows the effective date bracket on the same line.
+;
+; The bug was that "; [=date]" followed by anything containing a colon caused
+; the effective date to be ignored (the posting would use the transaction date
+; instead).  A trailing colon alone (e.g. "; [=date] :") was sufficient to
+; trigger the issue.
+
+; Case 1: bare colon after the effective date bracket.
+; The second posting should use the effective date 2008/11/01, not 2008/10/16.
+
+2008/10/16 store
+    expenses                  $ 37.50  ; [=2008/10/01]
+    expenses                  $ 37.50  ; [=2008/11/01] :
+    assets
+
+test reg --effective @store
+08-Oct-01 store                 expenses                    $ 37.50      $ 37.50
+08-Nov-01 store                 expenses                    $ 37.50      $ 75.00
+08-Oct-16 store                 assets                     $ -75.00            0
+end test
+
+; Case 2: date followed by a colon after the effective date bracket.
+; "2001/01/01:" looks like a metadata tag name; the effective date must still
+; be honoured.
+
+2008/10/16 shop
+    expenses                  $ 37.50  ; [=2008/10/01]
+    expenses                  $ 37.50  ; [=2008/11/01] 2001/01/01:
+    assets
+
+test reg --effective @shop
+08-Oct-01 shop                  expenses                    $ 37.50      $ 37.50
+08-Nov-01 shop                  expenses                    $ 37.50      $ 75.00
+08-Oct-16 shop                  assets                     $ -75.00            0
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for issue #1644 (originally reported in Bugzilla as BZ#1228)
- The bug was that an effective date in a posting note (`; [=YYYY/MM/DD]`) was silently ignored when a colon appeared later on the same note line
- A bare trailing colon was sufficient to trigger the bug: `; [=2008/11/01] :`
- A date-with-colon also triggered it: `; [=2008/11/01] 2001/01/01:`
- The bug is already fixed in the codebase; this adds a test to prevent future regressions

## Test plan

- [x] `python3 test/RegressTests.py --ledger $(which ledger) --sourcepath . test/regress/1644.test` passes (2/2 tests OK)
- [x] Both bug variants (bare colon and date-with-colon) are covered

Closes #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)