### PR TITLE
Add regression test for issue #1023: --exchange with budget crash

### DIFF
--- a/test/regress/1023.test
+++ b/test/regress/1023.test
@@ -1,0 +1,15 @@
+; Regression test for issue #1023: --exchange with --add-budget crashes
+; with "Cannot negate an uninitialized value" when an account has actual
+; transactions but no matching budget entry (display_total[1] is VOID).
+
+2023/01/15 * USD purchase
+    expenses:cash                         300.00 USD
+    assets:checking                      $-320.43
+
+~ Monthly
+    expenses:food                         100.00 USD
+    equity:budget
+
+test budget --add-budget --depth 2 -X USD -b 2023/01 -e 2023/02 ^expenses
+  300.00 USD                300.00 USD     0  expenses:cash
+end test


### PR DESCRIPTION
## Summary

- Adds `test/regress/1023.test` for GitHub issue #1023

## Problem

Issue #1023 reported that using `--exchange USD` with the `budget --add-budget` command crashed with `"Cannot negate an uninitialized value"` when an account had actual transactions but no matching budget entry. In this case, `display_total[1]` (the budget column) was VOID, and the budget format's `-scrub(get_at(display_total, 1))` expression triggered the crash.

## Fix

The crash was already fixed by commit `055f8fbe` which added `case VOID: return;` to `value_t::in_place_negate()`, making negation of a VOID value a no-op rather than throwing an error.

## Test

Added `test/regress/1023.test` with an account that has actual USD transactions but no budget entry, using `budget --add-budget --exchange USD` — the exact scenario that previously crashed.

## Test plan
- [x] Regression test added for issue #1023
- [x] Test passes with current ledger binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)