### PR TITLE
test(regress): fix 1936.test to verify (@) vs (@@) round-trip

### DIFF
--- a/test/regress/1936.test
+++ b/test/regress/1936.test
@@ -1,5 +1,9 @@
 ; Regression test for issue #1936:
 ; Parser should allow lot note (tag annotation) combined with virtual price indicator.
+;
+; Virtual per-unit price (@): the given price is multiplied by the posting quantity.
+; Virtual total price (@@): the given price is the total for all units combined.
+; Both forms are informational only and do not update the price history database.
 
 2020-06-22 * Virtual per-unit price with lot note
     Assets:Test               10.00 EUR {1.23 USD} (this is a note) (@) 1.30 USD
@@ -13,6 +17,23 @@
     Assets:Test               10.00 EUR {1.23 USD} (@@) 1.30 USD
     Assets:Bank
 
+; All three transactions parse successfully and the EUR amounts accumulate correctly.
 test bal Assets:Test
            30.00 EUR  Assets:Test
+end test
+
+; Verify that (@) (per-unit) and (@@) (total) annotations are round-tripped correctly
+; through print.  Transaction 1 must emit (@) while transactions 2 and 3 must emit (@@).
+test print
+2020/06/22 * Virtual per-unit price with lot note
+    Assets:Test                         10.00 EUR {USD1.23} (this is a note) (@) USD1.3
+    Assets:Bank
+
+2020/06/22 * Virtual total price with lot note
+    Assets:Test                         10.00 EUR {USD1.23} (this is a note) (@@) USD1.3
+    Assets:Bank
+
+2020/06/22 * Virtual total price without lot note
+    Assets:Test                         10.00 EUR {USD1.23} (@@) USD1.3
+    Assets:Bank
 end test


### PR DESCRIPTION
## Summary

- The original `1936.test` only verified that all three transactions
  parsed without error and that the EUR balance accumulated to 30 EUR.
  That single assertion produces identical output for both `(@)`
  (virtual per-unit) and `(@@)` (virtual total) because the lot-price
  annotation `{1.23 USD}` dominates the cost calculation in both
  cases, making it impossible to distinguish the two forms from the
  test output alone.
- Add a `test print` block that round-trips each posting through the
  printer and confirms that transaction 1 preserves the `(@)` marker
  while transactions 2 and 3 preserve the `(@@)` marker.
- Add header comments that explain the semantic difference between the
  two forms (per-unit vs. total virtual price).

Fixes #2880.

## Test plan

- [x] `python test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1936.test` passes both test blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)