### PR TITLE
Fix Python bindings for virtual posting flag detection (issue #2169)

### DIFF
--- a/src/py_item.cc
+++ b/src/py_item.cc
@@ -129,11 +129,12 @@ void export_item() {
   class_<item_t, noncopyable>("JournalItem", no_init)
 #endif
 #if 1
-      .add_property("flags", &supports_flags<>::flags, &supports_flags<>::set_flags)
-      .def("has_flags", &supports_flags<>::has_flags)
-      .def("clear_flags", &supports_flags<>::clear_flags)
-      .def("add_flags", &supports_flags<>::add_flags)
-      .def("drop_flags", &supports_flags<>::drop_flags)
+      .add_property("flags", &supports_flags<uint_least16_t>::flags,
+                    &supports_flags<uint_least16_t>::set_flags)
+      .def("has_flags", &supports_flags<uint_least16_t>::has_flags)
+      .def("clear_flags", &supports_flags<uint_least16_t>::clear_flags)
+      .def("add_flags", &supports_flags<uint_least16_t>::add_flags)
+      .def("drop_flags", &supports_flags<uint_least16_t>::drop_flags)
 #endif
 
       .add_property("note", make_getter(&item_t::note, return_value_policy<return_by_value>()),

--- a/src/py_post.cc
+++ b/src/py_post.cc
@@ -89,6 +89,13 @@ account_t* py_reported_account(post_t& post) {
   return post.reported_account();
 }
 
+/*--- Virtual Posting Predicates ---*/
+
+/// True when the posting uses a (parens) or [brackets] account.
+bool py_post_is_virtual(const post_t& post) {
+  return post.has_flags(POST_VIRTUAL);
+}
+
 } // unnamed namespace
 
 void export_post() {
@@ -164,6 +171,8 @@ void export_post() {
 
       .add_property("date", &post_t::date)
       .add_property("aux_date", &post_t::aux_date)
+
+      .add_property("is_virtual", py_post_is_virtual)
 
       .def("must_balance", &post_t::must_balance)
 

--- a/test/python/PostingTest.py
+++ b/test/python/PostingTest.py
@@ -194,6 +194,44 @@ class PostingTestCase(unittest.TestCase):
         # (Virtual:Unbal) is an unbalanced virtual posting: must_balance is False
         self.assertFalse(posts[0].must_balance())
 
+    def test_is_virtual_false_for_real_posting(self):
+        """Test is_virtual is False for a regular (non-virtual) posting."""
+        posts = self.journal.query("food")
+        self.assertEqual(len(posts), 1)
+        self.assertFalse(posts[0].is_virtual)
+
+    def test_is_virtual_true_for_balanced_virtual(self):
+        """Test is_virtual is True for balanced virtual [brackets] postings."""
+        posts = self.journal.query("budget and savings")
+        self.assertEqual(len(posts), 1)
+        # [Budget:Savings] is a balanced virtual posting: is_virtual is True
+        self.assertTrue(posts[0].is_virtual)
+
+    def test_is_virtual_true_for_unbalanced_virtual(self):
+        """Test is_virtual is True for unbalanced virtual (parens) postings."""
+        journal = read_journal_from_string("""
+2012-06-01 Test
+    Expenses:Food      $10.00
+    (Virtual:Unbal)    $5.00
+    Assets:Cash
+""")
+        posts = journal.query("unbal")
+        self.assertEqual(len(posts), 1)
+        # (Virtual:Unbal) is an unbalanced virtual posting: is_virtual is True
+        self.assertTrue(posts[0].is_virtual)
+
+    def test_has_flags_post_virtual(self):
+        """Test post.has_flags(POST_VIRTUAL) works for virtual postings."""
+        # Real posting: POST_VIRTUAL flag should NOT be set
+        posts = self.journal.query("food")
+        self.assertEqual(len(posts), 1)
+        self.assertFalse(posts[0].has_flags(POST_VIRTUAL))
+
+        # Balanced virtual posting: POST_VIRTUAL flag SHOULD be set
+        posts = self.journal.query("budget and savings")
+        self.assertEqual(len(posts), 1)
+        self.assertTrue(posts[0].has_flags(POST_VIRTUAL))
+
     def test_posting_note(self):
         """Test the note property inherited from item_t."""
         posts = self.journal.query("food")

--- a/test/regress/2169.py
+++ b/test/regress/2169.py
@@ -1,0 +1,42 @@
+import ledger
+
+# Regression test for GitHub issue #2169:
+# post.xdata().has_flags(POST_VIRTUAL) always returns False.
+#
+# The bug had two root causes:
+#
+# 1. POST_VIRTUAL is a flag on post_t itself (checked via post.has_flags()),
+#    not on xdata_t (checked via post.xdata().has_flags()).  Users who called
+#    post.xdata().has_flags(POST_VIRTUAL) were checking the wrong flag set;
+#    xdata_t uses POST_EXT_* flags for report-time state.
+#
+# 2. The JournalItem.has_flags() Python binding used supports_flags<> (i.e.
+#    supports_flags<uint_least8_t>) as the 'this' type, while item_t actually
+#    inherits from supports_flags<uint_least16_t>.  This type mismatch has
+#    been corrected to use the right template instantiation.
+#
+# The fix also adds a post.is_virtual convenience property that directly
+# tests the POST_VIRTUAL flag, making the API unambiguous.
+
+session = ledger.Session()
+j = session.read_journal_from_string("""
+2022-07-24 Budget
+    [Budget:Expenses:Gas]    $200.00
+    [Budget:Equity]         -$200.00
+
+2022-07-25 Virtual unbalanced
+    (Virtual:Tracking)      $100.00
+    Expenses:Other          $100.00
+    Assets:Cash            -$100.00
+""")
+
+results = []
+for xact in j:
+    for post in xact.posts:
+        name = post.account.fullname()
+        is_virt = post.is_virtual
+        has_flag = post.has_flags(ledger.POST_VIRTUAL)
+        results.append((name, is_virt, has_flag))
+
+for name, is_virt, has_flag in results:
+    print(f"{name}: is_virtual={is_virt}, has_flags={has_flag}")

--- a/test/regress/2169_py.test
+++ b/test/regress/2169_py.test
@@ -1,0 +1,7 @@
+test python test/regress/2169.py
+Budget:Expenses:Gas: is_virtual=True, has_flags=True
+Budget:Equity: is_virtual=True, has_flags=True
+Virtual:Tracking: is_virtual=True, has_flags=True
+Expenses:Other: is_virtual=False, has_flags=False
+Assets:Cash: is_virtual=False, has_flags=False
+end test


### PR DESCRIPTION
## Summary

Fixes #2169: `post.xdata().has_flags(POST_VIRTUAL)` always returned `False` in Python.

Two root causes were identified and fixed:

- **Wrong flag set**: `POST_VIRTUAL` is a flag on `post_t` itself (tested via
  `post.has_flags(POST_VIRTUAL)`), not on `xdata_t` which uses separate
  `POST_EXT_*` flags for report-time state.  Users calling
  `post.xdata().has_flags(POST_VIRTUAL)` were checking an entirely different
  flag set that never contains `POST_VIRTUAL`.

- **Type mismatch in Python binding**: The `JournalItem` binding registered
  `has_flags()` against `supports_flags<>` (defaulting to `uint_least8_t`),
  while `item_t` actually inherits from `supports_flags<uint_least16_t>`.
  This mismatch caused flag checks to silently operate on the wrong bits.

## Changes

- **`src/py_item.cc`**: Correct the template parameter from `supports_flags<>`
  to `supports_flags<uint_least16_t>` for the `JournalItem` flag methods
  (`flags`, `has_flags`, `clear_flags`, `add_flags`, `drop_flags`).

- **`src/py_post.cc`**: Add an `is_virtual` convenience property to the
  `Posting` class that directly tests `POST_VIRTUAL` on the posting itself,
  making the intent unambiguous and providing a safe, idiomatic API.

- **`test/python/PostingTest.py`**: Four new tests cover:
  - `is_virtual` is `False` for real postings
  - `is_virtual` is `True` for balanced-virtual `[bracket]` postings
  - `is_virtual` is `True` for unbalanced-virtual `(parens)` postings
  - `has_flags(POST_VIRTUAL)` returns the correct value for both posting types

- **`test/regress/2169.py`** + **`test/regress/2169_py.test`**: Regression
  test that mirrors the exact scenario from the issue report, verifying all
  five postings across two transactions return the correct `is_virtual` and
  `has_flags` results.

## Test plan

- [x] `ctest -R 2169` passes (regression test)
- [x] `test/python/PostingTest.py` new tests pass
- [x] All pre-commit hooks pass (build + full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)