### PR TITLE
Add regression test for Cygwin build fix (issue #1166)

### DIFF
--- a/test/regress/1166.test
+++ b/test/regress/1166.test
@@ -1,0 +1,23 @@
+; Regression test for GitHub issue #1166
+; "Ledger 3.1.1 won't compile on latest cygwin (64-bit)"
+;
+; On Cygwin, the strptime() function is not provided by the system
+; (unlike Linux/macOS). Ledger's custom strptime implementation in
+; strptime.cc was only compiled on Windows (#ifdef _WIN32), not on
+; Cygwin. The fix was to change the guard to:
+;   #if defined(_WIN32) || defined(__CYGWIN__)
+;
+; Additionally, Cygwin removed strnicmp() around August 2014, so the
+; custom strptime.cc had to define strnicmp as strncasecmp for Cygwin.
+;
+; This test exercises date/time parsing via --input-date-format, which
+; uses the strptime() function internally.
+
+01%23%2015 Payee
+    Expenses:Food    $10.00
+    Assets:Cash
+
+test reg --input-date-format='%m%%%d%%%Y'
+15-Jan-23 Payee                 Expenses:Food                $10.00       $10.00
+                                Assets:Cash                 $-10.00            0
+end test


### PR DESCRIPTION
## Summary

Issue #1166 reported that Ledger 3.1.1 would not compile on 64-bit Cygwin due to `strptime` not being declared in scope.

The root cause was that `strptime.cc` and `times.cc` used `#ifdef _WIN32` to guard the custom `strptime` implementation, but Cygwin does not define `_WIN32`. Additionally, the custom `strptime.cc` used `strnicmp()`, which was removed from Cygwin around August 2014.

These compilation issues were already fixed in:
- Commit `c2785590` (Fix build under Cygwin) — changed `#ifdef _WIN32` to `#if defined(_WIN32) || defined(__CYGWIN__)` and added `strnicmp` → `strncasecmp` mapping for Cygwin
- `src/CMakeLists.txt` already had `if(WIN32 OR CYGWIN)` to include `strptime.cc` only on those platforms

This PR adds a regression test that exercises the `--input-date-format` option, which uses `strptime()` internally, to document that date parsing works correctly (using the custom strptime on Windows/Cygwin, and the system strptime on Linux/macOS).

## Test plan

- [x] Verify `test/regress/1166.test` passes with `python test/RegressTests.py`
- [x] Confirm the original fix is in place in `src/strptime.cc`, `src/times.cc`, and `src/CMakeLists.txt`

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)