### PR TITLE
fix(register): show payee when it changes between sorted postings

### DIFF
--- a/src/output.cc
+++ b/src/output.cc
@@ -144,6 +144,8 @@ void format_posts::operator()(post_t& post) {
     } else if (last_post && last_post->date() != post.date()) {
       out << first_line_format(bound_scope);
     } else {
+      if (last_post && last_post->payee() != post.payee())
+        post.xdata().add_flags(POST_EXT_PAYEE_CHANGED);
       out << next_lines_format(bound_scope);
     }
     // NOLINTEND(bugprone-branch-clone)

--- a/src/post.cc
+++ b/src/post.cc
@@ -263,6 +263,10 @@ value_t get_payee(post_t& post) {
   return string_value(post.payee());
 }
 
+value_t get_payee_changed(post_t& post) {
+  return post.has_xdata() && post.xdata().has_flags(POST_EXT_PAYEE_CHANGED);
+}
+
 /**
  * @brief Combine the posting's note with its transaction's note.
  *
@@ -678,6 +682,8 @@ expr_t::ptr_op_t post_t::lookup(const symbol_t::kind_t kind, const string& name)
       return WRAP_FUNCTOR(get_wrapper<&get_this>);
     else if (name == "payee")
       return WRAP_FUNCTOR(get_wrapper<&get_payee>);
+    else if (name == "payee_changed")
+      return WRAP_FUNCTOR(get_wrapper<&get_payee_changed>);
     else if (name == "primary")
       return WRAP_FUNCTOR(get_wrapper<&get_commodity_is_primary>);
     else if (name == "price")

--- a/src/post.h
+++ b/src/post.h
@@ -294,6 +294,7 @@ public:
 #define POST_EXT_MATCHES 0x0080    ///< Posting matches the current query predicate.
 #define POST_EXT_CONSIDERED 0x0100 ///< Posting has already been counted toward account totals.
 #define POST_EXT_DISPLAY_TOTAL_CACHED 0x0200 ///< display_total has been computed and cached.
+#define POST_EXT_PAYEE_CHANGED 0x0400 ///< Payee differs from previous posting in display order.
 
     value_t visited_value;  ///< Value recorded when the posting was visited.
     value_t compound_value; ///< Compound value set by filters (overrides amount when

--- a/src/report.h
+++ b/src/report.h
@@ -727,7 +727,7 @@ public:
                       "           bold if should_bold))\n%/"
                       "%(justify(\" \", int(date_width)))"
                       " %(ansify_if("
-                      "   justify(truncated(has_tag(\"Payee\") ? payee : \" \", "
+                      "   justify(truncated(payee_changed ? payee : \" \", "
                       "                     int(payee_width)), int(payee_width)),"
                       "             bold if should_bold))"
                       " %$3 %$4 %$5 %$6\n");
@@ -1114,7 +1114,7 @@ public:
                  "           bold if should_bold))\n%/"
                  "%(justify(\" \", int(date_width)))"
                  " %(ansify_if("
-                 "   justify(truncated(has_tag(\"Payee\") ? payee : \" \", "
+                 "   justify(truncated(payee_changed ? payee : \" \", "
                  "                     int(payee_width)), int(payee_width)),"
                  "             bold if should_bold))"
                  " %$3 %$4 %$5\n");

--- a/test/regress/1647.test
+++ b/test/regress/1647.test
@@ -16,10 +16,10 @@ tag foo
 
 test reg --strict
 17-May-04 xxx                   A                         10.00 EUR    10.00 EUR
-          xxx                   B                        -10.00 EUR            0
+                                B                        -10.00 EUR            0
 end test
 
 test reg --pedantic
 17-May-04 xxx                   A                         10.00 EUR    10.00 EUR
-          xxx                   B                        -10.00 EUR            0
+                                B                        -10.00 EUR            0
 end test

--- a/test/regress/868.test
+++ b/test/regress/868.test
@@ -1,0 +1,25 @@
+; Regression test for issue #868
+; When using --sort, the register should show the payee when it changes
+; between sorted postings, even for postings that inherit the transaction
+; payee (i.e. have no explicit Payee tag).
+
+2012/10/30 * (1) ACME Inc.
+    Assets:Bank:Checking                      $50.00
+    Foo                                       $20.00
+    Expenses:Office Supplies
+    ; Payee: Binders, Pens, Digital Prints
+
+2012/10/30 * (2) ACME Inc.
+    Assets:Bank:Checking                      $1.00
+    Foo                                       $4.00
+    Expenses:Office Supplies
+    ; Payee: Binders, Pens, Digital Prints
+
+test reg --sort amount --columns 100
+12-Oct-30 Binders, Pens, Digital P.. Expenses:Office Supplies               $-70.00         $-70.00
+12-Oct-30 Binders, Pens, Digital P.. Expenses:Office Supplies                $-5.00         $-75.00
+          ACME Inc.                  Assets:Bank:Checking                     $1.00         $-74.00
+                                     Foo                                      $4.00         $-70.00
+12-Oct-30 ACME Inc.                  Foo                                     $20.00         $-50.00
+                                     Assets:Bank:Checking                    $50.00               0
+end test

--- a/test/regress/coverage-post-new.test
+++ b/test/regress/coverage-post-new.test
@@ -37,7 +37,7 @@ end test
 
 test reg @Override
 24-Jan-02 Override Payee        Expenses:Food                $15.00       $15.00
-          Override Payee        Assets:Cash                 $-15.00            0
+                                Assets:Cash                 $-15.00            0
 end test
 
 test reg %receipt

--- a/test/regress/coverage-xact-h-access.test
+++ b/test/regress/coverage-xact-h-access.test
@@ -55,5 +55,5 @@ end test
 ; Test filtering by code (exercises code lookup)
 test reg --limit "code == \"INV-001\"" --columns 80
 24-Jan-15 Grocery Store         Expenses:Food                $50.00       $50.00
-          Grocery Store         Assets:Checking             $-50.00            0
+                                Assets:Checking             $-50.00            0
 end test


### PR DESCRIPTION
## Summary
- When `--sort` reorders postings, the register's `next_lines_format` used `has_tag("Payee")` to decide whether to display the payee on continuation lines. This failed when sorting caused a posting that inherits the transaction payee (no `Payee` metadata tag) to follow a posting with a different payee — the inherited payee was incorrectly suppressed.
- Added `POST_EXT_PAYEE_CHANGED` xdata flag, set at display time in `format_posts::operator()` by comparing the current posting's payee against the previous posting's payee
- Exposed it as `payee_changed` in the expression scope, used in the default register format instead of `has_tag("Payee")`
- Updated 3 existing tests whose expected output changed due to improved payee suppression logic

## Test plan
- [x] New regression test `test/regress/868.test` verifies payee display with `--sort amount` across multiple transactions with mixed payees
- [x] All 4001 tests pass
- [x] `nix build` passes

Fixes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)