### PR TITLE
Add regression test for issue #979: functions in sort expressions

### DIFF
--- a/test/regress/979.test
+++ b/test/regress/979.test
@@ -1,0 +1,23 @@
+; Regression test for GitHub issue #979
+; Functions like abs() should be usable in --sort expressions.
+; Previously this would fail with "Error: Unknown identifier 'abs'"
+; because sort expressions did not have access to the report scope
+; where functions like abs() are defined.
+
+2024/01/01 Groceries
+    Expenses:Food    $100.00
+    Assets:Cash
+
+2024/01/02 Refund
+    Expenses:Food    $-50.00
+    Assets:Cash
+
+2024/01/03 Dinner
+    Expenses:Food    $75.00
+    Assets:Cash
+
+test reg Expenses --sort 'abs(amount)'
+24-Jan-02 Refund                Expenses:Food               $-50.00      $-50.00
+24-Jan-03 Dinner                Expenses:Food                $75.00       $25.00
+24-Jan-01 Groceries             Expenses:Food               $100.00      $125.00
+end test


### PR DESCRIPTION
## Summary

- Issue #979 reported that functions like `abs()` failed in `--sort` expressions with "Unknown identifier 'abs'"
- The bug was already fixed in commit f27d7776 ("Item sorting should have access to the report scope")
- This PR adds a regression test to prevent future regressions

## Test plan

- [ ] `test/regress/979.test` verifies that `--sort 'abs(amount)'` correctly sorts postings by absolute value
- [ ] Test passes: `python test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/979.test`

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)