### PR TITLE
Fix alias directive to mark target accounts as known (issue #1022)

### DIFF
--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -505,7 +505,9 @@ void instance_t::alias_directive(char* line) {
     *e++ = '\0';
     e = skip_ws(e);
 
-    account_alias_directive(top_account()->find_account(e), line);
+    account_t* account = top_account()->find_account(e);
+    account->add_flags(ACCOUNT_KNOWN);
+    account_alias_directive(account, line);
   }
 }
 

--- a/test/regress/1022.test
+++ b/test/regress/1022.test
@@ -1,0 +1,38 @@
+; Regression test for GitHub issue #1022:
+; Account aliases should not produce "Unknown account" warnings with --strict.
+;
+; Form 1: account ACCOUNT / alias ALIAS (sub-directive of account directive)
+; Form 2: alias ALIAS=ACCOUNT (top-level alias directive)
+;
+; With --strict, both forms must not emit "Unknown account" warnings for the
+; aliased account, since the alias declaration implicitly declares the account.
+
+commodity $
+
+; Form 1: sub-directive alias
+account expenses:tools
+    alias tools
+
+account assets:checking
+    alias ccp
+
+; Form 2: top-level alias directive
+alias Dining=Expenses:Dining
+alias Cash=Assets:Cash
+
+2014/04/12 Tools expense
+    tools                                    $13.90
+    ccp
+
+2012/03/15 Dining expense
+    Dining                        $100.00
+    Cash
+
+test bal --strict
+            $-100.00  Assets:Cash
+             $100.00  Expenses:Dining
+             $-13.90  assets:checking
+              $13.90  expenses:tools
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- The top-level `alias ALIAS=ACCOUNT` directive did not mark the target account as `ACCOUNT_KNOWN`, causing spurious "Unknown account" warnings when using `--strict`
- The `account ACCOUNT / alias ALIAS` sub-directive form worked correctly; this fix makes both forms consistent
- Added regression test `test/regress/1022.test` covering both alias forms with `--strict`

## Root Cause

In `alias_directive()`, the target account was created via `find_account()` without the `ACCOUNT_KNOWN` flag. When `--strict` is enabled and a posting uses such an alias, `register_account()` sees the resolved account lacks `ACCOUNT_KNOWN` and emits a spurious warning.

The `account ... alias` sub-directive form was unaffected because the enclosing `account` directive explicitly sets `ACCOUNT_KNOWN` before registering the alias.

## Test plan

- [ ] `ctest -R alias` — all 26 alias tests pass
- [ ] `ctest -R RegressTest_1022` — new regression test passes
- [ ] Both `account ... alias` and top-level `alias X=Y` forms no longer warn with `--strict`

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)