### PR TITLE
Fix 'expr any()' not recognized as keyword in single-arg queries (issue #1185)

### DIFF
--- a/test/regress/1185.test
+++ b/test/regress/1185.test
@@ -1,0 +1,16 @@
+; Regression test for issue #1185:
+; any() in conjunction with 'expr' in an automated transaction
+
+= expr any ( account =~ /Assets:ThatBankAccount/ )
+       $account                       -0.5
+
+2016/01/01 * test transaction
+     Expenses:Food                 $500
+     Assets:ThatBankAccount       $-500
+
+test bal
+               $-250  Assets:ThatBankAccount
+                $250  Expenses:Food
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

Fixes #1185: `any()` in conjunction with `expr` does not work when the `expr` keyword and its expression are in the same string token.

### Root Cause

The query lexer has two modes controlled by `multiple_args`:
- `multiple_args=true`: designed for separate command-line arguments, where each arg is a separate token
- `multiple_args=false`: designed for single-string queries (automated transactions)

When `multiple_args=true` and a user passes `expr any(account =~ /Pattern/)` as a **single** string (one shell argument or the entirety of an automated transaction query), the lexer includes whitespace in identifier reading. This causes `expr any` to be read as a single identifier `"expr any"` instead of recognizing `"expr"` as a keyword followed by `"any(...)"`. The keyword goes unrecognized, and the remaining `(account =~ /Pattern/)` is parsed incorrectly, leading to a "Missing ')'" error.

### Fix

In `test_ident`, after stripping trailing whitespace from the collected identifier, detect the case where `multiple_args=true` and the identifier starts with `"expr "`. In that case, rewind `arg_i` to just after the `"expr"` keyword so the existing `consume_next_arg` mechanism correctly captures the rest of the string as the expression argument.

### Tests

The new regression test (`test/regress/1185.test`) verifies that:
```
= expr any ( account =~ /Assets:ThatBankAccount/ )
       $account                       -0.5
```
works correctly in an automated transaction.

All 120 existing query/expr tests still pass.

## Test plan

- [x] New regression test `test/regress/1185.test` passes
- [x] All existing `query`/`expr` regression tests pass (120 tests)
- [x] Related `any`/`all` tests pass
- [x] Build with debug configuration succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)