### PR TITLE
Fix Python FileInfo.filename and FileInfo.modtime access (issue #1205)

### DIFF
--- a/src/py_journal.cc
+++ b/src/py_journal.cc
@@ -226,6 +226,32 @@ post_t* posts_getitem(collector_wrapper& collector, long i) {
       ->posts[static_cast<std::size_t>(i)];
 }
 
+object py_fileinfo_filename(const journal_t::fileinfo_t& fi) {
+  if (fi.filename)
+    return object(fi.filename->native());
+  return object();
+}
+
+void py_fileinfo_set_filename(journal_t::fileinfo_t& fi, const object& obj) {
+  if (obj.is_none())
+    fi.filename = none;
+  else
+    fi.filename = path(extract<std::string>(obj)());
+}
+
+object py_fileinfo_modtime(const journal_t::fileinfo_t& fi) {
+  if (fi.modtime.is_not_a_date_time())
+    return object();
+  return object(fi.modtime);
+}
+
+void py_fileinfo_set_modtime(journal_t::fileinfo_t& fi, const object& obj) {
+  if (obj.is_none())
+    fi.modtime = datetime_t();
+  else
+    fi.modtime = extract<datetime_t>(obj)();
+}
+
 } // unnamed namespace
 
 #define EXC_TRANSLATOR(type)                                                                       \
@@ -249,10 +275,10 @@ void export_journal() {
   class_<journal_t::fileinfo_t>("FileInfo")
       .def(init<path>())
 
-      .add_property("filename", make_getter(&journal_t::fileinfo_t::filename),
-                    make_setter(&journal_t::fileinfo_t::filename))
-      .add_property("modtime", make_getter(&journal_t::fileinfo_t::modtime),
-                    make_setter(&journal_t::fileinfo_t::modtime))
+      .add_property("filename", make_function(py_fileinfo_filename),
+                    make_function(py_fileinfo_set_filename))
+      .add_property("modtime", make_function(py_fileinfo_modtime),
+                    make_function(py_fileinfo_set_modtime))
       .add_property("from_stream", make_getter(&journal_t::fileinfo_t::from_stream),
                     make_setter(&journal_t::fileinfo_t::from_stream));
 

--- a/test/regress/1205.py
+++ b/test/regress/1205.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Regression test for GitHub issue #1205:
+# Accessing .filename or .modtime on a FileInfo object raised:
+#   TypeError: No Python class registered for C++ class
+#   boost::optional<boost::filesystem::path>
+# because no Python converter was registered for boost::optional<path>.
+
+import ledger
+import os
+
+journal = ledger.read_journal_from_string("""
+2024/01/01 Payee
+    Expenses:Food    $10.00
+    Assets:Cash
+""")
+
+sources = list(journal.sources())
+assert len(sources) > 0, "Expected at least one source"
+
+fi = sources[0]
+
+# filename should be None for an in-memory journal (read from string)
+assert fi.filename is None, "Expected filename to be None for in-memory journal"
+
+# from_stream should be True for an in-memory journal
+assert fi.from_stream is True, "Expected from_stream to be True for in-memory journal"
+
+# modtime should be accessible without TypeError
+_ = fi.modtime
+
+print("FileInfo.filename and FileInfo.modtime are accessible")

--- a/test/regress/1205_py.test
+++ b/test/regress/1205_py.test
@@ -1,0 +1,3 @@
+test python test/regress/1205.py
+FileInfo.filename and FileInfo.modtime are accessible
+end test


### PR DESCRIPTION
## Summary

- Accessing `.filename` or `.modtime` on a `FileInfo` Python object raised `TypeError: No Python class registered for C++ class boost::optional<boost::filesystem::path>`
- Root cause: `make_getter`/`make_setter` cannot auto-convert `boost::optional<path>` or `datetime_t` to Python since no `boost::python` class is registered for these types
- Fix: add explicit helper getter/setter functions that unwrap the optional and handle the `not-a-date-time` sentinel, following the same pattern as `position_t::pathname` in `py_item.cc`

## Changes

- `py_fileinfo_filename`: returns path as Python `str`, or `None`
- `py_fileinfo_set_filename`: accepts `str` or `None`
- `py_fileinfo_modtime`: returns Python `datetime.datetime`, or `None` if unset
- `py_fileinfo_set_modtime`: accepts Python `datetime.datetime` or `None`

## Test plan

- [x] Added regression test `test/regress/1205_py.test` / `test/regress/1205.py`
- [x] All existing Python regression tests still pass

Closes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)