### PR TITLE
Add regression tests for issue #1168 (zero-diff balance assignment)

### DIFF
--- a/test/regress/1168.test
+++ b/test/regress/1168.test
@@ -1,0 +1,35 @@
+; Regression test for issue #1168
+; Balance assignments where the difference is zero (account balance already
+; matches the asserted amount) should succeed without error.
+;
+; Prior to the fix, this produced "Only one posting with null amount allowed
+; per transaction" because the zero-diff balance assignment left the posting
+; amount null, which conflicted with the other null (auto-computed) posting.
+
+2024/11/24 * Opening Balance
+    Equity:Adjustments              P 1000.00
+    Equity:Opening Balance
+
+2024/11/25 * Metrobank
+    Expenses:Food                   P 300.00
+    Liabilities:Credit:Metrobank
+
+; This balance assignment has zero difference (Liabilities:Credit:Metrobank
+; is already P -300.00), so it should be a no-op that succeeds without error.
+2024/11/26 * Adjustments
+    Liabilities:Credit:Metrobank    = P -300.00
+    Equity:Adjustments
+
+test bal
+                   0  Equity
+           P 1000.00    Adjustments
+          P -1000.00    Opening Balance
+            P 300.00  Expenses:Food
+           P -300.00  Liabilities:Credit:Metrobank
+--------------------
+                   0
+end test
+
+test bal Liabilities
+           P -300.00  Liabilities:Credit:Metrobank
+end test

--- a/test/regress/1168b.test
+++ b/test/regress/1168b.test
@@ -1,0 +1,25 @@
+; Regression test for issue #1168 (alternative form)
+; An explicit zero amount with a balance assertion ($0 = $100) should pass
+; without error even when the current balance matches.
+;
+; Eric Portis noted: "Assets:Bank account  $0 = $100" lets you balance the
+; whole folder but the assertion fails when you try to balance the statement
+; by itself (as expected).  The main form "= $100" (balance assignment) should
+; succeed in both the individual and combined-file cases.
+
+2016-09-01 Previous transaction
+    Assets:Bank account     $100
+    Equity:Opening balances
+
+; Explicit zero amount + balance assertion: the $0 posts and the = $100
+; confirms the running balance equals $100.
+2016-10-01 Statement opening balance
+    Assets:Bank account     $0 = $100
+    Equity:Opening balances
+
+test bal
+                $100  Assets:Bank account
+               $-100  Equity:Opening balances
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Issue #1168 reported that balance assignments where the difference is zero produced "Only one posting with null amount allowed per transaction" 
- Investigation shows this bug is already fixed in the current codebase: when a balance assignment computes to zero diff, `post->amount` is set to `amt - amt` (zero, not null), allowing the other null posting to auto-compute normally
- These regression tests guard against any future regression of this behavior

## Test cases

**1168.test**: The original reporter's scenario (Philippine Peso credit card):
```ledger
11/25 * Metrobank
    Expenses:Food                   P 300.00
    Liabilities:Credit:Metrobank

11/26 * Adjustments
    Liabilities:Credit:Metrobank    = P -300.00  ; diff is zero, was buggy
    Equity:Adjustments
```

**1168b.test**: Eric Portis's variant using explicit `$0 = $100` balance assertion when the running balance already matches.

## Test plan

- [x] Both test files pass: `python test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1168.test test/regress/1168b.test`
- [x] Tests confirm the zero-diff balance assignment succeeds without error
- [x] Tests confirm the final account balances are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)