### PR TITLE
Fix pre-commit Boost version mismatch in nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,14 @@
 
     devShells = forAllSystems (system: let
         pkgs = nixpkgsFor.${system};
+        # Build Boost with Python support, matching exactly what the ledger
+        # package uses.  A local binding lets us reference the same derivation
+        # in both inputsFrom (via the ledger package) and in the explicit
+        # Boost_DIR cmake flag below.
+        boostWithPython = pkgs.boost.override {
+          enablePython = true;
+          python = pkgs.python3;
+        };
       in with pkgs; {
       default = mkShellNoCC {
         name = "ledger-dev";
@@ -132,6 +140,13 @@
           "-DUSE_DOXYGEN=ON"
           "-DUSE_GPGME=ON"
           "-DBUILD_DOCS=ON"
+          # Explicitly pin Boost_DIR to the Nix-provided Boost with Python.
+          # Without this, a stale CMakeCache.txt from a previous configure (e.g.
+          # one that ran when a different Boost version was current) can leave a
+          # cached Boost_DIR pointing to the wrong version.  That causes the
+          # internal find_package(boost_python) inside BoostConfig.cmake to fail
+          # with a version mismatch even though the correct Boost is available.
+          "-DBoost_DIR=${boostWithPython.dev}/lib/cmake/Boost-${boost.version}"
           # Pin CMake to the Nix-provided Python so it doesn't pick up a
           # Homebrew Python (e.g. 3.14) that mismatches the Boost.Python build.
           "-DPython_EXECUTABLE=${python3}/bin/python3"


### PR DESCRIPTION
## Summary

Fixes a pre-commit hook failure caused by a Boost version mismatch in
the nix dev shell.

### Root Cause

When a developer switches nixpkgs versions (or reuses a build directory
after `nix flake update`), CMake reuses the stale `CMakeCache.txt` that
has `Boost_DIR` cached from the previous Boost version.  The
`BoostConfig.cmake` loaded from the old path then calls
`find_package(boost_python <old_version>)` internally, which fails
because only the new version is available — even though the correct
Boost is fully present in the dev shell.

For example, after nixpkgs bumped Boost from 1.88.0 → 1.89.0, the
cache retained `Boost_DIR` pointing to the 1.88.0 store path.  CMake
loaded `Boost-1.88.0/BoostConfig.cmake` and could not find
`boost_python-1.88.0`, causing the pre-commit `cmake-checks` job to
fail with:

```
Could not find a package configuration file provided by "boost_python"
(requested version 1.88.0)
```

### Fix

Add an explicit `-DBoost_DIR=...` to the `cmakeFlags` exported by the
nix dev shell.  The path is computed dynamically from the same
`boostWithPython` derivation that the `ledger` package uses, so it
always matches the currently-pinned Boost version and automatically
tracks future nixpkgs updates.

A new `boostWithPython` let-binding in the `devShells` section keeps
the derivation defined once and available to future shell configuration
if needed.

## Test plan

- [ ] Delete `build/CMakeCache.txt` and verify `cmake -B build $cmakeFlags` succeeds in `nix develop`
- [ ] With a stale cache pointing to a different Boost version, verify the configure step still succeeds
- [ ] Confirm `nix flake check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)