### PR TITLE
Python: expose display_amounts on PostCollectorWrapper for commodity exchange (fix #2158)

### DIFF
--- a/src/py_journal.cc
+++ b/src/py_journal.cc
@@ -168,6 +168,7 @@ struct collector_wrapper {
   report_t report;
   post_handler_ptr handler_chain; // Keeps the filter chain alive (owns synthetic temp posts)
   post_handler_ptr posts_collector;
+  std::vector<value_t> display_amounts; ///< Report-converted amount for each collected posting.
 
   collector_wrapper(boost::shared_ptr<journal_t> _journal_sp, report_t& base)
       : journal_sp(std::move(_journal_sp)), report(base), posts_collector(new collect_posts) {
@@ -235,6 +236,24 @@ shared_ptr<collector_wrapper> py_query(boost::shared_ptr<journal_t> journal_sp,
     journal_posts_iterator walker(*coll->report.session.journal.get());
     pass_down_posts<journal_posts_iterator>(coll->handler_chain, walker);
 
+    // Evaluate the report's display_amount_ expression for each collected
+    // posting while xdata is still intact.  This captures any commodity
+    // exchange (-X), market valuation (-V), or other display transformations
+    // so that Python callers can access the report-converted amounts rather
+    // than just the raw journal amounts (issue #2158).
+    {
+      expr_t& display_amount_expr(coll->report.HANDLER(display_amount_).expr);
+      collect_posts* collector = dynamic_cast<collect_posts*>(coll->posts_collector.get());
+      for (post_t* post : collector->posts) {
+        bind_scope_t bound_scope(coll->report, *post);
+        try {
+          coll->display_amounts.push_back(display_amount_expr.calc(bound_scope));
+        } catch (...) {
+          coll->display_amounts.push_back(value_t(post->amount));
+        }
+      }
+    }
+
     if (!coll->report.HANDLED(group_by_))
       coll->report.session.journal->clear_xdata();
   } catch (...) {
@@ -249,6 +268,14 @@ shared_ptr<collector_wrapper> py_query(boost::shared_ptr<journal_t> journal_sp,
 post_t* posts_getitem(collector_wrapper& collector, long i) {
   return dynamic_cast<collect_posts*>(collector.posts_collector.get())
       ->posts[static_cast<std::size_t>(i)];
+}
+
+/// Convert the display_amounts vector to a Python list of Value objects.
+boost::python::object py_collector_display_amounts(collector_wrapper& coll) {
+  boost::python::list result;
+  for (const value_t& v : coll.display_amounts)
+    result.append(v);
+  return result;
 }
 
 /*--- FileInfo Property Wrappers ---*/
@@ -299,7 +326,8 @@ void export_journal() {
       .def("__len__", &collector_wrapper::length)
       .def("__getitem__", posts_getitem, return_internal_reference<>())
       .def("__iter__", boost::python::range<return_internal_reference<>>(&collector_wrapper::begin,
-                                                                         &collector_wrapper::end));
+                                                                         &collector_wrapper::end))
+      .add_property("display_amounts", py_collector_display_amounts);
 
   class_<journal_t::fileinfo_t>("FileInfo")
       .def(init<path>())

--- a/test/python/JournalTest.py
+++ b/test/python/JournalTest.py
@@ -150,6 +150,92 @@ commodity Comm
         posts = journal.query('books -l "commodity  * 2 == \\"BB\\""')
         self.assertTrue(len(posts) == 1 and posts[0].amount.commodity == b_control)
 
+    def testQueryDisplayAmounts_exchange(self):
+        """Test that display_amounts reflects -X commodity exchange (issue #2158).
+
+        journal.query("-X EUR ...") should expose the EUR-converted amounts
+        via PostCollectorWrapper.display_amounts, even though posting.amount
+        still returns the original commodity (USD) for backward compatibility.
+        """
+        journal = read_journal_from_string("""
+commodity USD
+commodity EUR
+
+D 1000.00 EUR
+
+P 2023/01/01 EUR 1.07 USD
+
+2023/01/01 * Initial balance
+    Assets:Account  1000.00 USD
+    Equity:Initial
+
+2023/01/01 * Test expense
+    Expenses:Category  10.00 USD
+    Assets:Account
+""")
+        posts = journal.query("-X EUR --no-rounding --no-revalued Assets:Account")
+        self.assertEqual(len(posts), 2)
+
+        # Raw posting amounts are still in USD (backward compat)
+        self.assertEqual(posts[0].amount, Amount("1000.00 USD"))
+        self.assertEqual(posts[1].amount, Amount("-10.00 USD"))
+
+        # display_amounts should contain EUR-converted values
+        display_amts = posts.display_amounts
+        self.assertEqual(len(display_amts), 2)
+
+        # 1000.00 USD / 1.07 USD per EUR ≈ 934.58 EUR
+        amt0 = display_amts[0].to_amount()
+        self.assertEqual(amt0.commodity.symbol, "EUR")
+        self.assertAlmostEqual(float(str(amt0.number())), 934.58, places=0)
+
+        # -10.00 USD / 1.07 USD per EUR ≈ -9.35 EUR
+        amt1 = display_amts[1].to_amount()
+        self.assertEqual(amt1.commodity.symbol, "EUR")
+        self.assertAlmostEqual(float(str(amt1.number())), -9.35, places=0)
+
+    def testQueryDisplayAmounts_no_exchange(self):
+        """Test that display_amounts without -X returns the raw amounts."""
+        journal = read_journal_from_string("""
+2023/01/01 * Test
+    Expenses:Food    $10.00
+    Assets:Cash
+""")
+        posts = journal.query("food")
+        self.assertEqual(len(posts), 1)
+
+        # Without -X, display_amounts should equal posting.amount
+        display_amts = posts.display_amounts
+        self.assertEqual(len(display_amts), 1)
+        self.assertEqual(display_amts[0].to_amount(), Amount("$10.00"))
+
+    def testQueryDisplayAmounts_market(self):
+        """Test that display_amounts reflects -X EUR market valuation on USD amounts."""
+        journal = read_journal_from_string("""
+commodity USD
+commodity EUR
+
+P 2023/01/01 EUR 1.07 USD
+
+2023/01/01 * Test
+    Assets:USDAccount   107.00 USD
+    Equity:Initial
+""")
+        posts = journal.query("-X EUR --no-rounding --no-revalued Assets")
+        self.assertEqual(len(posts), 1)
+
+        # Raw amount is in USD
+        self.assertEqual(posts[0].amount.commodity.symbol, "USD")
+
+        # display_amounts with -X EUR should give the EUR value
+        display_amts = posts.display_amounts
+        self.assertEqual(len(display_amts), 1)
+        amt = display_amts[0].to_amount()
+        self.assertEqual(amt.commodity.symbol, "EUR")
+        # 107.00 USD / 1.07 USD per EUR = 100.00 EUR
+        self.assertAlmostEqual(float(str(amt.number())), 100.00, places=0)
+
+
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(JournalTestCase)
 


### PR DESCRIPTION
## Summary

Fixes #2158: `journal.query()` does not apply commodity exchange when `-X` (or `-V`) is used.

### Root Cause

When `journal.query("-X EUR ...")` is called in Python, the filter chain runs
correctly (including the `display_amount_` expression set to
`market(display_amount, value_date, exchange)` by `-X`). However, this
conversion only happens during CLI format-string evaluation. Python callers
accessing `posting.amount` get the raw journal amount in the original
commodity (e.g., USD), not the converted amount (e.g., EUR).

### Fix

After the filter chain runs and before `clear_xdata()` is called, evaluate
the report's `display_amount_` expression for each collected posting and store
the results in a new `display_amounts` vector on the `collector_wrapper`. This
gives Python callers access to the same commodity conversion that the CLI
applies when displaying results.

The `posting.amount` field is intentionally left unchanged to preserve
backward compatibility — it always reflects the raw journal amount.

### API

```python
posts = journal.query("-X EUR --no-rounding --no-revalued Assets:Account")

# Iterate postings — posting.amount still returns original USD (backward compat)
for post in posts:
    print(post.amount)  # e.g., 1000.00 USD

# Access converted amounts via display_amounts
for i, post in enumerate(posts):
    eur_amt = posts.display_amounts[i].to_amount()
    print(eur_amt)  # e.g., 934.58 EUR
```

The `display_amounts` list contains `ledger.Value` objects, one per posting,
in the same order as the postings in the result. Call `.to_amount()` to get an
`Amount` when the value is a simple amount.

## Test plan

- [x] `testQueryDisplayAmounts_exchange`: verifies `-X EUR` converts USD→EUR
- [x] `testQueryDisplayAmounts_no_exchange`: verifies plain query returns raw amounts
- [x] `testQueryDisplayAmounts_market`: verifies `-X EUR` on a USD posting
- [x] All existing Python tests continue to pass
- [x] All C++ unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)