### PR TITLE
Honor --date-format and --datetime-format in prices/pricedb (#1202)

### DIFF
--- a/src/times.cc
+++ b/src/times.cc
@@ -1825,16 +1825,27 @@ std::string format_date(const date_t& when, const format_type_t format_type,
 
 namespace {
 bool is_initialized = false;
-}
+bool explicit_date_format = false;
+bool explicit_datetime_format = false;
+} // namespace
 
 void set_datetime_format(const char* format) {
+  explicit_datetime_format = true;
   written_datetime_io->set_format(format);
   printed_datetime_io->set_format(format);
 }
 
 void set_date_format(const char* format) {
+  explicit_date_format = true;
   written_date_io->set_format(format);
   printed_date_io->set_format(format);
+}
+
+bool date_format_is_set() {
+  return explicit_date_format;
+}
+bool datetime_format_is_set() {
+  return explicit_datetime_format;
 }
 
 void set_input_date_format(const char* format) {
@@ -1844,6 +1855,9 @@ void set_input_date_format(const char* format) {
 
 void times_initialize() {
   if (!is_initialized) {
+    explicit_date_format = false;
+    explicit_datetime_format = false;
+
     input_datetime_io.reset(new datetime_io_t("%Y/%m/%d %H:%M:%S", true));
     timelog_datetime_io.reset(new datetime_io_t("%m/%d/%Y %H:%M:%S", true));
 

--- a/src/times.h
+++ b/src/times.h
@@ -111,6 +111,8 @@ std::string format_date(const date_t& when, const format_type_t format_type = FM
                         const optional<const char*>& format = none);
 void set_date_format(const char* format);
 void set_input_date_format(const char* format);
+bool date_format_is_set();
+bool datetime_format_is_set();
 
 inline void put_datetime(property_tree::ptree& pt, const datetime_t& when) {
   pt.put_value(format_datetime(when, FMT_WRITTEN));

--- a/src/value.cc
+++ b/src/value.cc
@@ -1193,7 +1193,7 @@ void value_t::in_place_cast(type_t cast_type) {
       set_datetime(datetime_t(as_date(), time_duration(0, 0, 0, 0)));
       return;
     case STRING:
-      set_string(format_date(as_date(), FMT_WRITTEN));
+      set_string(format_date(as_date(), date_format_is_set() ? FMT_PRINTED : FMT_WRITTEN));
       return;
     default:
       break;
@@ -1205,7 +1205,8 @@ void value_t::in_place_cast(type_t cast_type) {
       set_date(as_datetime().date());
       return;
     case STRING:
-      set_string(format_datetime(as_datetime(), FMT_WRITTEN));
+      set_string(
+          format_datetime(as_datetime(), datetime_format_is_set() ? FMT_PRINTED : FMT_WRITTEN));
       return;
     default:
       break;
@@ -1999,11 +2000,11 @@ void value_t::print(std::ostream& _out, const int first_width, const int latter_
     break;
 
   case DATETIME: // NOLINT(bugprone-branch-clone)
-    out << format_datetime(as_datetime(), FMT_WRITTEN);
+    out << format_datetime(as_datetime(), datetime_format_is_set() ? FMT_PRINTED : FMT_WRITTEN);
     break;
 
   case DATE:
-    out << format_date(as_date(), FMT_WRITTEN);
+    out << format_date(as_date(), date_format_is_set() ? FMT_PRINTED : FMT_WRITTEN);
     break;
 
   case INTEGER:

--- a/test/regress/1202.test
+++ b/test/regress/1202.test
@@ -1,0 +1,18 @@
+; Verify that --date-format is honored by the prices command and
+; --datetime-format is honored by the pricedb command (issue #1202).
+
+2020/01/10 Buy Stock
+    Assets:Brokerage    10 AAPL @ $30.00
+    Assets:Cash
+
+P 2020/01/15 00:00:00 AAPL $31.00
+
+test prices --date-format %Y-%m-%d
+2020-01-10 AAPL           $30.00
+2020-01-15 AAPL           $31.00
+end test
+
+test pricedb --datetime-format "%Y-%m-%d %H:%M:%S"
+P 2020-01-10 00:00:00 AAPL $30.00
+P 2020-01-15 00:00:00 AAPL $31.00
+end test


### PR DESCRIPTION
## Summary

- When `--date-format` or `--datetime-format` is set, all date/datetime value interpolation in format expressions now respects the user's format
- When not set, the default `%Y/%m/%d` format is preserved for backward compatibility
- This is a general fix in `value_t` that applies to all commands, not just `prices`/`pricedb`
- Added regression test `test/regress/1202.test`

## Root Cause

When a date or datetime value is interpolated in a format expression (e.g., `%(date)` or `%(datetime)`), the result was always rendered using `FMT_WRITTEN` (hardcoded `%Y/%m/%d`), ignoring the user's `--date-format` and `--datetime-format` options.

## Fix

Added `explicit_date_format` and `explicit_datetime_format` tracking flags in `times.cc`. When the user sets `--date-format`/`--datetime-format`, these flags are set to true. In `value_t::print()` and `value_t::in_place_cast(STRING)`, the code now checks these flags: if set, uses `FMT_PRINTED` (user-configured format); if not set, uses `FMT_WRITTEN` (default format) for backward compatibility.

## Test plan

- [x] New regression test `test/regress/1202.test` verifies `--date-format` works with `prices`
- [x] New regression test verifies `--datetime-format` works with `pricedb`
- [x] All previously-passing tests continue to pass (pre-existing failures in budget tests are unrelated)

Fixes #1202