### PR TITLE
Fix datetime field to include time for timelog postings

### DIFF
--- a/src/post.cc
+++ b/src/post.cc
@@ -486,8 +486,11 @@ value_t get_value_date(post_t& post) {
   return post.date();
 }
 value_t get_datetime(post_t& post) {
-  return (!post.xdata().datetime.is_not_a_date_time() ? post.xdata().datetime
-                                                      : datetime_t(post.date()));
+  if (!post.xdata().datetime.is_not_a_date_time())
+    return post.xdata().datetime;
+  if (post.checkin)
+    return *post.checkin;
+  return datetime_t(post.date());
 }
 value_t get_checkin(post_t& post) {
   return post.checkin ? *post.checkin : NULL_VALUE;

--- a/test/regress/2264.test
+++ b/test/regress/2264.test
@@ -1,0 +1,13 @@
+; Regression test for issue #2264: datetime field for timelog entries should
+; include the time component (the check-in time), not just midnight.
+
+i 2023-06-16 06:30:00 Start of test entry
+o 2023-06-16 07:00:00
+
+test reg --format '%(format_datetime(datetime, "%H:%M"))\n'
+06:30
+end test
+
+test reg --format '%(datetime)\n'
+2023/06/16 06:30:00
+end test


### PR DESCRIPTION
## Summary

- The `datetime` expression field for timelog (timeclock) entries was returning midnight (`datetime_t(post.date())`) instead of the actual check-in time
- For timelog posts, `post.checkin` holds the actual check-in timestamp; `get_datetime()` now falls back to that value before defaulting to date-only
- After this fix, `format_datetime(datetime, "%H:%M")` correctly shows the check-in time (e.g. `06:30`) instead of `00:00`

## Root Cause

`get_datetime()` in `src/post.cc` only checked `xdata().datetime` (set by the filter pipeline) and then fell back to `datetime_t(post.date())`. For timelog postings generated from check-in/check-out records, neither was set — the time was stored in `post.checkin` — so the function returned midnight.

## Fix

Added an intermediate check: if `xdata().datetime` is not set but `post.checkin` is, return `*post.checkin`. This makes the `datetime` field accurately reflect the check-in time for timelog entries.

## Test plan

- [x] Added regression test `test/regress/2264.test` verifying `format_datetime(datetime, "%H:%M")` returns `06:30` for a timeclock entry starting at 06:30:00
- [x] Added test verifying `%(datetime)` shows the full datetime with time component
- [x] All 3,675 existing regression tests pass
- [x] All 4 unit test suites pass

Fixes #2264

🤖 Generated with [Claude Code](https://claude.com/claude-code)