### PR TITLE
Add regression test for issue #1018: timelog commodity reporting

### DIFF
--- a/test/regress/1018.test
+++ b/test/regress/1018.test
@@ -1,0 +1,49 @@
+; Test that -X forces timelog entries into the specified time unit (issue #1018)
+;
+; Ledger should allow choosing the output unit for timelog reporting.
+; By default, time values are displayed in their most compact form >= 1 unit
+; (e.g. 5 minutes shows as 5.0m, 90 minutes as 1.50h).
+;
+; Using -X h forces all time amounts into hours, even when the result would
+; be fractional (e.g. 5 minutes = 0.08h, 30 minutes = 0.50h).
+
+i 2013/04/05 09:30:00 Internal:Meeting:Tactical [Intelligent comment]
+o 2013/04/05 10:00:00
+i 2013/04/05 10:00:00 CustomerA:Email
+o 2013/04/05 10:05:00
+i 2013/04/05 10:05:00 CustomerB:Config
+o 2013/04/05 11:30:00
+i 2013/04/05 11:30:00 Personal:Walk
+o 2013/04/05 12:00:00
+i 2013/04/05 12:00:00 Personal:Lunch
+o 2013/04/05 13:30:00
+
+test bal
+                5.0m  CustomerA:Email
+               1.42h  CustomerB:Config
+               30.0m  Internal:Meeting:Tactical [Intelligent comment]
+               2.00h  Personal
+               1.50h    Lunch
+               30.0m    Walk
+--------------------
+               4.00h
+end test
+
+test bal -X h
+               0.08h  CustomerA:Email
+               1.42h  CustomerB:Config
+               0.50h  Internal:Meeting:Tactical [Intelligent comment]
+               2.00h  Personal
+               1.50h    Lunch
+               0.50h    Walk
+--------------------
+               4.00h
+end test
+
+test reg -X h
+13-Apr-05                       ..Intelligent comment]        0.50h        0.50h
+13-Apr-05                       CustomerA:Email               0.08h        0.58h
+13-Apr-05                       CustomerB:Config              1.42h        2.00h
+13-Apr-05                       Personal:Walk                 0.50h        2.50h
+13-Apr-05                       Personal:Lunch                1.50h        4.00h
+end test


### PR DESCRIPTION
## Summary

- Adds regression test `test/regress/1018.test` demonstrating that timelog entries can be reported in a user-specified time unit using `-X h`
- The test verifies both the default auto-scaling behavior and the forced-hours behavior for both `bal` and `reg` commands
- The underlying fix (making `-X` work with time unit commodities) was already applied in commit 517f2811 (issue #1177)

## Background

Issue #1018 requested the ability to "choose the output quantity, such as using only hours" when reporting timelogs. Previously, ledger would auto-scale time to the most compact representation >= 1 unit (e.g. 5 minutes showed as `5.0m`, 90 minutes as `1.50h`). There was no user-friendly way to force all output into a single unit.

The fix for issue #1177 (commit 517f2811) corrected the `larger()` chain walk in `amount_t::value()` to properly return scaled amounts when the target commodity is reached via unit conversion. This enables `-X h` to work for time commodities, forcing all time output into hours (including fractional hours like `0.08h` for 5 minutes or `0.50h` for 30 minutes).

## Test plan

- [x] Regression test passes: `python test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1018.test`
- [x] Default behavior (auto-scaling) is unchanged
- [x] `-X h` forces all time amounts to hours in both `bal` and `reg` commands
- [x] Fractional hours display correctly (5 min → 0.08h, 30 min → 0.50h)

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)