### PR TITLE
Fix outdated documentation for single-letter value expression variables (issue #994)

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -9002,15 +9002,11 @@ The posting's amount; the balance of an account, without
 considering children.
 
 @item b
+@itemx cost
 The cost of a posting; the cost of an account, without its
-children.
-
-@item v
-The market value of a posting or an account, without its children.
-
-@item g
-The net gain (market value minus cost basis), for a posting or an
-account, without its children.  It is the same as @samp{v-b}.
+children.  To compute the market value of a posting, use the
+@code{market} function or the single-letter function @code{P}
+(@pxref{Functions}).  The unrealized gain is then @samp{P(a) - b}.
 
 @item depth
 The depth (``level'') of an account.  If an account has one parent,

--- a/test/regress/994.test
+++ b/test/regress/994.test
@@ -1,0 +1,32 @@
+; Regression test for GitHub issue #994
+; The single-letter value expression variables v (market value) and g (gain)
+; from ledger 2.x are no longer supported in ledger 3.x.  The documentation
+; previously listed these as valid variables, causing user confusion.
+;
+; The modern equivalents are:
+;   v (market value) -> market(amount) or P(a)
+;   g (net gain)     -> market(amount) - cost  or  P(a) - b
+
+P 2024-01-15 AAPL $200.00
+
+2024-01-01 Buy stocks
+    Assets:Brokerage            5 AAPL @ $150.00
+    Assets:Cash                -$750.00
+
+; Using the deprecated 'v' variable produces an error
+test reg --format "%(v)\n" Assets:Brokerage -> 1
+__ERROR__
+While handling posting from "$FILE", line 13:
+>     Assets:Brokerage            5 AAPL @ $150.00
+Error: The V and v value expression variables are no longer supported
+end test
+
+; The modern replacement for 'v' is market(amount)
+test reg --format "%(market(amount))\n" Assets:Brokerage
+$1000.00
+end test
+
+; The modern replacement for 'g' (gain = market value - cost) is market(amount) - cost
+test reg --format "%(market(amount) - cost)\n" Assets:Brokerage
+$250.00
+end test


### PR DESCRIPTION
## Summary

- Remove `v` (market value) and `g` (net gain) from the value expression variables table — these were removed in ledger 3.x and throw an error when used
- Extend the `b` (cost) variable entry to also document the named form `cost`, and add a cross-reference showing `market(amount)` / `P(a)` for market value and `P(a) - b` for unrealized gain
- Add regression test `994.test` that documents the error for deprecated `v` and demonstrates the correct modern alternatives

## Test plan

- [x] `python3 test/RegressTests.py --ledger $(which ledger) --sourcepath . test/regress/994.test` — all 3 tests pass

Fixes #994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)