### PR TITLE
Add regression test for issue #1005 (zero-target balance assignment)

### DIFF
--- a/test/regress/1005.test
+++ b/test/regress/1005.test
@@ -1,0 +1,30 @@
+; Regression test for issue #1005
+; Balance assignments where the target is $0 (i.e. the account's balance is
+; already zero) should succeed without error.
+;
+; Prior to the fix, mixing a zero-target balance assignment (= $0) with an
+; auto-balancing posting in the same transaction produced:
+;   "Only one posting with null amount allowed per transaction"
+;
+; Root cause: when the diff between the account balance and the assignment
+; target was zero, the posting amount was left null.  A second null posting
+; (the auto-balancing "todo:adjust" entry) then violated the one-null-post
+; rule.  The fix sets post->amount to a zero amount (amt - amt) in the
+; zero-diff case, giving it a proper non-null value.
+
+2015/01/05 accuracy checking
+    Assets:b   = $1
+    Assets:a   = $0
+    todo:adjust
+
+test bal
+                  $1  Assets:b
+                 $-1  todo:adjust
+--------------------
+                   0
+end test
+
+test reg
+15-Jan-05 accuracy checking     Assets:b                         $1           $1
+                                todo:adjust                     $-1            0
+end test


### PR DESCRIPTION
## Summary

- Issue #1005 reported that a balance assignment of `= $0` in a transaction that also contained an auto-balancing posting threw "Only one posting with null amount allowed per transaction"
- The root cause: when the diff between the account balance and the assignment target was zero, `post->amount` was left null — conflicting with the other null (auto-computed) posting
- The fix was already applied in the codebase (as part of closing #1168): when the diff is zero, the balance assignment code now sets `post->amount = amt - amt`, giving it a zero but non-null value
- This PR adds a dedicated regression test for the exact scenario from #1005 to guard against future regressions

## Test plan

- [ ] `test/regress/1005.test` — verifies that a zero-target balance assignment (`= $0`) succeeds and produces correct `bal` and `reg` output
- [ ] Run `ctest -R 1005` in the build directory to confirm the test passes

Fixes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)