### PR TITLE
Pre-scan --now to make option order independent

### DIFF
--- a/src/global.cc
+++ b/src/global.cc
@@ -465,6 +465,30 @@ void global_scope_t::read_environment_settings(char* envp[]) {
 strings_list global_scope_t::read_command_arguments(scope_t& scope, strings_list args) {
   TRACE_START(arguments, 1, "Processed command-line arguments");
 
+  // Pre-scan for --now so that date-relative options (--begin, --end) that
+  // appear earlier on the command line resolve against the correct epoch.
+  // The --now handler is idempotent, so processing it again during the
+  // normal pass is harmless.
+  for (auto i = args.begin(); i != args.end(); ++i) {
+    if ((*i)[0] != '-' || (*i)[1] != '-')
+      continue;
+    const char* arg = (*i).c_str() + 2;
+    const char* value = nullptr;
+    if (std::strcmp(arg, "now") == 0) {
+      auto next = std::next(i);
+      if (next != args.end())
+        value = (*next).c_str();
+    } else if (std::strncmp(arg, "now=", 4) == 0) {
+      value = arg + 4;
+    }
+    if (value) {
+      date_interval_t interval(value);
+      if (optional<date_t> begin = interval.begin())
+        ledger::epoch = datetime_t(*begin);
+      break;
+    }
+  }
+
   strings_list remaining = process_arguments(std::move(args), scope);
 
   TRACE_FINISH(arguments, 1);

--- a/test/regress/coverage-dayofweek-last.test
+++ b/test/regress/coverage-dayofweek-last.test
@@ -17,7 +17,7 @@
     Expenses:Food   $30.00
     Assets:Cash
 
-test reg --now 2026/03/03 --begin "last wednesday"
+test reg --begin "last wednesday" --now 2026/03/03
 26-Mar-02 Monday tx             Expenses:Food                $20.00       $20.00
                                 Assets:Cash                 $-20.00            0
 26-Mar-03 Tuesday tx            Expenses:Food                $30.00       $30.00

--- a/test/regress/coverage-dayofweek-next.test
+++ b/test/regress/coverage-dayofweek-next.test
@@ -13,7 +13,7 @@
     Expenses:Food   $40.00
     Assets:Cash
 
-test reg --now 2026/03/03 --end "next friday"
+test reg --end "next friday" --now 2026/03/03
 26-Mar-02 Monday tx             Expenses:Food                $20.00       $20.00
                                 Assets:Cash                 $-20.00            0
 26-Mar-03 Tuesday tx            Expenses:Food                $30.00       $30.00


### PR DESCRIPTION
## Summary

- Pre-scan argv for `--now` in `read_command_arguments()` before the main option-processing pass, so that `ledger::epoch` is set before `--begin`/`--end` parse relative date expressions
- Reverts test files to their original argument order (`--begin`/`--end` before `--now`) to serve as regression tests for this fix
- Follows the existing `handle_debug_options()` pattern for options that must take effect before normal processing

## Context

PR #2865 fixed CI by reordering test arguments (placing `--now` before `--begin`/`--end`). This was a workaround — the real issue is that `--begin` and `--end` handlers eagerly parse date strings using `CURRENT_DATE()`, which reads `ledger::epoch`. When `--now` appeared later on the command line, `epoch` hadn't been set yet, causing relative date expressions like "last wednesday" to resolve against the system clock.

## Test plan

- [x] Both dayofweek tests pass with `--begin`/`--end` before `--now` (the previously-failing order)
- [x] Full test suite passes (3983/3983 tests)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)