### PR TITLE
Add pyproject.toml and scikit-build-core support for PyPI distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,11 @@ endif()
 
 ########################################################################
 
-option(USE_PYTHON "Build support for the Python scripting bridge" OFF)
+if(SKBUILD)
+  option(USE_PYTHON "Build support for the Python scripting bridge" ON)
+else()
+  option(USE_PYTHON "Build support for the Python scripting bridge" OFF)
+endif()
 option(USE_DOXYGEN "Build reference documentation using Doxygen" OFF)
 
 option(DISABLE_ASSERTS "Build without any internal consistency checks" OFF)
@@ -66,7 +70,13 @@ option(USE_GPGME "Build with support for encrypted journals" OFF)
 option(USE_GCOV "Enable code coverage with gcov" OFF)
 option(USE_LLVM_COV "Enable code coverage with LLVM instrumentation and lcov/genhtml" OFF)
 option(USE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
-option(BUILD_LIBRARY "Build and install Ledger as a library" ON)
+# In SKBUILD mode, BUILD_LIBRARY is OFF: we build a Python MODULE directly,
+# not a shared library plus a separately-installed .so copy.
+if(SKBUILD)
+  option(BUILD_LIBRARY "Build and install Ledger as a library" OFF)
+else()
+  option(BUILD_LIBRARY "Build and install Ledger as a library" ON)
+endif()
 option(BUILD_DOCS "Build and install documentation" OFF)
 option(BUILD_WEB_DOCS "Build version of documentation suitable for viewing online" OFF)
 
@@ -200,13 +210,20 @@ endif()
 ########################################################################
 
 if(USE_PYTHON)
-  if(NOT BUILD_LIBRARY)
-    message(ERROR "Building the python module requires BUILD_LIBRARY=ON.")
+  if(NOT BUILD_LIBRARY AND NOT SKBUILD)
+    message(WARNING "Building the python module requires BUILD_LIBRARY=ON (or SKBUILD mode).")
   endif()
 
-  find_package(Python
-    COMPONENTS Interpreter Development)
-  if(PYTHON_FOUND AND ${Python_VERSION} VERSION_GREATER_EQUAL ${Required_Python_Version})
+  # In SKBUILD mode scikit-build-core only provides Development.Module (no
+  # Development.Embed), so request that component explicitly.  In a regular
+  # build the full Development component (Module + Embed) is still used so
+  # that the interpreter can embed Python for the --python command.
+  if(SKBUILD)
+    find_package(Python COMPONENTS Interpreter Development.Module)
+  else()
+    find_package(Python COMPONENTS Interpreter Development)
+  endif()
+  if(Python_FOUND AND ${Python_VERSION} VERSION_GREATER_EQUAL ${Required_Python_Version})
     set(BOOST_PYTHON "python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}")
     set(HAVE_BOOST_PYTHON 1)
     include_directories(SYSTEM ${Python_INCLUDE_DIRS})
@@ -501,9 +518,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 add_subdirectory(src)
-add_subdirectory(doc)
-add_subdirectory(contrib)
-add_subdirectory(test)
+if(NOT SKBUILD)
+  add_subdirectory(doc)
+  add_subdirectory(contrib)
+  add_subdirectory(test)
+endif()
 
 ########################################################################
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["scikit-build-core>=0.10"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "ledger"
+version = "3.4.1"
+description = "A command-line double-entry accounting system"
+readme = "README.md"
+license = {file = "LICENSE.md"}
+requires-python = ">=3.10"
+authors = [
+  {name = "John Wiegley", email = "jwiegley@gmail.com"},
+]
+keywords = ["accounting", "double-entry", "finance", "ledger"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Intended Audience :: End Users/Desktop",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: C++",
+  "Programming Language :: Python :: 3",
+  "Topic :: Office/Business :: Financial",
+  "Topic :: Office/Business :: Financial :: Accounting",
+]
+
+[project.urls]
+Homepage = "https://ledger-cli.org"
+Documentation = "https://ledger-cli.org/docs.html"
+Repository = "https://github.com/ledger/ledger"
+"Issue Tracker" = "https://github.com/ledger/ledger/issues"
+
+[tool.scikit-build]
+# Development.Module (CMake 3.18+) is required for Python extension builds.
+cmake.minimum-version = "3.18"
+# No Python package directory: the extension module is installed directly
+# to the site-packages root by CMake's install(TARGETS ledger DESTINATION .)
+wheel.packages = []
+
+[tool.scikit-build.cmake.define]
+# Force Python bindings on and skip the shared library in wheel builds.
+USE_PYTHON = "ON"
+BUILD_LIBRARY = "OFF"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,80 +191,98 @@ endif()
 
 include(GNUInstallDirs)
 
-if(BUILD_LIBRARY)
-  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-  add_library(libledger SHARED ${LEDGER_SOURCES})
-  add_ledger_library_dependencies(libledger)
-  set_target_properties(libledger PROPERTIES
-    OUTPUT_NAME "ledger"
-    VERSION ${Ledger_VERSION_MAJOR}
-    SOVERSION ${Ledger_VERSION_MAJOR})
-  set_source_files_properties(
-    ${LEDGER_CLI_SOURCES} PROPERTIES COMPILE_FLAGS "-fPIC")
-
-  add_executable(ledger ${LEDGER_CLI_SOURCES})
-  target_link_libraries(ledger libledger)
-  if(HAVE_GPGME)
-    target_link_libraries(ledger Gpgmepp)
-  endif()
-
-  if(HAVE_BOOST_PYTHON)
-    target_link_libraries(ledger ${Python_LIBRARIES})
-  endif()
-
-  install(TARGETS libledger DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  install(FILES ${LEDGER_INCLUDES}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ledger)
-else()
-  add_executable(ledger ${LEDGER_SOURCES} main.cc global.cc)
+if(SKBUILD)
+  # When called by scikit-build-core, build a Python extension module
+  # directly from all sources (no separate libledger shared library).
+  # Python sources are already included in LEDGER_SOURCES via the
+  # HAVE_BOOST_PYTHON block above.
+  Python_add_library(ledger MODULE ${LEDGER_SOURCES} WITH_SOABI)
   add_ledger_library_dependencies(ledger)
-endif()
 
-# Precompiled headers for system.hh significantly reduce build times.
-# This is enabled for all build types (Debug, Release, RelWithDebInfo, etc.)
-# via the PRECOMPILE_SYSTEM_HH option. CMake's target_precompile_headers
-# (available since CMake 3.16) handles PCH generation and reuse automatically.
-if(PRECOMPILE_SYSTEM_HH)
-  if(BUILD_LIBRARY)
-    target_precompile_headers(libledger PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
-    target_precompile_headers(ledger REUSE_FROM libledger)
-  else()
+  # Precompiled headers for system.hh reduce build times.
+  if(PRECOMPILE_SYSTEM_HH)
     target_precompile_headers(ledger PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
   endif()
-endif()
 
-if(USE_PYTHON)
-  if(Python_SITEARCH)
-    if(WIN32 AND NOT CYGWIN)
-      set(_ledger_python_module_name "ledger.pyd")
-    elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-      set(_ledger_python_module_name "ledger.so")
-    else()
-      set(_ledger_python_module_name "ledger${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  # Install directly to the site-packages root; scikit-build-core maps
+  # DESTDIR / CMAKE_INSTALL_PREFIX to the wheel's site-packages directory.
+  install(TARGETS ledger DESTINATION .)
+else()
+
+if(BUILD_LIBRARY)set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+    add_library(libledger SHARED ${LEDGER_SOURCES})
+    add_ledger_library_dependencies(libledger)
+    set_target_properties(libledger PROPERTIES
+      OUTPUT_NAME "ledger"
+      VERSION ${Ledger_VERSION_MAJOR}
+      SOVERSION ${Ledger_VERSION_MAJOR})
+    set_source_files_properties(
+      ${LEDGER_CLI_SOURCES} PROPERTIES COMPILE_FLAGS "-fPIC")
+
+    add_executable(ledger ${LEDGER_CLI_SOURCES})
+    target_link_libraries(ledger libledger)
+    if(HAVE_GPGME)
+      target_link_libraries(ledger Gpgmepp)
     endif()
 
-    # Allow packagers to override where the Python module is installed.
-    # By default this uses Python's site-packages, but systems like Homebrew
-    # may need to install under CMAKE_INSTALL_PREFIX instead.
-    set(LEDGER_PYTHON_INSTALL_DIR "${Python_SITEARCH}" CACHE PATH
-      "Directory to install the ledger Python module into")
+    if(HAVE_BOOST_PYTHON)
+      target_link_libraries(ledger ${Python_LIBRARIES})
+    endif()
 
-    # FIXME: symlink would be sufficient:
-    # maybe using install(CODE "...") and
-    # execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink ...).
-    # Windows will need a special case due to not supporting symlinks.
-    add_custom_command(
-      TARGET libledger POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      $<TARGET_FILE:libledger> "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}")
-    install(
-      FILES "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}"
-      DESTINATION "${LEDGER_PYTHON_INSTALL_DIR}")
+    install(TARGETS libledger DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES ${LEDGER_INCLUDES}
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ledger)
   else()
-    message(WARNING "Python_SITEARCH not set. Will not install python module.")
+    add_executable(ledger ${LEDGER_SOURCES} main.cc global.cc)
+    add_ledger_library_dependencies(ledger)
   endif()
-endif()
 
-install(TARGETS ledger DESTINATION ${CMAKE_INSTALL_BINDIR})
+  # Precompiled headers for system.hh significantly reduce build times.
+  # This is enabled for all build types (Debug, Release, RelWithDebInfo, etc.)
+  # via the PRECOMPILE_SYSTEM_HH option. CMake's target_precompile_headers
+  # (available since CMake 3.16) handles PCH generation and reuse automatically.
+  if(PRECOMPILE_SYSTEM_HH)
+    if(BUILD_LIBRARY)
+      target_precompile_headers(libledger PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
+      target_precompile_headers(ledger REUSE_FROM libledger)
+    else()
+      target_precompile_headers(ledger PRIVATE ${PROJECT_BINARY_DIR}/system.hh)
+    endif()
+  endif()
+
+  if(USE_PYTHON)
+    if(Python_SITEARCH)
+      if(WIN32 AND NOT CYGWIN)
+        set(_ledger_python_module_name "ledger.pyd")
+      elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        set(_ledger_python_module_name "ledger.so")
+      else()
+        set(_ledger_python_module_name "ledger${CMAKE_SHARED_LIBRARY_SUFFIX}")
+      endif()
+  
+      # Allow packagers to override where the Python module is installed.
+      # By default this uses Python's site-packages, but systems like Homebrew
+      # may need to install under CMAKE_INSTALL_PREFIX instead.
+      set(LEDGER_PYTHON_INSTALL_DIR "${Python_SITEARCH}" CACHE PATH
+        "Directory to install the ledger Python module into")
+  
+      # FIXME: symlink would be sufficient:
+      # maybe using install(CODE "...") and
+      # execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink ...).
+      # Windows will need a special case due to not supporting symlinks.
+      add_custom_command(
+        TARGET libledger POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:libledger> "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}")
+      install(
+        FILES "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}"
+        DESTINATION "${LEDGER_PYTHON_INSTALL_DIR}")
+    else()
+      message(WARNING "Python_SITEARCH not set. Will not install python module.")
+    endif()
+  endif()
+
+  install(TARGETS ledger DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 ### CMakeLists.txt ends here


### PR DESCRIPTION
## Summary

Adds support for installing the Ledger Python extension module via pip, enabling Python packages that `import ledger` to express a proper PyPI dependency.

- Adds `pyproject.toml` using scikit-build-core as the build backend
- Adds SKBUILD mode to `CMakeLists.txt` and `src/CMakeLists.txt` that builds only the Python extension module (not the CLI binary or shared library)
- Fixes `PYTHON_FOUND` → `Python_FOUND` (wrong variable name for the modern `find_package(Python ...)` module)
- Uses `Python_add_library(ledger MODULE ... WITH_SOABI)` for proper ABI-tagged filenames (e.g. `ledger.cpython-312-x86_64-linux-gnu.so`)
- Installs the extension directly to the site-packages root so `import ledger` works without any wrapper package

## Usage

Install from source with all system dependencies (Boost, Boost.Python, GMP, MPFR) present:

```sh
pip install git+https://github.com/ledger/ledger.git
```

Or build a wheel locally:

```sh
pip install scikit-build-core
python -m build --wheel
```

## Design decisions

- **Module name kept as `ledger`**: `BOOST_PYTHON_MODULE(ledger)` defines `PyInit_ledger`, so no C++ changes are required. Class names remain `ledger.Amount`, `ledger.Balance`, etc.
- **Direct site-packages install**: The `.so` is installed at the site-packages root (not inside a `ledger/` package directory), matching the existing `ledger.so` install convention.
- **SKBUILD isolation**: The SKBUILD and non-SKBUILD code paths are separated by a top-level `if(SKBUILD)...else()...endif()` in `src/CMakeLists.txt`. Existing acprep/cmake builds are entirely unaffected.
- **`Development.Module`**: scikit-build-core isolated builds may not provide Python embedding headers (`Development.Embed`); using `Development.Module` is the recommended approach for extension-only builds.

Closes #1934

Previously PR #2678 (closed when `master` was renamed to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)