### PR TITLE
Fix buffer overread in quantity punctuation-stripping loop

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -1763,8 +1763,10 @@ bool amount_t::parse(std::istream& in, const parse_flags_t& flags) {
     char* t = buf.get();
 
     while (*p) {
-      if (*p == ',' || *p == '.' || *p == '\'')
-        p++;
+      if (*p == ',' || *p == '.' || *p == '\'') {
+        ++p;
+        continue; // skip separator; do NOT copy the character that follows
+      }
       *t++ = *p++;
     }
     *t = '\0';


### PR DESCRIPTION
## Summary

- Fix a buffer overread bug in `amount_t::parse()` where the punctuation-stripping loop (`src/amount.cc`) would skip a separator character (`,.\'`) but then fall through to copy the *next* character without rechecking the loop condition. If a separator appeared at the end of the string, this read one byte past the NUL terminator.
- The fix adds `continue` after advancing past the separator so control returns to the `while (*p)` guard.

## Test plan

- [ ] Verify existing `ctest` suite passes (the loop is exercised by any amount with thousands separators or decimal marks)
- [ ] Confirm no ASan/UBSan findings on amounts ending with a trailing separator

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>