### PR TITLE
Enable ANSI color on Windows CMD/PowerShell (fix #2110)

### DIFF
--- a/src/report.cc
+++ b/src/report.cc
@@ -112,6 +112,20 @@ void report_t::normalize_options(const string& verb) {
       HANDLER(pager_).off();
   }
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+  // On Windows, ANSI escape sequences are not processed by CMD or PowerShell
+  // unless virtual terminal processing is explicitly enabled.  Enable it now
+  // if we have determined that color output will be used.
+  if (HANDLED(color)) {
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut != INVALID_HANDLE_VALUE) {
+      DWORD dwMode = 0;
+      if (GetConsoleMode(hOut, &dwMode))
+        SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+    }
+  }
+#endif
+
   item_t::use_aux_date = (HANDLED(aux_date) && !HANDLED(primary_date));
 
   commodity_pool_t::current_pool->keep_base = HANDLED(base);

--- a/src/system.hh.in
+++ b/src/system.hh.in
@@ -69,6 +69,17 @@
 /* System includes                                                        */
 /*------------------------------------------------------------------------*/
 
+// Define NOMINMAX and WIN32_LEAN_AND_MEAN before any includes on Windows to
+// prevent min/max macro conflicts and reduce header bloat.
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#endif
+
 #include "utf8.h"
 
 #include <algorithm>
@@ -107,6 +118,15 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <io.h>
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+// ENABLE_VIRTUAL_TERMINAL_PROCESSING was introduced in Windows 10 SDK 10.0.10586.
+// Provide a fallback definition for older SDKs so the code compiles but the
+// SetConsoleMode call will simply return false on older Windows versions.
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+#endif
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
## Summary

Fixes #2110: `--color` does not work in Windows CMD or PowerShell.

On Windows 10+, CMD and PowerShell support ANSI escape sequences (the
same `\033[31m` codes used on Unix), but the Windows Console requires
virtual terminal processing to be **explicitly enabled** via the
`SetConsoleMode` Win32 API.  Without this flag, ANSI sequences appear
as literal characters in the output.

### Changes

- **`src/report.cc`**: In `normalize_options()`, after Ledger determines
  that color output will be used (auto-detected TTY or `--color` /
  `--force-color`), call `SetConsoleMode` with
  `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on native Windows builds
  (`_WIN32` but not `__CYGWIN__`).  Cygwin terminals already handle
  ANSI natively.  The call fails silently on older Windows versions that
  predate VTP support (pre-10.0.10586).

- **`src/system.hh.in`**: Add `NOMINMAX` and `WIN32_LEAN_AND_MEAN`
  before any includes on Windows to prevent `min`/`max` macro conflicts
  and reduce header bloat.  Include `<windows.h>` in the precompiled
  header for native Windows builds so the console API is available
  across all translation units.  Also add a fallback definition of
  `ENABLE_VIRTUAL_TERMINAL_PROCESSING` for older SDKs.

## Test plan

- [ ] Build on macOS/Linux — all 3983 existing tests pass (verified locally)
- [ ] On Windows CMD: `ledger --color -f sample.dat bal` should display
      colored output
- [ ] On Windows PowerShell: same as above
- [ ] `--force-color` continues to work on all platforms
- [ ] `--no-color` disables color on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)