### PR TITLE
Add regression test for issue #1196: fixed commodity identity

### DIFF
--- a/test/regress/1196.test
+++ b/test/regress/1196.test
@@ -1,0 +1,23 @@
+; Regression test for GitHub issue #1196: Fixed commodity treated as separate
+; commodity. When using a fixed lot price {=price}, the annotated commodity
+; should not appear as a distinct commodity from the base one. The running
+; total in reg and bal reports should combine amounts of the same base
+; commodity regardless of their lot price annotations.
+
+2016-02-26 Test 1
+    Expenses:Foo            £560.70 {=$1.3866} @ $1.3866
+    Assets:Cash
+
+2016-09-08 Test 2
+    Expenses:Bar            £1744.26 {$1.5766} @ $1.5766
+    Assets:Cash
+
+test reg expenses
+16-Feb-26 Test 1                Expenses:Foo                £560.70      £560.70
+16-Sep-08 Test 2                Expenses:Bar               £1744.26     £2304.96
+end test
+
+test commodities
+$
+£
+end test


### PR DESCRIPTION
## Summary

Issue #1196 reported that using a fixed lot price annotation `{=price}` caused the commodity to appear as a distinct commodity from the base one. After a second transaction, the register running total would show two separate entries instead of combining them.

The fix was already applied in commit e46e1739 (via PR #2130), which removed a special case in `strip_annotations` that kept fixated price annotations visible when the commodity had also seen floating price annotations.

This PR adds a regression test to:
- Document the expected behavior
- Prevent future regressions where `{=price}` annotated amounts are not properly combined in `reg`/`bal` reports
- Verify that the `commodities` command shows base commodity names without annotations

## Test plan

- [x] New regression test `test/regress/1196.test` passes
- [x] Full test suite (2202 tests) passes with no failures

Closes #1196

🤖 Generated with [Claude Code](https://claude.com/claude-code)