### PR TITLE
Fix signed debit amounts in CSV convert command

### DIFF
--- a/src/csv.cc
+++ b/src/csv.cc
@@ -231,10 +231,16 @@ xact_t* csv_reader::read_xact(bool rich_data) {
       (void)amt.parse(amount_str, PARSE_NO_REDUCE);
       if (!amt.has_commodity() && commodity_pool_t::current_pool->default_commodity)
         amt.set_commodity(*commodity_pool_t::current_pool->default_commodity);
-      if (index[n] == FIELD_DEBIT)
+      // For a debit column: negate only if the value is positive (unsigned
+      // convention where the bank gives the debit amount as a positive number).
+      // If the value is already negative (signed convention, e.g. some credit
+      // unions write -70.55 in the "Amount Debit" column), it already encodes
+      // the outflow direction and must not be negated again.
+      if (index[n] == FIELD_DEBIT && amt.sign() > 0)
         amt = -amt;
       if (!post->amount.is_null())
-        throw_(csv_error, _("Cannot have two values for a single transaction"));
+        throw_(csv_error, _("Only one of credit, debit, or amount may have a "
+                            "value per transaction"));
       post->amount = amt;
       break;
     }

--- a/test/baseline/cmd-convert.test
+++ b/test/baseline/cmd-convert.test
@@ -49,5 +49,5 @@ While parsing file "$sourcepath/test/baseline/cmd-convert6.dat", line 1:
 While parsing CSV line:
   01/01/2011,20.00 EUR,10.00 EUR,test1,
 
-Error: Cannot have two values for a single transaction
+Error: Only one of credit, debit, or amount may have a value per transaction
 end test

--- a/test/regress/2295.csv
+++ b/test/regress/2295.csv
@@ -1,0 +1,3 @@
+Date,Payee,Amount Debit,Amount Credit
+01/05/2018,VZWRLSS,-70.55,
+01/10/2018,DIRECT DEPOSIT,,500.00

--- a/test/regress/2295.test
+++ b/test/regress/2295.test
@@ -1,0 +1,25 @@
+; Regression test for GitHub issue #2295:
+; Support signed debit/credit amounts in CSV convert command.
+;
+; Some financial institutions (e.g. Rivermark CU) export CSV files where the
+; "Amount Debit" column already contains negative values for outflows rather
+; than the more common convention of positive debit amounts.  Previously,
+; ledger would negate the value regardless of its sign, turning a -70.55 debit
+; into +70.55 (a credit), which is wrong.
+;
+; The fix: only negate the debit column amount when it is positive (unsigned
+; convention).  If the value is already negative (signed convention), it
+; correctly represents an outflow and must be used as-is.
+
+account Expenses:Unknown
+account Assets:Checking
+
+test convert test/regress/2295.csv --input-date-format "%m/%d/%Y" --account Assets:Checking
+2018/01/05 * VZWRLSS
+    Expenses:Unknown                          -70.55
+    Assets:Checking
+
+2018/01/10 * DIRECT DEPOSIT
+    Expenses:Unknown                             500
+    Assets:Checking
+end test


### PR DESCRIPTION
## Summary

- Fixes #2295: some financial institutions (e.g. Rivermark Credit Union) export CSV files where the `Amount Debit` column already contains negative values for outflows, rather than the more common unsigned positive convention
- Previously, ledger would unconditionally negate any value in a column mapped to `FIELD_DEBIT`, double-negating an already-negative `-70.55` into `+70.55` (a credit), producing an incorrect transaction
- Fix: only negate a debit column's value when it is positive; if the value is already negative (signed convention), it correctly encodes the outflow direction and is used as-is
- Also improves the error message when both a credit column and a debit column have values in the same CSV row

## Test plan

- [x] New regression test `test/regress/2295.test` with CSV data (`test/regress/2295.csv`) demonstrating signed debit (negative) and credit (positive) values are both handled correctly
- [x] Updated baseline test `test/baseline/cmd-convert.test` for the improved error message
- [x] All 3983 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)