### PR TITLE
Fix crash in csv -X when display_amount is a multi-commodity balance (issue #1184)

### DIFF
--- a/src/post.cc
+++ b/src/post.cc
@@ -325,6 +325,13 @@ value_t get_use_direct_amount(post_t& post) {
  */
 value_t get_commodity(call_scope_t& args) {
   if (args.has<amount_t>(0)) {
+    value_t val(args[0]);
+    if (val.is_balance()) {
+      const balance_t& bal(val.as_balance());
+      if (bal.single_amount())
+        return bal.amounts.begin()->second.commodity().strip_annotations(keep_details_t{});
+      return string_value(empty_string);
+    }
     return args.get<amount_t>(0).commodity().strip_annotations(keep_details_t{});
   } else {
     post_t& post(args.context<post_t>());

--- a/src/report.cc
+++ b/src/report.cc
@@ -819,7 +819,14 @@ value_t report_t::fn_unrounded(call_scope_t& args) {
 }
 
 value_t report_t::fn_quantity(call_scope_t& args) {
-  return args.get<amount_t>(0).number();
+  value_t val(args[0]);
+  if (val.is_balance()) {
+    const balance_t& bal(val.as_balance());
+    if (bal.single_amount())
+      return bal.amounts.begin()->second.number();
+    return 0L;
+  }
+  return val.to_amount().number();
 }
 
 value_t report_t::fn_truncate(call_scope_t& args) {
@@ -980,7 +987,14 @@ value_t report_t::fn_percent(call_scope_t& args) {
 }
 
 value_t report_t::fn_commodity(call_scope_t& args) {
-  return string_value(args.get<amount_t>(0).commodity().symbol());
+  value_t val(args[0]);
+  if (val.is_balance()) {
+    const balance_t& bal(val.as_balance());
+    if (bal.single_amount())
+      return string_value(bal.amounts.begin()->first->symbol());
+    return string_value(empty_string);
+  }
+  return string_value(val.to_amount().commodity().symbol());
 }
 
 value_t report_t::fn_commodity_price(call_scope_t& args) {

--- a/test/regress/1184.test
+++ b/test/regress/1184.test
@@ -1,0 +1,26 @@
+; Regression test for GitHub issue #1184
+; csv -X EUR should not crash when a synthetic revaluation posting has a
+; multi-commodity balance (e.g., when commodity conversion is incomplete).
+
+2016/04/03 Opening Balances
+    Assets:Sparkasse                              20 EUR
+    Equity:Opening Balances
+
+2016/05/01 buying deka
+    Assets:Deka                                  0.1 DK @ 20.00 EUR
+    Assets:Sparkasse
+
+2016/04/06 deposit to kraken
+    Assets:Kraken                                 20 EUR
+    Assets:Sparkasse
+
+test csv -X EUR
+"2016/04/03","","Opening Balances","Assets:Sparkasse","EUR","20","",""
+"2016/04/03","","Opening Balances","Equity:Opening Balances","EUR","-20","",""
+"2016/05/01","","buying deka","Assets:Deka","EUR","2","",""
+"2016/05/01","","buying deka","Assets:Sparkasse","EUR","-2","",""
+"2016/04/06","","deposit to kraken","<Adjustment>","","0","",""
+"2016/04/06","","deposit to kraken","Assets:Kraken","EUR","20","",""
+"2016/04/06","","deposit to kraken","Assets:Sparkasse","EUR","-20","",""
+"2016/05/01","","Commodities revalued","<Revalued>","EUR","0","",""
+end test


### PR DESCRIPTION
## Summary

- Fixes crash in `ledger csv -X EUR` when a synthetic revaluation posting has a multi-commodity balance
- `get_commodity()` in `post.cc` and `fn_commodity()`/`fn_quantity()` in `report.cc` now handle balance values gracefully
- For single-commodity balances, the functions extract the commodity/quantity from the single amount
- For multi-commodity balances, `commodity()` returns an empty string and `quantity()` returns 0

## Root Cause

When using `-X EUR` (or `-V`), the `changed_value_posts` revaluation filter generates synthetic postings to represent unrealized gains/losses. These synthetic postings can have a compound balance value (e.g., `0.1 DK -2 EUR`) when commodity conversion is incomplete. The CSV format calls `commodity(scrub(display_amount))` on these postings, which crashed with "Cannot convert a balance with multiple commodities to an amount" because the `commodity()` and `quantity()` functions expected a single-commodity amount.

The `reg` command was unaffected because its format uses `justify(scrub(display_amount))` which handles balance values natively.

## Test plan

- [x] Existing CSV regression tests pass (13/13)
- [x] New regression test `test/regress/1184.test` added and passes
- [x] No pre-existing test regressions introduced
- [x] Code passes `clang-format` check

Closes #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)