### PR TITLE
Add regression test for issue #1748: year directive and price history

### DIFF
--- a/test/regress/1748.test
+++ b/test/regress/1748.test
@@ -1,0 +1,37 @@
+; Regression test for issue #1748
+; The 'year' directive should not affect price history lookup across years.
+; When multiple year directives are used, the prices command must show price
+; entries from ALL years, not just the first year's entries.
+
+year 2017
+
+2017-10-24 Testing
+  Assets       12 L
+  Income       -12 EUR
+
+year 2018
+
+2018-10-24 Testing
+  Assets       12 L
+  Income       -15 EUR
+
+; Both years' implicit prices must appear in the price database.
+; Previously, the second year's prices were missing because the year
+; directive incorrectly limited the price history lookup window.
+test prices
+2017/10/24 L               1 EUR
+2018/10/24 L            1.25 EUR
+end test
+
+; Period filtering must work correctly even when year directives are present.
+test reg -p 2017
+17-Oct-24 Testing               Assets                         12 L         12 L
+                                Income                      -12 EUR      -12 EUR
+                                                                            12 L
+end test
+
+test reg -p 2018
+18-Oct-24 Testing               Assets                         12 L         12 L
+                                Income                      -15 EUR      -15 EUR
+                                                                            12 L
+end test


### PR DESCRIPTION
## Summary

This PR adds a regression test for issue #1748 which was reported in 2019.

**Issue**: When multiple `year` directives are used in a Ledger journal:
- `ledger prices` only showed price entries from the first year's transactions
- `ledger stats` showed incorrect "Days since last post" values
- Period filtering with `-p YEAR` was broken

**Root Cause**: The `year` directive was overriding the `epoch` timestamp,
which is used as the upper bound for price history lookups. This capped the
visible price window to the first year's December 31st, hiding prices from
subsequent years.

**Fix History**: This was resolved by commit 67f13ce8 which introduced the
`year_directive_year` variable to track the year directive separately from
`epoch`. Year directives now update `year_directive_year` (used for
yearless date parsing) without modifying `epoch` (used for price history
bounds).

## Test plan

- [x] New regression test `test/regress/1748.test` verifies:
  - `prices` command shows price entries from ALL years when year directives are used
  - `reg -p YEAR` correctly filters by year even with multiple year directives
- [x] Test passes: `python3 test/RegressTests.py --ledger build/ledger --sourcepath . test/regress/1748.test`
- [x] All other regression tests continue to pass

Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)