### PR TITLE
Add regression test for issue #1754

### DIFF
--- a/test/regress/1754.test
+++ b/test/regress/1754.test
@@ -1,0 +1,28 @@
+; Regression test for issue #1754
+;
+; Two consecutive balance assignments with the same amount should not fail
+; with "Only one posting with null amount allowed per transaction".
+;
+; When the second balance assignment has the same value as the current account
+; balance, the computed difference is zero.  Previously this zero-diff posting
+; was left with a null amount, causing finalize() to see two null postings
+; (the zero-diff posting and the auto-balancing posting), and throw an error.
+;
+; The fix ensures that a zero-diff balance assignment explicitly sets the
+; posting amount to zero (with the correct commodity) instead of leaving it
+; null, so finalize() sees only one null posting (the auto-balancing one).
+
+2019-01-21 Adjustment
+    Assets:Cash                                 = $500.00
+    Equity:Adjustments
+
+2019-01-25 Adjustment
+    Assets:Cash                                 = $500.00
+    Equity:Adjustments
+
+test bal
+             $500.00  Assets:Cash
+            $-500.00  Equity:Adjustments
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Adds regression test `test/regress/1754.test` for the bug reported in #1754
- The bug (duplicate balance assignments with the same amount failing with "Only one posting with null amount allowed per transaction") was already fixed in an earlier commit
- This test confirms and documents the fix

## Background

When two consecutive transactions both used a balance assignment (`= $500.00`) to the same account, the second one would fail if the account balance was already at the assigned value. The diff between the assigned amount and the current balance was zero, but instead of setting the posting amount to `$0.00`, it was left as null. This caused `finalize()` to see two null postings and throw an error.

## Test plan

- [x] `test/regress/1754.test` passes with the current codebase
- [x] Verified with `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1754.test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)