### PR TITLE
Fix crash when using --limit with commodity filter in budget mode (issue #2247)

### DIFF
--- a/src/post.cc
+++ b/src/post.cc
@@ -316,13 +316,20 @@ value_t get_use_direct_amount(post_t& post) {
  * Accepts an optional amount argument; if provided, returns that amount's
  * commodity instead of the posting's.  Annotations are stripped to return
  * the base commodity symbol.
+ *
+ * When the posting has a compound value (e.g., budget display sequences like
+ * "(actual, budget)"), and that compound value is a sequence, fall back to
+ * post.amount for the commodity.  Calling to_amount() on a sequence throws,
+ * and for budget filtering purposes the underlying amount's commodity is the
+ * correct thing to check (issue #2247).
  */
 value_t get_commodity(call_scope_t& args) {
   if (args.has<amount_t>(0)) {
     return args.get<amount_t>(0).commodity().strip_annotations(keep_details_t{});
   } else {
     post_t& post(args.context<post_t>());
-    if (post.has_xdata() && post.xdata().has_flags(POST_EXT_COMPOUND))
+    if (post.has_xdata() && post.xdata().has_flags(POST_EXT_COMPOUND) &&
+        !post.xdata().compound_value.is_sequence())
       return post.xdata().compound_value.to_amount().commodity().strip_annotations(
           keep_details_t{});
     else
@@ -331,7 +338,8 @@ value_t get_commodity(call_scope_t& args) {
 }
 
 value_t get_commodity_is_primary(post_t& post) {
-  if (post.has_xdata() && post.xdata().has_flags(POST_EXT_COMPOUND))
+  if (post.has_xdata() && post.xdata().has_flags(POST_EXT_COMPOUND) &&
+      !post.xdata().compound_value.is_sequence())
     return post.xdata().compound_value.to_amount().commodity().has_flags(COMMODITY_PRIMARY);
   else
     return post.amount.commodity().has_flags(COMMODITY_PRIMARY);

--- a/test/regress/2247.test
+++ b/test/regress/2247.test
@@ -1,0 +1,34 @@
+; Regression test for issue #2247: budget --limit fails with multiple currencies.
+;
+; When the budget command is used with --limit and a commodity filter, the
+; commodity function was calling to_amount() on a compound sequence value
+; (which budget_posts sets up for display purposes), causing a crash:
+;   "Cannot convert a sequence to an amount"
+;
+; The fix: get_commodity and get_commodity_is_primary in post.cc now fall back
+; to post.amount when compound_value is a sequence, instead of trying to
+; convert the sequence to an amount.
+
+~ monthly
+    assets:bank1  500 USD
+    assets:bank2  500 EUR
+    income:work
+
+2021-01-01
+    assets:bank1  500 USD
+    assets:bank2  500 EUR
+    equity:opening balances
+
+test budget --limit '(commodity == "USD")'
+     500 USD    31500 USD   -31000 USD    2%  assets:bank1
+           0   -31500 USD    31500 USD     0  income:work
+------------ ------------ ------------ -----
+     500 USD            0      500 USD     0
+end test
+
+test budget --limit '(commodity == "EUR")'
+     500 EUR    31500 EUR   -31000 EUR    2%  assets:bank2
+           0   -31500 EUR    31500 EUR     0  income:work
+------------ ------------ ------------ -----
+     500 EUR            0      500 EUR     0
+end test


### PR DESCRIPTION
## Summary

- Fixes crash `Cannot convert a sequence to an amount` when using `budget --limit '(commodity == "USD")'` with a multi-currency journal
- Root cause: `get_commodity` and `get_commodity_is_primary` in `post.cc` called `.to_amount()` on a compound sequence value that budget sets up for display (`(actual, budget)` pairs), which fails when the compound value is a sequence type
- Fix: check `is_sequence()` before calling `to_amount()` on the compound value; fall back to `post.amount` for the commodity when it's a sequence

## Details

The `budget_posts` filter wraps posting values into sequences for display purposes:
- Budgeted postings: `(actual, -budget)` 
- Unbudgeted postings: `(amount, void)`

When `--limit` evaluates an expression like `(commodity == "USD")`, it calls `get_commodity` on these wrapped postings. The function saw `POST_EXT_COMPOUND` and tried `compound_value.to_amount()`, which throws `"Cannot convert a sequence to an amount"` for sequence-type compound values.

The fix is minimal: guard both `get_commodity` and `get_commodity_is_primary` with `!compound_value.is_sequence()`. When the compound value is a sequence, the posting's underlying `amount` is the correct source for commodity information.

## Test plan

- [x] New regression test `test/regress/2247.test` covering both `commodity == "USD"` and `commodity == "EUR"` filters with multi-currency budget
- [x] All 3984 existing tests pass

Fixes #2247

🤖 Generated with [Claude Code](https://claude.com/claude-code)