### PR TITLE
Fix periodicity for plot mode with multi-commodity accounts (#984)

### DIFF
--- a/src/chain.cc
+++ b/src/chain.cc
@@ -213,9 +213,9 @@ post_handler_ptr chain_post_handlers(post_handler_ptr base_handler, report_t& re
     // collapse per-account postings within each period into a single total posting.
     // This ensures that each time period produces exactly one data point for graphing,
     // even when the account contains multiple commodities or sub-accounts (issue #984).
-    bool auto_collapse_for_plot =
-        !report.HANDLED(collapse) && !report.HANDLED(depth_) && report.HANDLED(period_) &&
-        (report.HANDLED(amount_data) || report.HANDLED(total_data));
+    bool auto_collapse_for_plot = !report.HANDLED(collapse) && !report.HANDLED(depth_) &&
+                                  report.HANDLED(period_) &&
+                                  (report.HANDLED(amount_data) || report.HANDLED(total_data));
 
     if (report.HANDLED(collapse) || report.HANDLED(depth_) || auto_collapse_for_plot) {
       unsigned short collapse_depth = 0;

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -648,8 +648,7 @@ bool display_filter_posts::output_rounding(post_t& post) {
       // intermediate adjustment would only create an unwanted extra data point
       // for each period in the plot output (issue #984).
       bool suppress_period_plot_adjustment =
-          report.HANDLED(period_) &&
-          (report.HANDLED(amount_data) || report.HANDLED(total_data));
+          report.HANDLED(period_) && (report.HANDLED(amount_data) || report.HANDLED(total_data));
 
       if (!suppress_period_plot_adjustment) {
         if (value_t diff = precise_display_total - last_display_total) {

--- a/test/regress/984.test
+++ b/test/regress/984.test
@@ -1,0 +1,43 @@
+; Regression test for issue #984
+;
+; When using plot mode (-J/-j) combined with period mode (-M/--period) and
+; exchange to a single commodity (-X $), accounts holding multiple commodities
+; or sub-accounts must produce exactly ONE output line per time period.
+;
+; Before the fix, interval_posts generated one synthetic posting per account
+; per period (e.g. AAPL and IBM each got their own posting), and
+; display_filter_posts::output_rounding() injected an extra <Adjustment>
+; posting at the start of each subsequent period to account for market
+; revaluation.  Both caused multiple lines per period in the plot output.
+;
+; The fix auto-collapses postings within each period when both period mode
+; and plot mode are active (chain.cc), and suppresses the rounding adjustment
+; posting in that combined mode (filters.cc).
+
+commodity AAPL
+    format 0.000 AAPL
+
+commodity IBM
+    format 0.000 IBM
+
+P 2011-01-15 AAPL $309.23
+P 2011-01-15 IBM  $150.00
+P 2011-02-15 AAPL $320.00
+P 2011-02-15 IBM  $160.00
+
+2011-01-10 Purchase AAPL
+    Assets:401K:AAPL        100.000 AAPL @ $309.23
+    Assets:Cash
+
+2011-01-10 Purchase IBM
+    Assets:401K:IBM         200.000 IBM @ $150.00
+    Assets:Cash
+
+2011-02-10 Purchase AAPL
+    Assets:401K:AAPL         10.000 AAPL @ $320.00
+    Assets:Cash
+
+test reg -J -M -X $ Assets:401K
+2011-01-01 60923
+2011-02-01 67200
+end test


### PR DESCRIPTION
## Summary

- When using \`-J\`/\`-j\` (plot mode) combined with \`-M\`/\`--period\` and \`-X\` (exchange to a single commodity), accounts holding multiple commodities or sub-accounts produced multiple output lines per period instead of one
- \`interval_posts\` creates one synthetic posting **per account** per period (all within the same \`xact_t\`); in plot mode the user expects a single collapsed total — fix auto-inserts \`collapse_posts\` when both \`period_\` and \`amount_data\`/\`total_data\` are active (\`chain.cc\`)
- \`display_filter_posts::output_rounding()\` emits an \`<Adjustment>\` posting between periods to account for market-value drift; in period+plot mode the \`market()\` expression in \`display_total_\` already provides the correct value, so the intermediate adjustment creates an unwanted extra data point — suppress it in that combined mode (\`filters.cc\`)

## Test plan

- [x] New regression test \`test/regress/984.test\`: \`ledger reg -J -M -X $ Assets:401K\` on a portfolio holding AAPL and IBM over two months now produces exactly two lines (one per month) instead of four or more
- [x] \`ctest -R 984\` passes
- [x] Full test suite shows no regressions introduced by this change

Fixes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)