### PR TITLE
Fix makeinfo issues

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -8370,8 +8370,7 @@ When combined with @option{--gain}, report gain relative to the market
 value at @var{DATE} rather than original cost.  Use this to measure
 performance within a period: positions held before @var{DATE} use their
 market value at @var{DATE} as the baseline, so only appreciation since
-that date is counted.  @xref{--gain-since}, for a full description and
-example.
+that date is counted.
 
 @end ftable
 


### PR DESCRIPTION
When running `makeinfo doc/ledger3.texi` the following issues were reported:

```
ledger3.texi:1232: unknown command `times'
ledger3.texi:1232: misplaced {
ledger3.texi:1232: misplaced }
ledger3.texi:1237: unknown command `times'
ledger3.texi:1237: misplaced {
ledger3.texi:1237: misplaced }
ledger3.texi:7326: unknown command `times'
ledger3.texi:7326: misplaced {
ledger3.texi:7326: misplaced }
ledger3.texi:7326: unknown command `times'
ledger3.texi:7326: misplaced {
ledger3.texi:7326: misplaced }
ledger3.texi:7336: unknown command `times'
ledger3.texi:7336: misplaced {
ledger3.texi:7336: misplaced }
ledger3.texi:7338: unknown command `times'
ledger3.texi:7338: misplaced {
ledger3.texi:7338: misplaced }
ledger3.texi:8373: @xref reference to nonexistent node `--gain-since'
```

This PR addresses these.