### PR TITLE
Extend regression test for issue #551: --budget with --invert and monthly grouping

### DIFF
--- a/test/regress/551.test
+++ b/test/regress/551.test
@@ -31,3 +31,14 @@ test reg Stuff --budget --invert -W -e 2024/01/15
 24-Jan-07 - 24-Jan-13           Expenses:Stuff            30.00 USD    10.00 USD
 24-Jan-14 - 24-Jan-20           Expenses:Stuff            80.00 USD    90.00 USD
 end test
+
+; Test --budget with monthly grouping (-M) without --invert
+test reg Stuff --budget -M -b 2024/01/01 -e 2024/02/01
+24-Jan-01 - 24-Jan-31           Expenses:Stuff          -170.00 USD  -170.00 USD
+end test
+
+; Test --budget with monthly grouping (-M) WITH --invert
+; The bug also affected monthly grouping: amount was inverted but total was not
+test reg Stuff --budget --invert -M -b 2024/01/01 -e 2024/02/01
+24-Jan-01 - 24-Jan-31           Expenses:Stuff           170.00 USD   170.00 USD
+end test


### PR DESCRIPTION
## Summary

Issue #551 reported that `--budget` combined with `--invert` showed incorrect cumulative values in the register report. The bug has already been fixed in the codebase (a regression test was previously added in 6552face covering the weekly grouping case with `-W`).

This PR extends the existing regression test (`test/regress/551.test`) to also cover the **monthly grouping** case (`-M`) mentioned in the original issue report, where the reporter observed that the amount was inverted but the cumulative total was not.

### New test cases added:

1. `--budget -M -b 2024/01/01 -e 2024/02/01` — monthly without `--invert` (baseline)
2. `--budget --invert -M -b 2024/01/01 -e 2024/02/01` — monthly with `--invert` (bug scenario)

Both cases verify that:
- Individual amounts are correctly inverted by `--invert`
- The running total is also correctly inverted

## Test plan

- [x] Ran `ctest -R 551` — all 4 tests pass
- [x] Verified expected output matches current ledger behavior

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)