### PR TITLE
Fix -X to convert time values across scale units (issue #1177)

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -838,13 +838,17 @@ std::optional<amount_t> amount_t::value(const datetime_t& moment,
         // smallest unit (D) but a price is only defined for an intermediate
         // unit such as B.  We scale the amount up to the larger unit before
         // computing the price, then return the scaled price directly.
+        //
+        // Also handles the case where the target commodity is reachable via
+        // the larger() chain directly (e.g. -X h forces seconds to hours,
+        // even when the result is a fraction like 0.50h for 1800s).
         if (!point && commodity().larger()) {
           amount_t scaled(*this);
           while (!point && scaled.commodity_ && scaled.commodity().larger()) {
             scaled /= scaled.commodity().larger()->number();
             scaled.commodity_ = scaled.commodity().larger()->commodity_;
             if (comm && scaled.commodity().referent() == comm->referent())
-              break;
+              return scaled;
             point = scaled.commodity().find_price(comm, moment);
             if (point)
               point = scaled.commodity().check_for_updated_price(point, moment, comm);

--- a/test/regress/1177.test
+++ b/test/regress/1177.test
@@ -1,0 +1,31 @@
+; Test that -X forces time values into the specified unit (issue #1177)
+;
+; Without -X, ledger unreduces time to the most compact form >= 1 unit:
+;   5400s -> 1.50h, 1800s -> 30.0m, 30s -> 30s
+;
+; With -X h, all time values should be forced into hours, even when the
+; result is fractional (e.g. 1800s = 0.50h, 30s = 0.01h).
+
+2016-01-01 Employer
+    Me   -5400s
+    Them  5400s
+2016-01-01 Employer
+    Me   -3600s
+    Them  3600s
+2016-01-02 Employer
+    Me   -1800s
+    Them  1800s
+2016-01-02 Employer
+    Me   -30s
+    Them  30s
+
+test reg -X h
+16-Jan-01 Employer              Me                           -1.50h       -1.50h
+                                Them                          1.50h            0
+16-Jan-01 Employer              Me                           -1.00h       -1.00h
+                                Them                          1.00h            0
+16-Jan-02 Employer              Me                           -0.50h       -0.50h
+                                Them                          0.50h            0
+16-Jan-02 Employer              Me                           -0.01h       -0.01h
+                                Them                          0.01h            0
+end test


### PR DESCRIPTION
## Summary

- Fixes `-X h` so that time values in smaller units (seconds, minutes) are converted to the target unit even when the result is fractional
- `1800s` now correctly displays as `0.50h` when using `-X h` instead of staying as `30.0m`
- `30s` now displays as `0.01h` instead of remaining as `30s`

## Root Cause

In `amount_t::value()`, when searching for a price for an amount in terms of a target commodity, the code walks the `larger()` chain (the chain of commodity scale relationships, e.g. s → m → h). When the target commodity was found via this chain, the code executed `break` and then fell through without returning the scaled result (since no price history entry exists for time unit conversions). The fix returns the scaled amount directly when the target commodity is found via the `larger()` chain.

## Test plan

- [x] New regression test `test/regress/1177.test` verifies all four cases: 5400s (1.5h), 3600s (1h), 1800s (0.5h), 30s (~0.01h)
- [x] All 2201 existing tests pass

Fixes #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)