### PR TITLE
Fix #868: Show payee when it changes between sorted postings

### DIFF
--- a/src/output.cc
+++ b/src/output.cc
@@ -149,6 +149,7 @@ void format_posts::operator()(post_t& post) {
     // NOLINTEND(bugprone-branch-clone)
 
     post.xdata().add_flags(POST_EXT_DISPLAYED);
+    report.last_displayed_payee = post.payee();
     last_post = &post;
   }
 }

--- a/src/post.cc
+++ b/src/post.cc
@@ -263,6 +263,10 @@ value_t get_payee(post_t& post) {
   return string_value(post.payee());
 }
 
+value_t get_xact_payee(post_t& post) {
+  return string_value(post.xact ? post.xact->payee : "");
+}
+
 /**
  * @brief Combine the posting's note with its transaction's note.
  *
@@ -713,6 +717,8 @@ expr_t::ptr_op_t post_t::lookup(const symbol_t::kind_t kind, const string& name)
       return WRAP_FUNCTOR(get_wrapper<&get_xact>);
     else if (name == "xact_id")
       return WRAP_FUNCTOR(get_wrapper<&get_xact_id>);
+    else if (name == "xact_payee")
+      return WRAP_FUNCTOR(get_wrapper<&get_xact_payee>);
     break;
 
   case 'N':

--- a/src/report.cc
+++ b/src/report.cc
@@ -1010,6 +1010,10 @@ value_t report_t::fn_join(call_scope_t& args) {
   return string_value(out.str());
 }
 
+value_t report_t::fn_last_payee(call_scope_t&) {
+  return string_value(last_displayed_payee);
+}
+
 value_t report_t::fn_format_date(call_scope_t& args) {
   if (args.has<string>(1))
     return string_value(format_date(args.get<date_t>(0), FMT_CUSTOM, args.get<string>(1).c_str()));
@@ -1696,7 +1700,9 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind, const string& nam
       break;
 
     case 'l':
-      if (is_eq(p, "lifo_lots"))
+      if (is_eq(p, "last_payee"))
+        return MAKE_FUNCTOR(report_t::fn_last_payee);
+      else if (is_eq(p, "lifo_lots"))
         return MAKE_FUNCTOR(report_t::fn_lifo_lots);
       break;
 

--- a/src/report.h
+++ b/src/report.h
@@ -168,6 +168,7 @@ public:
   optional<datetime_t>
       gain_from; ///< Reference date for --gain-since (compute gain from this date's market value)
   uint_least8_t budget_flags; ///< Bitmask of BUDGET_* flags controlling budget report behavior
+  string last_displayed_payee; ///< Last payee shown by register format (for payee change detection)
 
   explicit report_t(session_t& _session)
       : session(_session), terminus(CURRENT_TIME()), budget_flags(BUDGET_NO_BUDGET) {
@@ -271,6 +272,9 @@ public:
   fn_format_datetime(call_scope_t& scope);   ///< Format a datetime: format_datetime(dt [, fmt])
   value_t fn_ansify_if(call_scope_t& scope); ///< Wrap text in ANSI color codes if condition is met
   value_t fn_percent(call_scope_t& scope);   ///< Compute percentage: percent(part, whole)
+
+  // Display state
+  value_t fn_last_payee(call_scope_t& scope); ///< Last payee shown in register output
 
   // Commodity and lot inspection
   value_t fn_commodity(call_scope_t& scope);       ///< Return the commodity symbol of an amount
@@ -1114,7 +1118,7 @@ public:
                  "           bold if should_bold))\n%/"
                  "%(justify(\" \", int(date_width)))"
                  " %(ansify_if("
-                 "   justify(truncated(has_tag(\"Payee\") ? payee : \" \", "
+                 "   justify(truncated(payee != last_payee ? payee : \" \", "
                  "                     int(payee_width)), int(payee_width)),"
                  "             bold if should_bold))"
                  " %$3 %$4 %$5\n");

--- a/test/regress/1647.test
+++ b/test/regress/1647.test
@@ -16,10 +16,10 @@ tag foo
 
 test reg --strict
 17-May-04 xxx                   A                         10.00 EUR    10.00 EUR
-          xxx                   B                        -10.00 EUR            0
+                                B                        -10.00 EUR            0
 end test
 
 test reg --pedantic
 17-May-04 xxx                   A                         10.00 EUR    10.00 EUR
-          xxx                   B                        -10.00 EUR            0
+                                B                        -10.00 EUR            0
 end test

--- a/test/regress/868.test
+++ b/test/regress/868.test
@@ -1,0 +1,25 @@
+; Regression test for issue #868
+; When using --sort, postings from different transactions may be
+; interleaved.  The register format should show the payee when it
+; changes from the previous line, not just when the transaction changes.
+
+2024/01/01 Store B
+    Expenses:Food                    $20.00
+    Assets:Cash
+
+2024/01/02 Store A
+    Expenses:Food                    $15.00
+    Assets:Cash
+
+2024/01/03 Store B
+    Expenses:Food                    $10.00
+    Assets:Cash
+
+test reg --sort payee --columns 80
+24-Jan-02 Store A               Expenses:Food                $15.00       $15.00
+                                Assets:Cash                 $-15.00            0
+24-Jan-01 Store B               Expenses:Food                $20.00       $20.00
+                                Assets:Cash                 $-20.00            0
+24-Jan-03 Store B               Expenses:Food                $10.00       $10.00
+                                Assets:Cash                 $-10.00            0
+end test

--- a/test/regress/coverage-post-new.test
+++ b/test/regress/coverage-post-new.test
@@ -37,7 +37,7 @@ end test
 
 test reg @Override
 24-Jan-02 Override Payee        Expenses:Food                $15.00       $15.00
-          Override Payee        Assets:Cash                 $-15.00            0
+                                Assets:Cash                 $-15.00            0
 end test
 
 test reg %receipt

--- a/test/regress/coverage-xact-h-access.test
+++ b/test/regress/coverage-xact-h-access.test
@@ -55,5 +55,5 @@ end test
 ; Test filtering by code (exercises code lookup)
 test reg --limit "code == \"INV-001\"" --columns 80
 24-Jan-15 Grocery Store         Expenses:Food                $50.00       $50.00
-          Grocery Store         Assets:Checking             $-50.00            0
+                                Assets:Checking             $-50.00            0
 end test


### PR DESCRIPTION
## Summary
- When `--sort` reorders postings from different transactions, the register format only showed the payee on the first line of each transaction group, not when the payee actually changed between consecutive output lines
- Root cause: the next_lines_format used `has_tag("Payee") ? payee : " "` which only checked for an explicit Payee metadata tag, ignoring payee changes caused by sorting
- Fix: track the last displayed payee in `report_t::last_displayed_payee` and expose it as `last_payee` in format expressions. The next_lines_format now uses `payee != last_payee ? payee : " "` to show the payee whenever it differs from the previous line
- Added `xact_payee` property to `post_t` for accessing the raw transaction payee
- Updated 3 existing tests with corrected payee suppression expectations
- Added regression test `test/regress/868.test`

## Test plan
- [x] New regression test verifies payee display with `--sort payee`
- [x] Existing tests updated for improved payee suppression behavior
- [x] All 3996+ tests pass (cmake + ctest)
- [x] nix build passes

Fixes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)