### PR TITLE
Add regression tests for issue #1167 (balance assertion with --decimal-comma)

### DIFF
--- a/test/regress/1167.test
+++ b/test/regress/1167.test
@@ -1,0 +1,41 @@
+; Regression test for issue #1167
+;
+; Bug: With --decimal-comma, a balance assertion of "= 0,00 EUR" on a
+; transaction that posts to an account whose running balance is already zero
+; (because a prior "bill received" transaction is absent) would SILENTLY PASS
+; instead of raising an error.
+;
+; Root cause (old code): the assertion machinery first computed
+;
+;   diff = assertion_amount - account_total
+;
+; and only entered the assertion-check block when diff != 0.  When the
+; account total was 0 (no prior activity), diff was 0, the entire block was
+; skipped, and the posting amount (1200 EUR) was never compared against the
+; assertion target (0 EUR).  The transaction was accepted with an incorrect
+; payable balance.
+;
+; Fix (current code): the assertion diff is always computed as
+;
+;   diff = assertion_amount - account_total - post_amount
+;
+; and checked unconditionally.
+;
+; SCENARIO 1 (this file): both transactions present.  The payment posting
+; carries a balance assertion that the payable account must reach zero.  With
+; both transactions, the assertion must pass and the full balance must be zero.
+
+2014/01/01 * Bill received
+    Expenses:Rent            1.200,00 EUR
+    Liabilities:Payable
+
+2014/01/31 * Bill paid
+    Liabilities:Payable      1.200,00 EUR = 0,00 EUR
+    Assets:Checking
+
+test bal --decimal-comma
+       -1.200,00 EUR  Assets:Checking
+        1.200,00 EUR  Expenses:Rent
+--------------------
+                   0
+end test

--- a/test/regress/1167b.test
+++ b/test/regress/1167b.test
@@ -1,0 +1,24 @@
+; Regression test for issue #1167 (part B)
+;
+; SCENARIO 2: only the payment transaction is present (no prior bill).
+; Liabilities:Payable is at 0 before the payment.  Posting +1200 EUR to it
+; would leave it at 1200 EUR, not the asserted 0 EUR.  The balance assertion
+; MUST raise an error.
+;
+; The old (buggy) code checked `if (!diff.is_zero())` before subtracting the
+; posting amount.  With no prior activity diff = 0, the gate was false, the
+; assertion block was never entered, and the transaction was silently accepted.
+; The current code always executes the assertion check, raising the error below.
+
+2014/01/31 * Bill paid (no prior bill transaction)
+    Liabilities:Payable      1.200,00 EUR = 0,00 EUR
+    Assets:Checking
+
+test bal --decimal-comma Liabilities -> 1
+__ERROR__
+While parsing file "$FILE", line 14:
+While parsing posting:
+  Liabilities:Payable      1.200,00 EUR = 0,00 EUR
+                                          ^^^^^^^^
+Error: Balance assertion off by -1.200,00 EUR (expected to see 1.200,00 EUR)
+end test


### PR DESCRIPTION
## Summary

- Adds two regression tests for [issue #1167](https://github.com/ledger/ledger/issues/1167): balance assertion not firing when account has no prior activity with `--decimal-comma`
- The underlying bug is already fixed in the current codebase; these tests guard against regressions

## Background

The original bug (reported with `--decimal-comma`): when a balance assertion like `= 0,00 EUR` appeared on a posting to an account with no prior transactions, the assertion would silently pass rather than raising an error.

**Root cause** (old code): the assertion machinery computed `diff = assertion_amount - account_total`, then only entered the assertion-check block when `diff != 0`. With an empty account, `diff` was zero so the block was skipped entirely — the posting amount was never compared against the assertion target.

**Fix** (current code): the diff is always computed as `assertion_amount - account_total - post_amount` and checked unconditionally, so the assertion fires correctly regardless of the prior account balance.

## Test plan

- [x] `test/regress/1167.test` — both bill and payment transactions present; balance assertion passes and net balance is zero
- [x] `test/regress/1167b.test` — only payment transaction present (no prior bill); balance assertion fires with "Balance assertion off by -1.200,00 EUR" error
- [x] Both tests pass with the current ledger binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)