### PR TITLE
Fix crash in magnitude() when posting has null amount (issue #2212)

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -133,7 +133,7 @@ void xact_base_t::clear_xdata() {
 value_t xact_base_t::magnitude() const {
   value_t halfbal = 0L;
   for (const post_t* post : posts) {
-    if (post->amount.sign() > 0) {
+    if (!post->amount.is_null() && post->amount.sign() > 0) {
       if (post->cost)
         halfbal += *post->cost;
       else

--- a/test/regress/2212.test
+++ b/test/regress/2212.test
@@ -1,0 +1,27 @@
+; Regression test for #2212:
+; A balance assignment on a balanced-virtual posting ([account]) paired
+; with a real posting with no amount should give a clear "Transaction does
+; not balance" error instead of crashing with "Cannot determine sign of an
+; uninitialized amount".
+;
+; The virtual balanced posting ([assets]) must balance against other
+; balanced-virtual postings, not real postings (income:past).
+; A null-amount real posting cannot be inferred from a virtual balance.
+
+2023-03-13
+    [assets]    = 1 rsd
+    income:past
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 13:
+While balancing transaction from "$FILE", lines 11-13:
+> 2023-03-13
+>     [assets]    = 1 rsd
+>     income:past
+Unbalanced remainder is:
+               1 rsd
+Amount to balance against:
+               1 rsd
+Error: Transaction does not balance
+end test


### PR DESCRIPTION
## Summary

- Fixes a crash with \"Cannot determine sign of an uninitialized amount\" that occurred when a balanced-virtual posting (`[account]`) with a balance assignment was paired with a null-amount real posting in the same transaction
- The `magnitude()` function, called during error reporting for unbalanced transactions, did not guard against null-amount postings before calling `sign()`
- After the fix, the proper \"Transaction does not balance\" error is displayed with the correct \"Amount to balance against\" information

## Root Cause

When a transaction like:
```
2023-03-13
    [assets]    = 1 rsd
    income:past
```
fails to balance (because balanced-virtual postings must balance against other balanced-virtual postings, not real postings), `finalize()` throws a balance error. The error reporting code calls `magnitude()` to compute the transaction size for the error message. However, `income:past` still has a null amount at this point (it could not be inferred from the virtual balance), and `magnitude()` called `amount_t::sign()` directly without checking for null, causing the crash.

## Fix

A one-line null-check guard in `xact_base_t::magnitude()`:
```cpp
if (!post->amount.is_null() && post->amount.sign() > 0) {
```

## Test plan

- [x] New regression test `test/regress/2212.test` verifies the proper error message is shown instead of a crash
- [x] All 4006 existing tests continue to pass

Fixes #2212

🤖 Generated with [Claude Code](https://claude.com/claude-code)