### PR TITLE
Add regression test for issue #1761

### DIFF
--- a/test/regress/1761.dat
+++ b/test/regress/1761.dat
@@ -1,0 +1,3 @@
+--no-pager --columns=80 bal Brokerage
+--no-pager --columns=80 bal --market Brokerage
+--no-pager --columns=80 bal Brokerage

--- a/test/regress/1761.test
+++ b/test/regress/1761.test
@@ -1,0 +1,14 @@
+; Regression test for GitHub issue #1761
+; -V/--market flag was "sticky" in REPL/script mode: once used in one command,
+; subsequent commands without --market still showed market values instead of
+; reverting to the original commodity display.
+
+2019-01-01 Buy AAPL
+  Brokerage  1 AAPL @ $158
+  Bank  -$158
+
+test --script test/regress/1761.dat
+              1 AAPL  Brokerage
+                $158  Brokerage
+              1 AAPL  Brokerage
+end test


### PR DESCRIPTION
## Summary

- The `-V`/`--market` flag was "sticky" in REPL/script mode: once used in one command, subsequent commands without `--market` still showed market values instead of reverting to the original commodity display
- The bug was already fixed in the codebase via the `push_report`/`pop_report` mechanism in `execute_command_wrapper`
- This PR adds a regression test (`test/regress/1761.test` + `test/regress/1761.dat`) to document the fix and prevent future regressions

## Test plan

- [x] `test/regress/1761.test` verifies that running `bal Brokerage`, then `bal --market Brokerage`, then `bal Brokerage` in REPL/script mode produces `1 AAPL`, `$158`, `1 AAPL` (not the buggy `1 AAPL`, `$158`, `$158`)
- [x] Test passes: `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1761.test`

Fixes #1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)