### PR TITLE
Add regression test for issue #1966: lot date without explicit cost

### DIFF
--- a/test/regress/1966.test
+++ b/test/regress/1966.test
@@ -1,0 +1,31 @@
+; Regression test for bug #1966: lot date specified without explicit cost should
+; be preserved, not replaced by the transaction date during finalization.
+;
+; When a posting specifies only a lot date (no @ cost), the transaction's
+; auto-pricing logic would replace the user-specified lot date with the
+; transaction date, causing the lot to not match its counterpart.
+
+2020/10/01 Purchase
+    Expense                             1.00 EUR
+    Bank                               -1.00 EUR
+    Assets:Reimbursements               1.00 EUR [2020/10/01]
+    Income:Something                   -1.00 EUR
+
+2020/11/01 Reimbursement
+    Bank                                1.00 EUR
+    Assets:Reimbursements              -1.00 EUR [2020/10/01]
+
+test print
+2020/10/01 Purchase
+    Expense                                 1.00 EUR
+    Bank                                   -1.00 EUR
+    Assets:Reimbursements               1.00 EUR [2020/10/01]
+    Income:Something                       -1.00 EUR
+
+2020/11/01 Reimbursement
+    Bank                                    1.00 EUR
+    Assets:Reimbursements               -1.00 EUR [2020/10/01]
+end test
+
+test bal --lot-dates Assets:Reimbursements
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for bug #1966 which reported that lot dates specified on postings without explicit cost annotations were being replaced by the transaction date during finalization.
- The fix itself was already implemented in PR #2558 (which introduced `POST_AMOUNT_USER_DATE` and the `lot_date` parameter to `exchange()`).
- This PR adds the missing regression test for the no-cost case specifically.

## Background

When a transaction has two different EUR "commodities" — one plain and one lot-dated (e.g., `EUR` and `EUR[2020/10/01]`) — the auto-pricing path in `finalize()` assigns a computed cost and calls `exchange()`. Before the fix in #2558, `exchange()` always used the transaction date, discarding the user's explicit lot date. The fix in #2558 resolves this via the `POST_AMOUNT_USER_DATE` flag, which is set by the parser when the user explicitly provides a lot date annotation.

## Test plan

- [x] `python test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1966.test` passes (2/2 tests)
- [x] All related lot-date tests (`ctest -R "1393|1966|lot"`) pass (36/36)
- [x] The test confirms that `Assets:Reimbursements -1.00 EUR [2020/10/01]` in a transaction dated 2020/11/01 correctly retains the lot date `[2020/10/01]`, not the transaction date

Closes #1966

🤖 Generated with [Claude Code](https://claude.com/claude-code)