### PR TITLE
Add regression test for issue #1207 (auto+budget assertion crash)

### DIFF
--- a/test/regress/1207.test
+++ b/test/regress/1207.test
@@ -1,0 +1,35 @@
+; Regression test for issue #1207:
+; Assertion error in post.cc when combining automated and budget transactions.
+;
+; When extend_xact() processes a period_xact_t (~ Monthly) at parse time,
+; matching auto-transaction rules add generated posts to the period
+; transaction's post list.  Because period_xact_t inherits from xact_base_t
+; (not xact_t), these generated posts have no xact back-pointer.
+;
+; If those NULL-xact posts were placed into pending_posts by add_period_xacts,
+; downstream handlers such as collapse_posts::report_subtotal (used by
+; --monthly --average balance) would dereference post->xact without a null
+; guard, triggering an assertion failure.
+;
+; Fixed by skipping ITEM_GENERATED posts (without POST_CALCULATED) in
+; add_period_xacts, same as was already done in extend_xact itself.
+
+= /^Expenses:AccountA$/
+    Expenses:AccountB  (amount*0.1)
+    Expenses:AccountA  (-(amount*0.1))
+
+~ Monthly
+    Expenses:AccountA   $100
+    Assets
+
+2017-04-01 My Payee
+    Expenses:AccountA   $100
+    Assets
+
+test --monthly --average balance ^Expenses
+                 $14  Expenses
+                 $22    AccountA
+                  $3    AccountB
+--------------------
+                 $12
+end test


### PR DESCRIPTION
## Summary

- Adds regression test `test/regress/1207.test` for issue #1207
- The underlying crash was already fixed in commit 94836f2f (PR #2043) which skips `ITEM_GENERATED` posts without `POST_CALCULATED` in `add_period_xacts`
- This test verifies the fix covers the exact `--monthly --average balance` scenario from the original bug report

## Root Cause

When `extend_xact()` processes a `period_xact_t` (`~ Monthly`) at parse time, any matching automated transaction rules add generated posts to the period transaction's post list. Because `period_xact_t` inherits from `xact_base_t` (not `xact_t`), these generated posts have no `xact` back-pointer.

Previously, these NULL-xact posts were placed into `pending_posts` by `add_period_xacts`, and downstream handlers such as `collapse_posts::report_subtotal` (used by `--monthly --average balance`) would dereference `post->xact` without a null guard, triggering the assertion failure:

```
Error: Assertion failed in "src/post.cc", line 109: virtual ledger::date_t
ledger::post_t::primary_date() const: xact
```

## Test plan

- [x] Regression test runs without crash and produces expected output
- [x] Test verified with `python3 test/RegressTests.py --ledger result/bin/ledger --sourcepath . test/regress/1207.test`

Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)