### PR TITLE
Fix contradictory documentation for --price-db and --download (-Q)

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -8296,9 +8296,10 @@ N h
 @end smallexample
 
 @noindent
-Note: Ledger NEVER writes output to files.  You are responsible for
-updating the price-db file.  The best way is to have your price
-download script maintain this file.
+Note: When using @option{--download (-Q)}, Ledger automatically
+appends downloaded prices to this file.  Otherwise, Ledger does not
+write to the price-db file, and you are responsible for maintaining
+it manually.
 
 The format of the file can be changed by telling ledger to use the
 @option{--pricedb-format @var{FORMAT_STRING}} you define.


### PR DESCRIPTION
## Summary

- Fixes a direct contradiction in the documentation between the `--price-db` and `--download (-Q)` option descriptions
- Removes the incorrect absolute claim that "Ledger NEVER writes output to files"
- Replaces it with accurate documentation reflecting the actual code behavior

## Background

The `--price-db` section previously stated:

> Note: Ledger NEVER writes output to files. You are responsible for updating the price-db file.

This directly contradicted the `--download (-Q)` section, which correctly states that downloaded prices are appended to the price database file. The code in `src/quotes.cc` (`commodity_quote_from_script`) confirms that Ledger *does* open the price-db file for appending when a quote is successfully downloaded via `-Q`.

## Test plan

- [ ] Verify the two option descriptions are now consistent with each other
- [ ] Verify the description matches actual behavior (`src/quotes.cc` lines 112–116)

Fixes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)