### PR TITLE
Fix CI: Python tests use property access after #2778

### DIFF
--- a/test/regress/1014.py
+++ b/test/regress/1014.py
@@ -23,7 +23,7 @@ with tempfile.NamedTemporaryFile(mode='w', suffix='.ledger', delete=False) as f:
 try:
     s = ledger.Session()
     journal = s.read_journal(tmppath)
-    xacts = list(journal.xacts())
+    xacts = list(journal.xacts)
     assert len(xacts) == 1, "Expected 1 transaction"
     print("session.read_journal(str) works")
 finally:

--- a/test/regress/1205.py
+++ b/test/regress/1205.py
@@ -14,7 +14,7 @@ journal = ledger.read_journal_from_string("""
     Assets:Cash
 """)
 
-sources = list(journal.sources())
+sources = list(journal.sources)
 assert len(sources) > 0, "Expected at least one source"
 
 fi = sources[0]


### PR DESCRIPTION
## Summary
- Fix `RegressTest_1014_py` and `RegressTest_1205_py` CI failures
- After PR #2778 changed `journal.xacts` and `journal.sources` from callable methods to properties, these two tests still called them with parentheses (`journal.xacts()`, `journal.sources()`), causing `TypeError: 'iterator' object is not callable`
- Remove parentheses to use property access: `journal.xacts`, `journal.sources`

## Test plan
- [ ] CI passes on all platforms (CMake Ubuntu, CMake macOS, Nix Flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)