### PR TITLE
Fix date comparison operators in automated transaction predicates

### DIFF
--- a/src/query.cc
+++ b/src/query.cc
@@ -334,34 +334,70 @@ query_t::parser_t::parse_query_term(query_t::lexer_t::token_t::kind_t tok_contex
     }
 
     default: {
-      node = new expr_t::op_t(expr_t::op_t::O_MATCH);
+      // Check if this term looks like a comparison expression rather than an
+      // account name pattern.  This supports "d>=[2014/01/01]" syntax in
+      // automated transaction predicates.
+      //
+      // Case 1: term ends with > or < (e.g., "d>" from "d>=[date]")
+      //   followed by TOK_EQ and another term → parse as expression "d>=[date]"
+      // Case 2: term contains ">["  or "<[" pattern (e.g., "d>[date]")
+      //   → parse the whole term as an expression
+      assert(tok.value);
+      {
+        const string& term = *tok.value;
+        bool ends_with_cmp = !term.empty() && (term.back() == '>' || term.back() == '<');
 
-      expr_t::ptr_op_t ident = new expr_t::op_t(expr_t::op_t::IDENT);
-      switch (tok_context) {
-      case lexer_t::token_t::TOK_ACCOUNT:
-        ident->set_ident("account");
-        break;
-      case lexer_t::token_t::TOK_PAYEE:
-        ident->set_ident("payee");
-        break;
-      case lexer_t::token_t::TOK_CODE:
-        ident->set_ident("code");
-        break;
-      case lexer_t::token_t::TOK_NOTE:
-        ident->set_ident("note");
-        break;
-      default:
-        assert(false);
-        break;
+        if (ends_with_cmp && lexer.peek_token(tok_context).kind == lexer_t::token_t::TOK_EQ) {
+          lexer.next_token(tok_context); // consume the '='
+          lexer_t::token_t rhs = lexer.next_token(tok_context);
+          if (rhs.kind == lexer_t::token_t::TERM && rhs.value) {
+            try {
+              string expr_str = term + "=" + *rhs.value;
+              node = expr_t(expr_str).get_op();
+            } catch (...) {
+              node = nullptr;
+            }
+          }
+        } else if (!ends_with_cmp &&
+                   (term.find(">[") != string::npos || term.find("<[") != string::npos)) {
+          try {
+            node = expr_t(term).get_op();
+          } catch (...) {
+            node = nullptr;
+          }
+        }
       }
 
-      expr_t::ptr_op_t mask = new expr_t::op_t(expr_t::op_t::VALUE);
-      DEBUG("query.mask", "Mask from string: " << *tok.value);
-      mask->set_value(mask_t(*tok.value));
-      DEBUG("query.mask", "Mask is: " << mask->as_value().as_mask().str());
+      if (!node) {
+        node = new expr_t::op_t(expr_t::op_t::O_MATCH);
 
-      node->set_left(ident);
-      node->set_right(mask);
+        expr_t::ptr_op_t ident = new expr_t::op_t(expr_t::op_t::IDENT);
+        switch (tok_context) {
+        case lexer_t::token_t::TOK_ACCOUNT:
+          ident->set_ident("account");
+          break;
+        case lexer_t::token_t::TOK_PAYEE:
+          ident->set_ident("payee");
+          break;
+        case lexer_t::token_t::TOK_CODE:
+          ident->set_ident("code");
+          break;
+        case lexer_t::token_t::TOK_NOTE:
+          ident->set_ident("note");
+          break;
+        default:
+          assert(false);
+          break;
+        }
+
+        expr_t::ptr_op_t mask = new expr_t::op_t(expr_t::op_t::VALUE);
+        DEBUG("query.mask", "Mask from string: " << *tok.value);
+        mask->set_value(mask_t(*tok.value));
+        DEBUG("query.mask", "Mask is: " << mask->as_value().as_mask().str());
+
+        node->set_left(ident);
+        node->set_right(mask);
+      }
     }
     }
     break;

--- a/test/regress/1011.test
+++ b/test/regress/1011.test
@@ -1,0 +1,30 @@
+; Regression test for issue #1011:
+; Date comparison operators (>=, <=, >, <) in automated transaction predicates
+; should work correctly, including when preceded by a Y year directive.
+
+Y 2014
+
+= /^Income:Projects:Company/ & d>=[2014/01/01] & d<[2015/01/01]
+  * Expenses:Taxes:Income      -0.18
+  * Liabilities:Accrued:Taxes   0.18
+
+2013/06/01 Old Income
+  Income:Projects:Company     -1000
+  Assets:Checking              1000
+
+2014/04/01 Income in 2014
+  Income:Projects:Company     -2000
+  Assets:Checking              2000
+
+2015/03/01 Future Income
+  Income:Projects:Company     -3000
+  Assets:Checking              3000
+
+test bal
+                6000  Assets:Checking
+                 360  Expenses:Taxes:Income
+               -6000  Income:Projects:Company
+                -360  Liabilities:Accrued:Taxes
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

Fixes #1011: Date comparison operators (`>=`, `<=`, `>`, `<`) in automated
transaction predicates were silently broken. For example:

```
= /^Income:Projects:Company/ & d>=[2014/01/01] & d<[2015/01/01]
```

The query lexer split `d>=` into `TERM("d>")` + `TOK_EQ`, so `"d>"` was
treated as an account name regex (which never matches), effectively
discarding the date filter entirely. The automated rule fired for all
matching postings regardless of date.

- Fix the query parser's `parse_query_term` to detect when a TERM ends
  with `>` or `<` followed by `=` (the `>=`/`<=` case), or contains
  `>[`/`<[` (the `>`/`<` case), and route those through the expression
  parser rather than treating them as account name masks
- Fall back to the mask on any parse error, preserving existing behaviour
  for account-name patterns
- Add regression test `test/regress/1011.test`

The `Y` year directive has no bearing on the bug — it was always broken
regardless of order. The `expr` workaround (`= expr (account =~ /.../ and
date>=[2014/01/01])`) already worked and continues to work unchanged.

## Test plan
- [x] `python3 test/RegressTests.py --ledger build/ledger --sourcepath . test/regress/1011.test` passes
- [x] All existing regression tests continue to pass (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)