### PR TITLE
test: add regression test for issue #1213 (balance doubling with --period)

### DIFF
--- a/test/regress/1213.test
+++ b/test/regress/1213.test
@@ -1,0 +1,20 @@
+; Test for issue #1213: Balance amount doubled when using --period with
+; multiple postings to the same account.
+; With --immediate, --explicit, and --pedantic flags, the balance report
+; should show $8.00 ($5.00 + $3.00) for Expenses:Stuff, not $16.00.
+
+commodity $
+account Assets
+account Assets:Bank
+account Expenses
+account Expenses:Stuff
+payee   Some Store
+
+2017-06-17 * Some Store
+   Expenses:Stuff              $5.00
+   Expenses:Stuff              $3.00
+   Assets:Bank                -$8.00
+
+test bal --explicit --immediate --pedantic --period "june 2017" "^Expenses"
+               $8.00  Expenses:Stuff
+end test


### PR DESCRIPTION
## Summary

- Adds regression test `test/regress/1213.test` for GitHub issue #1213
- The bug: balance report doubled amounts when using `--period` with multiple postings to the same account in a single transaction (showing `$16.00` instead of `$8.00`)
- The fix was already present in the codebase; this PR adds the missing regression test

## Repro

Given this transaction:
```ledger
2017-06-17 * Some Store
   Expenses:Stuff              $5.00
   Expenses:Stuff              $3.00
   Assets:Bank                -$8.00
```

Running `ledger bal --period "june 2017" "^Expenses"` with `--immediate`, `--explicit`, and `--pedantic` flags previously showed `$16.00` instead of the correct `$8.00`.

## Test plan

- [x] Regression test passes with current ledger binary
- [x] Test correctly validates that two postings ($5.00 + $3.00) to the same account sum to $8.00, not $16.00

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)