### PR TITLE
Add regression test for issue #700: alias directive without account

### DIFF
--- a/test/regress/700.test
+++ b/test/regress/700.test
@@ -1,0 +1,16 @@
+; Regression test for GitHub issue #700 / #706:
+; `alias` directive without a preceding `account` directive should not segfault.
+; The alias keyword (and @alias legacy form) must expand account names correctly.
+
+alias Dining=Expenses:Dining
+
+2012/03/15 KFC
+    Dining                        $100.00
+    Checking
+
+test bal -> 0
+            $-100.00  Checking
+             $100.00  Expenses:Dining
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test (`test/regress/700.test`) for GitHub issue #700 / #706
- The `alias` directive (and its legacy `@alias` form) was reported to cause a segfault when used without a preceding `account` directive
- The bug has been fixed in the current codebase; this PR adds coverage to prevent recurrence

## Test case

```
alias Dining=Expenses:Dining

2012/03/15 KFC
    Dining  $100.00
    Checking
```

Running `ledger bal` on this input previously caused a segfault; it now produces the correct balance report.

## Test plan

- [x] New regression test `test/regress/700.test` passes
- [x] Existing alias-related tests continue to pass

Closes #700
Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)