### PR TITLE
Add regression test for issue #2104 (expr date in automated transaction with periodic transaction)

### DIFF
--- a/test/regress/2104.test
+++ b/test/regress/2104.test
@@ -1,0 +1,38 @@
+; Regression test for GitHub issue #2104
+; "error when using `expr date` invoked from a periodic transaction"
+;
+; When an automated transaction predicate contains `expr date < [DATE]`
+; and is applied to postings from a periodic transaction (~ monthly, etc.),
+; it should not crash with an assertion failure in primary_date().
+;
+; The crash occurred because periodic transaction postings have xact == nullptr,
+; and the old code had assert(xact) in primary_date(). The fix returns
+; CURRENT_DATE() as a fallback when xact is null, so the predicate evaluates
+; against the current date rather than crashing.
+;
+; Additionally, the automated transaction's generated postings are skipped
+; during budget generation (ITEM_GENERATED without POST_CALCULATED), so
+; the budget output is unaffected by the date-constrained auto transaction.
+
+= income:salary and expr date < [2023/01/01]
+    expense:gym         $50
+    assets:bank        -$50
+
+~ monthly
+    assets:bank         $1,000
+    income:salary      -$1,000
+
+; When --now is before the date cutoff, the auto transaction predicate
+; evaluates to TRUE against CURRENT_DATE(), but its generated postings
+; are ITEM_GENERATED and skipped during budget generation.
+test reg --budget --now 2022/06/15
+22-Jun-01 Budget transaction    assets:bank                 $-1,000      $-1,000
+22-Jun-01 Budget transaction    income:salary                $1,000            0
+end test
+
+; When --now is after the date cutoff, the auto transaction predicate
+; evaluates to FALSE, and the budget output is identical.
+test reg --budget --now 2023/06/15
+23-Jun-01 Budget transaction    assets:bank                 $-1,000      $-1,000
+23-Jun-01 Budget transaction    income:salary                $1,000            0
+end test


### PR DESCRIPTION
## Summary

- Adds regression test for GitHub issue #2104: \"error when using `expr date` invoked from a periodic transaction\"
- The underlying fix (replacing `assert(xact)` with `CURRENT_DATE()` fallback in `primary_date()`) was already applied in commit 27ba9545
- This PR adds the missing regression test to prevent regressions

## Problem

When an automated transaction predicate uses `expr date < [DATE]` and the journal also contains periodic transactions (`~ monthly`), ledger crashed with:

```
Error: Assertion failed in post.cc, line 109:
virtual ledger::date_t ledger::post_t::primary_date() const: xact
```

This happened because:
1. During parsing, automated transactions are applied to periodic transaction template postings
2. Periodic transaction postings have `xact == nullptr` (they're templates, not regular transactions)
3. The old `primary_date()` had `assert(xact)` which crashed for these postings

## Fix

The crash was already fixed by replacing `assert(xact)` with a `CURRENT_DATE()` fallback. When a posting has no parent transaction (periodic template posts), `primary_date()` now returns the current date rather than crashing.

The auto transaction's date predicate is evaluated against `CURRENT_DATE()` for periodic template postings. Any auto-transaction-generated postings that result are marked `ITEM_GENERATED` and skipped during budget generation, so the budget output is unaffected.

## Test plan

- [x] New regression test `test/regress/2104.test` passes with current ledger binary
- [x] Tests verify behavior both before and after the date cutoff with `--now`
- [x] Related tests `1218.test` and `1858.test` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)