### PR TITLE
Fix CSV convert to handle missing or same-commodity cost fields

### DIFF
--- a/src/csv.cc
+++ b/src/csv.cc
@@ -240,6 +240,8 @@ xact_t* csv_reader::read_xact(bool rich_data) {
     }
 
     case FIELD_COST: {
+      if (field.length() == 0)
+        break;
       std::istringstream amount_str(field); // NOLINT(bugprone-unused-local-non-trivial-variable)
       (void)amt.parse(amount_str, PARSE_NO_REDUCE);
       if (!amt.has_commodity() && commodity_pool_t::current_pool->default_commodity)
@@ -263,6 +265,15 @@ xact_t* csv_reader::read_xact(bool rich_data) {
       break;
     }
     n++;
+  }
+
+  // If cost was provided but shares the same commodity as the amount, it is
+  // redundant (a 1:1 no-op conversion) and would cause a validation error.
+  // Clear it so the posting is treated as a simple same-currency entry.
+  if (post->cost && !post->amount.is_null() &&
+      post->amount.commodity() == post->cost->commodity()) {
+    post->cost = std::nullopt;
+    amt = post->amount;
   }
 
   // Phase 3: Attach rich metadata if requested (import timestamp and

--- a/test/regress/2142-data.csv
+++ b/test/regress/2142-data.csv
@@ -1,0 +1,4 @@
+date,descr,amount,cost
+2022-10-03,Expense with conversion,15 EUR,14 USD
+2022-10-07,Expense without cost,20 USD,
+2022-10-10,Expense same commodity cost,30 USD,30 USD

--- a/test/regress/2142.test
+++ b/test/regress/2142.test
@@ -1,0 +1,23 @@
+; Regression test for GitHub issue #2142:
+; CSV convert should handle missing or same-commodity cost fields gracefully.
+;
+; Case 1: empty cost field previously caused "No quantity specified for amount"
+; Case 2: same-commodity cost previously caused "A posting's cost must be of
+;         a different commodity than its amount"
+
+account Expenses:Unknown
+account Assets:Checking
+
+test convert test/regress/2142-data.csv --input-date-format "%Y-%m-%d" --account Assets:Checking
+2022/10/03 * Expense with conversion
+    Expenses:Unknown                          15 EUR
+    Assets:Checking                          -14 USD
+
+2022/10/07 * Expense without cost
+    Expenses:Unknown                          20 USD
+    Assets:Checking
+
+2022/10/10 * Expense same commodity cost
+    Expenses:Unknown                          30 USD
+    Assets:Checking
+end test


### PR DESCRIPTION
## Summary

Fixes two related bugs in `csv_reader::read_xact` when the CSV file contains a `cost` column.

- **Empty cost field** (e.g. `20 USD,`): previously threw `No quantity specified for amount`. Now the empty field is silently skipped, matching the existing guard on `FIELD_CREDIT`/`FIELD_DEBIT`.
- **Same-commodity cost** (e.g. `20 USD,20 USD`): previously threw `A posting's cost must be of a different commodity than its amount`. A cost in the same currency as the amount carries no exchange-rate information, so it is now silently cleared and the transaction processes normally.

Also includes a prerequisite fix for the CMake GPGME build: on some Nix configurations, `GpgmeppTargets.cmake` does not propagate `libgpg-error` include dirs as an interface dependency, causing `gpg-error.h` to be unfindable at compile time. The fix adds `${LibGpgError_INCLUDE_DIR}` to the include path when `USE_GPGME=ON`.

## Changes

- `src/csv.cc`: add early `break` for empty cost fields; clear same-commodity cost after column parsing is complete
- `CMakeLists.txt`: add `LibGpgError_INCLUDE_DIR` to include path when building with GPGME
- `test/regress/2142.test`, `test/regress/2142-data.csv`: regression test covering cross-currency (guard), empty cost, and same-commodity cost

## Test plan

- [ ] `ctest -R 2142` passes (covers all three CSV row types)
- [ ] Existing CSV tests still pass: `coverage-csv-cost-import`, `coverage-csv-debit`, `cov5-csv-convert`, `coverage-wave6-csv`
- [ ] Full test suite passes

Closes #2142

🤖 Generated with [Claude Code](https://claude.com/claude-code)