### PR TITLE
Fix #2008: Strip journal-syntax quotes from commodity names in CSV output

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -354,7 +354,7 @@ string value_t::to_string() const {
   if (is_string()) {
     return as_string();
   } else if (is_commodity()) {
-    return as_commodity().symbol();
+    return as_commodity().base_symbol();
   } else {
     value_t temp(*this);
     temp.in_place_cast(STRING);

--- a/test/regress/2008.test
+++ b/test/regress/2008.test
@@ -1,0 +1,9 @@
+; Quoted commodity symbols should not retain quotes in CSV output
+2021/01/01 Imaginary cryptocurrency tx
+    Assets:Crypto   5 "l33tc0in" @ £123
+    Assets:Checking
+
+test csv
+"2021/01/01","","Imaginary cryptocurrency tx","Assets:Crypto","l33tc0in","5","",""
+"2021/01/01","","Imaginary cryptocurrency tx","Assets:Checking","£","-615","",""
+end test


### PR DESCRIPTION
## Summary
- `value_t::to_string()` for COMMODITY type used `symbol()` which includes journal-syntax quotes (e.g., `"AAPL"` instead of `AAPL`)
- Changed to `base_symbol()` to return the raw commodity name without quoting
- Added regression test `test/regress/2008.test`

## Test plan
- [x] New regression test covers CSV output with quoted commodity names
- [x] All 3995+ tests pass (cmake + ctest)
- [x] nix build passes

Fixes #2008

🤖 Generated with [Claude Code](https://claude.com/claude-code)