### PR TITLE
Add regression test for issue #1225

### DIFF
--- a/test/regress/1225.test
+++ b/test/regress/1225.test
@@ -1,0 +1,22 @@
+; Test that automated transactions are visible to balance assertions,
+; specifically for the tax-estimation use case from issue #1225.
+;
+; Automated transactions estimate taxes at 30% of income. When filing
+; taxes, the balance assertion should see the auto-generated $300 and
+; only post the $50 adjustment (to reach $350), not the full $350.
+
+= expr account =~ /^Income/
+    (Liabilities:Taxes:Estimated)  -0.30
+
+2000/01/15 Paycheck
+    Income:Salary               $-1000.00
+    Assets:Checking              $1000.00
+
+2000/04/15 Tax Filing
+    [Liabilities:Taxes:Estimated]   = $350.00
+    [Equity:Retained Earnings]
+
+test reg Liabilities
+00-Jan-15 Paycheck              (Liab:Taxes:Estimated)      $300.00      $300.00
+00-Apr-15 Tax Filing            [Liab:Taxes:Estimated]       $50.00      $350.00
+end test


### PR DESCRIPTION
## Summary

- Issue #1225 reported that automated transactions combined with balance assertions give wrong posting amounts
- This is the same underlying bug as issue #1127 (auto-transaction postings not visible to balance assertions), which was already fixed by PR #1649
- Adds a regression test covering the specific tax-estimation use case from #1225

## Test

The test verifies that when an automated transaction estimates 30% taxes on income ($300), and a balance assertion sets the actual tax amount ($350), the assertion correctly sees the auto-generated $300 and posts only the $50 adjustment (not $350).

## Test plan

- [x] New regression test `test/regress/1225.test` passes
- [x] Existing regression test `test/regress/1127.test` still passes

Closes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)