### PR TITLE
Fix period parser rejecting trailing payee text in periodic transactions

### DIFF
--- a/src/times.cc
+++ b/src/times.cc
@@ -1544,6 +1544,12 @@ void date_parser_t::finalize_period(date_interval_t& period,
  *
  * After all tokens are consumed, finalize_period() assembles these
  * into the interval's range field.
+ *
+ * If an unrecognized word is encountered after at least one valid period
+ * component has been parsed, parsing stops silently.  This lets periodic
+ * transaction headers carry a free-text description (payee name) after
+ * the period expression without triggering an error.  An unrecognized
+ * word as the very first token is still an error.
  */
 date_interval_t date_parser_t::parse() {
   optional<date_specifier_t> since_specifier;
@@ -1553,10 +1559,11 @@ date_interval_t date_parser_t::parse() {
   date_interval_t period;
   date_t today = CURRENT_DATE();
   bool end_inclusive = false;
+  bool stop_parsing = false;
 
   // Main parsing loop - process tokens sequentially
-  for (lexer_t::token_t tok = lexer.next_token(); tok.kind != lexer_t::token_t::END_REACHED;
-       tok = lexer.next_token()) {
+  for (lexer_t::token_t tok = lexer.next_token();
+       !stop_parsing && tok.kind != lexer_t::token_t::END_REACHED; tok = lexer.next_token()) {
 
     switch (tok.kind) {
     // Simple date/time specifiers
@@ -1616,7 +1623,17 @@ date_interval_t date_parser_t::parse() {
       break;
 
     default:
-      tok.unexpected();
+      // An UNKNOWN token is an unrecognized word.  If at least one period
+      // component has been parsed, stop gracefully so that a trailing
+      // free-text description (e.g. a payee name like "YouTube Premium")
+      // in a periodic transaction header is silently ignored.  A
+      // recognized punctuation token (TOK_SLASH, TOK_DOT, etc.) or an
+      // UNKNOWN word as the very first token is still a hard error.
+      if (tok.kind == lexer_t::token_t::UNKNOWN &&
+          (period.duration || since_specifier || until_specifier || inclusion_specifier))
+        stop_parsing = true;
+      else
+        tok.unexpected();
       break;
     }
   }

--- a/test/regress/2282.test
+++ b/test/regress/2282.test
@@ -1,0 +1,21 @@
+; Regression test for issue #2282
+; A periodic transaction header with a free-text description after the
+; period expression should parse without error.  Before this fix,
+; "~ every month from 2023/10/06  YouTube Premium" would throw:
+;   Error: Unexpected date period token 'youtube'
+
+~ every month from 2023/10/06  YouTube Premium
+    Assets:Checking     $-13.99
+    Expenses:Entertainment
+
+2023/10/06 YouTube Premium
+    Assets:Checking     $-13.99
+    Expenses:Entertainment
+
+test balance Expenses
+              $13.99  Expenses:Entertainment
+end test
+
+test balance Assets
+             $-13.99  Assets:Checking
+end test


### PR DESCRIPTION
## Summary

Fixes #2282.

Periodic transaction headers like:

```
~ every month from 2023/10/06  YouTube Premium
```

previously failed with:

```
Error: Unexpected date period token 'youtube'
```

because the date period parser consumed the entire line and treated the
payee name as part of the period expression.

## Fix

Modified `date_parser_t::parse()` in `src/times.cc` to stop gracefully
when it encounters an unrecognized word (`UNKNOWN` token) after at least
one valid period component (duration, since/until, or inclusion
specifier) has already been parsed.  Free-form text after the period
expression is silently ignored, allowing users to add descriptions to
periodic transaction headers.

Error handling is preserved for:
- Recognized punctuation tokens (`TOK_SLASH`, `TOK_DOT`, etc.) — still
  a hard error
- `UNKNOWN` tokens appearing *before* any valid period component — still
  a hard error

## Test plan

- [x] New regression test `test/regress/2282.test` verifies that
  `~ every month from 2023/10/06  YouTube Premium` parses correctly and
  produces the expected balance report output
- [x] Existing tests for invalid period punctuation (`jan / feb`,
  `jan . feb`) continue to produce errors as before
- [x] All 4007 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)