### PR TITLE
cmake: build doc target by default when BUILD_DOCS is ON

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -187,7 +187,14 @@ endif()
 
 ########################################################################
 
-add_custom_target(doc DEPENDS ${ledger_doc_files} doc.doxygen)
+# When documentation is requested, include it in the default build so that
+# generated files (e.g. ledger3.info) exist when "cmake --install" runs.
+# Without ALL the install step would fail if the user never ran "make doc".
+if(BUILD_DOCS)
+  add_custom_target(doc ALL DEPENDS ${ledger_doc_files} doc.doxygen)
+else()
+  add_custom_target(doc DEPENDS ${ledger_doc_files} doc.doxygen)
+endif()
 
 ########################################################################
 


### PR DESCRIPTION
When `BUILD_DOCS=ON` the generated `ledger3.info` file must exist
before `cmake --install` runs, but the `doc` target was not included
in the default (`ALL`) build.  Users who ran `make install` without
first running `make doc` would get a hard failure because the compiled
`.info` file had not been produced yet.

Add `ALL` to the `doc` custom target when `BUILD_DOCS` is enabled so
that `make` (or `cmake --build .`) compiles the Texinfo source to
`.info` via `makeinfo` automatically, making the file available at
install time.

The underlying fix — compiling `ledger3.texi` with `makeinfo` instead
of installing the raw `.texi` source directly — was already present
from an earlier commit.

Fixes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)