### PR TITLE
Fix CI: place --now before --begin/--end in dayofweek tests

### DIFF
--- a/test/regress/coverage-dayofweek-last.test
+++ b/test/regress/coverage-dayofweek-last.test
@@ -17,7 +17,7 @@
     Expenses:Food   $30.00
     Assets:Cash
 
-test reg --begin "last wednesday" --now 2026/03/03
+test reg --now 2026/03/03 --begin "last wednesday"
 26-Mar-02 Monday tx             Expenses:Food                $20.00       $20.00
                                 Assets:Cash                 $-20.00            0
 26-Mar-03 Tuesday tx            Expenses:Food                $30.00       $30.00

--- a/test/regress/coverage-dayofweek-next.test
+++ b/test/regress/coverage-dayofweek-next.test
@@ -13,7 +13,7 @@
     Expenses:Food   $40.00
     Assets:Cash
 
-test reg --end "next friday" --now 2026/03/03
+test reg --now 2026/03/03 --end "next friday"
 26-Mar-02 Monday tx             Expenses:Food                $20.00       $20.00
                                 Assets:Cash                 $-20.00            0
 26-Mar-03 Tuesday tx            Expenses:Food                $30.00       $30.00


### PR DESCRIPTION
## Summary

- Fixes 2 failing regression tests (`coverage-dayofweek-last`, `coverage-dayofweek-next`) that are causing CI failures across all PRs
- The `--now` flag must precede `--begin`/`--end` on the command line so the epoch is set before relative date expressions like `"last wednesday"` are parsed
- Without this ordering, the system clock date is used instead of the `--now` date, making tests date-dependent and flaky

## Test plan

- [x] Both tests pass through the test harness locally
- [x] `nix build .` passes with 0 test failures (was 2 failures before fix)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)