### PR TITLE
test: add regression test for --pivot respecting --date-format (fixes #1693)

### DIFF
--- a/test/regress/1693.test
+++ b/test/regress/1693.test
@@ -1,0 +1,9 @@
+2018-12-11 * Test for date-format
+    Assets:Card:Tesco       10.00 GBP
+        ; Card: 123
+        ; Expiration:: [2019-12-11]
+    Assets:Cash            -10.00 GBP
+
+test bal card --pivot Expiration --date-format %Y-%m-%d
+           10.00 GBP  Expiration:2019-12-11:Assets:Card:Tesco
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for issue #1693: `--pivot` correctly respects `--date-format`
- The bug reported that `ledger --date-format %Y-%m-%d bal card --pivot Expiration` would show `2019/12/11` instead of `2019-12-11` for date-valued tags
- The test confirms that `--pivot` correctly uses the user-specified date format when tag values are dates

## Root cause analysis

The issue was originally reported in 2018. The proposed fix was to change `FMT_WRITTEN` to `FMT_PRINTED` in `src/value.cc`. However, investigation shows the bug is already fixed in the current codebase: `set_date_format()` updates **both** `written_date_io` and `printed_date_io` (in `src/times.cc`), so when `--date-format` is specified, all date formatting (including `FMT_WRITTEN` paths used by `--pivot`) correctly uses the user-specified format.

## Test plan

- [x] New regression test `test/regress/1693.test` passes
- [x] Full test suite passes (only pre-existing `coverage-wave3-precommands` failure)
- [x] Verified the test reproduces the exact scenario from the bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)