### PR TITLE
Add regression test for issue #1201 (balance reset with auto transactions)

### DIFF
--- a/test/regress/1201.test
+++ b/test/regress/1201.test
@@ -1,0 +1,39 @@
+; Test for issue #1201: Balance reset doesn't work with automated transactions
+; When a balance assignment (=amount) follows a transaction that triggers an
+; automated transaction affecting the same account, the balance diff must
+; account for the automated transaction's effect on the account total.
+;
+; In this example:
+;   - Budget:Groceries starts at 10 EUR
+;   - An automated transaction fires when Expenses:Groceries is posted,
+;     reducing Budget:Groceries by 1.0 * the Expenses amount
+;   - The balance assignment "=2 EUR" should result in Budget:Groceries = 2 EUR
+;   - Without the fix, the auto-generated post was not counted in the account
+;     total, so the diff was 2 - 10 = -8 EUR, giving a final balance of -8 EUR
+
+2017-02-17 Initial balance
+  Budget:Groceries   10 €
+  Assets:Bank       100 €
+  Equity:Opening
+
+= /Expenses:Groceries/
+  Budget:Groceries  -1.0
+  Equity:Other       1.0
+
+2017-02-17
+  Expenses:Groceries  10 €
+  Assets:Bank
+
+2017-02-17
+  Budget:Groceries   =2 €
+  Assets:Bank
+
+test bal Budget:Groceries
+                 2 €  Budget:Groceries
+end test
+
+test reg Budget:Groceries
+17-Feb-17 Initial balance       Budget:Groceries               10 €         10 €
+17-Feb-17 <Unspecified payee>   Budget:Groceries              -10 €            0
+17-Feb-17 <Unspecified payee>   Budget:Groceries                2 €          2 €
+end test


### PR DESCRIPTION
## Summary

- Issue #1201 reported that balance reset (`=amount`) didn't work correctly when automated transactions also affected the same account
- The fix was already applied in commit a534869 (PR #552, merged 2018) which made auto-generated postings visible to subsequent balance assignment computations during parsing
- This PR adds a regression test to prevent the bug from recurring

## Test scenario

The test data from the issue:
- `Budget:Groceries` starts at 10 EUR (initial balance)
- An automated transaction fires when `Expenses:Groceries` is posted, applying `-1.0 × amount` to `Budget:Groceries`
- A second transaction posts `Expenses:Groceries 10€`, triggering the auto-rule and reducing `Budget:Groceries` to 0€
- A third transaction uses a balance assignment `Budget:Groceries =2€` to set it to exactly 2€

**Expected:** `Budget:Groceries = 2€` ✓  
**Broken (pre-fix):** `Budget:Groceries = -8€` (auto-generated posting not counted in account balance)

## Test plan

- [x] Regression test `test/regress/1201.test` added with `bal` and `reg` sub-tests
- [x] Test verified to pass with `python test/RegressTests.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)