### PR TITLE
Add regression test for issue #1194 (--group-by with --invert crash)

### DIFF
--- a/test/regress/1194.test
+++ b/test/regress/1194.test
@@ -1,0 +1,33 @@
+; Test case from issue #1194
+; Using --group-by with --invert (or --unround) caused an assertion failure:
+;   Assertion failed in "src/op.h": refc > 0
+; due to an expression context pointer dangling across group iterations.
+; The second group's bind_scope_t ended up at the same stack address as
+; the first group's (already-destroyed) bind_scope_t, making the scope
+; appear to be its own parent and causing infinite recursion in define().
+
+2016-11-10 * Test
+    Expenses:Foo                10.00 EUR
+        ; Project: test
+    Assets:Cash                -10.00 EUR
+
+2016-11-10 * Test
+    Expenses:Foo                10.00 EUR
+        ; Project: bar
+    Assets:Cash                -10.00 EUR
+
+test bal --group-by 'tag("Project")' --invert
+bar
+          -10.00 EUR  Expenses:Foo
+
+test
+          -10.00 EUR  Expenses:Foo
+end test
+
+test bal --group-by 'tag("Project")' --unround
+bar
+           10.00 EUR  Expenses:Foo
+
+test
+           10.00 EUR  Expenses:Foo
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for issue #1194, where `ledger bal --group-by 'tag("Project")' --invert` caused an assertion failure on the second group iteration
- The test also covers `--unround`, which triggered the same bug
- The root cause (dangling `context` pointer in `expr_base_t`) was already fixed in commit b676ca69

## Background

Using `--group-by` with `--invert` (or `--unround`) triggered:
```
terminate called after throwing an instance of 'ledger::assertion_failed'
  what():  Assertion failed in "src/op.h", line 259: refc > 0
```

The bug was that `expr_base_t::compile()` unconditionally stored `context = &scope`, where `scope` was a stack-allocated `bind_scope_t`. After the first group's scope was destroyed, its stack address was reused for the second group's `bind_scope_t`, causing the scope to believe it was its own parent and triggering infinite recursion in `bind_scope_t::define()`.

## Test plan

- [x] `test/regress/1194.test` passes with both `--invert` and `--unround`
- [x] Pre-existing test failures are unrelated to this change (confirmed by checking before/after)

Closes #1194

🤖 Generated with [Claude Code](https://claude.com/claude-code)