### PR TITLE
Fix #604: Emit bucket directive in print output

### DIFF
--- a/src/print.cc
+++ b/src/print.cc
@@ -396,6 +396,11 @@ void print_xacts::title(const string&) {
 void print_xacts::flush() {
   std::ostream& out(report.output_stream);
 
+  if (journal_t* journal = report.session.get_journal()) {
+    if (journal->bucket)
+      out << "bucket " << journal->bucket->fullname() << '\n' << '\n';
+  }
+
   bool first = true;
   for (xact_t* xact : xacts) {
     if (first)

--- a/test/regress/604.test
+++ b/test/regress/604.test
@@ -1,0 +1,13 @@
+; print should emit bucket directive so output can be re-parsed
+bucket Assets:Checking
+
+2024/01/01 Grocery Store
+    Expenses:Food                                $50
+
+test print
+bucket Assets:Checking
+
+2024/01/01 Grocery Store
+    Expenses:Food                                $50
+    Assets:Checking
+end test


### PR DESCRIPTION
## Summary
- `ledger print` rendered all postings correctly (including bucket-inferred ones) but dropped the `bucket` directive itself
- Added bucket directive emission at the top of `print_xacts::flush()` when a bucket is set
- Added regression test `test/regress/604.test`

## Test plan
- [x] New regression test verifies bucket directive appears in print output
- [x] All 3995+ tests pass
- [x] nix build passes

Fixes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)