### PR TITLE
Add regression test for issue #1199: lot date and price matching

### DIFF
--- a/test/regress/1199.test
+++ b/test/regress/1199.test
@@ -1,0 +1,37 @@
+; Regression test for bug #1199: lot date must be preserved when using a
+; cost expression so that lots can be matched across transactions.
+;
+; When a posting specifies a lot date like `-4ea [2017/01/03] @ expr`,
+; the user-specified lot date should be used for lot matching rather than
+; being replaced by the transaction date.
+;
+; Also tests that using the displayed decimal lot price (copied from
+; `--lots bal` output) as an explicit lot annotation `{price} [date]`
+; correctly matches a lot whose price was originally computed from an
+; expression (the internal rational number normalizes to the same
+; display-precision decimal).
+
+; --- Scenario 1: lot date annotation with @ cost expression ---
+; The lot date [2017/01/03] should be honoured so the two postings
+; match the same lot; the net 6ea should be left in the account.
+
+2017/01/03 Supplier
+  Assets:Inventory:Tricky       10ea @ (($26.40/10)*191.52/138.65)
+  Assets:Other                  ($112.25*191.52/138.65)
+  Equity:Expenditures           -$191.52
+
+2017/01/06 Production department
+  Assets:Inventory:Tricky       -4ea [2017/01/03] @ (($26.40/10)*191.52/138.65)
+  Assets:Inventory:Work in process
+
+; --- Scenario 2: explicit decimal lot price taken from --lots bal output ---
+; The printed decimal representation of the computed lot price is
+; precise enough to round-trip back and match the original lot.
+
+2017/01/09 Production department 2
+  Assets:Inventory:Tricky       -2ea {$3.646684457266498377208799} [2017/01/03]
+  Assets:Inventory:Work in process
+
+test bal --lots Tricky
+4ea {$3.646684457266498377208799} [2017/01/03]  Assets:Inventory:Tricky
+end test


### PR DESCRIPTION
## Summary

Issue #1199 reported two related problems with lot matching when using computed cost expressions:

1. **Lot date ignored**: When using `[lot-date] @ expr`, the explicit lot date was ignored and replaced by the transaction date during finalization. This was fixed by commit f633aec6 (PR #2558) which introduced the `POST_AMOUNT_USER_DATE` flag.

2. **Decimal price mismatch**: When the displayed decimal lot price (copied from `--lots bal` output) was used as an explicit `{price}` annotation in a subsequent posting, it might not match the original lot's internally stored rational number. This was fixed by commit b7029e46 which normalizes computed lot prices to display precision.

This PR adds a regression test demonstrating both fixes work together:

- **Scenario 1**: A lot date annotation `[2017/01/03]` combined with `@ expr` correctly preserves the user-specified date so the lots match (6ea reduced by 4ea = 6ea remaining before scenario 2).
- **Scenario 2**: An explicit decimal lot price `{$3.646684457266498377208799}` taken from the `--lots bal` output correctly round-trips and matches the original computed-price lot.

## Test plan

- [x] Run `python test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1199.test` → passes
- [x] Run `ctest -R "RegressTest_1199$"` → passes
- [x] Run broader regression test suite (`ctest -R "RegressTest_10[0-9][0-9]|RegressTest_1[0-3][0-9][0-9]"`) → all 58 tests pass

Closes #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)