### PR TITLE
Add regression test for issue #1694: --exchange with zero-activity budget accounts

### DIFF
--- a/test/regress/1694.test
+++ b/test/regress/1694.test
@@ -1,0 +1,32 @@
+; Regression test for bug #1694: --exchange with budget reports crashes when
+; a budget account has a non-zero allocation but no actual transactions.
+; The error was "Cannot add an uninitialized value to an amount" or
+; "Cannot negate an uninitialized value" when the actual balance was
+; VOID (no transactions) and --exchange was applied.
+
+commodity R
+D R1,000.00
+
+~ Monthly
+    Income:Salary                            R-10000
+    Expenses:Groceries                         R2000
+    Expenses:Internet                           R100
+    Assets
+
+2023/01/01 Salary
+    Income:Salary                            R-10000
+    Assets:Checking
+
+2023/01/15 Groceries
+    Expenses:Groceries                          R500
+    Assets:Credit Card                         R-500
+
+test budget --exchange R -b 2023/01 -e 2023/02
+   R9,500.00    R7,900.00    R1,600.00  120%  Assets
+     R500.00    R2,100.00   R-1,600.00   24%  Expenses
+     R500.00    R2,000.00   R-1,500.00   25%    Groceries
+                  R100.00     R-100.00     0    Internet
+ R-10,000.00  R-10,000.00            0  100%  Income:Salary
+------------ ------------ ------------ -----
+           0            0            0     0
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for GitHub issue #1694

## Problem

Issue #1694 reported that using `--exchange` (or `-X`) with the `budget` command crashes with `"Cannot add an uninitialized value to an amount"` when a budget account has a non-zero allocation but no actual transactions in the reporting period.

## Fix

The crash was already fixed by earlier commits merged into this branch:
- **055f8fbe**: Handle VOID value negation as a no-op in `in_place_negate()` (previously threw "Cannot negate an uninitialized value")
- **50326143**: Return empty balance as-is instead of converting to `NULL_VALUE` in `value_t::value()` (previously caused blank display instead of `0`)

## Test

Added `test/regress/1694.test` that uses the `R` commodity (matching the original issue report) with a budget that includes `Expenses:Internet` having a non-zero budget allocation (`R100`) but no actual transactions. The test uses date bounds (`-b 2023/01 -e 2023/02`) to produce stable, date-independent output.

The test verifies:
1. The command completes without crashing
2. The `Internet` account row shows the budget amount correctly (blank actual column, `R100` budget, `R-100` difference)

## Test plan
- [x] Regression test added for issue #1694
- [x] Test passes with `python3 test/RegressTests.py --ledger $(which ledger) --sourcepath . test/regress/1694.test`
- [x] Related tests (1542.test, 2262.test) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)