### PR TITLE
fix(journal): prevent dangling context pointer in tag assertion expressions

### DIFF
--- a/src/journal.cc
+++ b/src/journal.cc
@@ -377,7 +377,12 @@ void journal_t::register_metadata(const string& key, const value_t& value,
       value_scope_t val_scope(bound_scope, value);
 
       (*i).second.first.mark_uncompiled();
-      if (!(*i).second.first.calc(val_scope).to_boolean()) {
+      bool holds = (*i).second.first.calc(val_scope).to_boolean();
+      // Clear context immediately: val_scope is stack-allocated and will be
+      // destroyed when this scope exits.  Leaving a dangling pointer behind
+      // would cause a use-after-free the next time the expression is compiled.
+      (*i).second.first.set_context(nullptr);
+      if (!holds) {
         if ((*i).second.second == expr_t::EXPR_ASSERTION)
           throw_(parse_error, _f("Metadata assertion failed for (%1%: %2%): %3%") % key % value %
                                   (*i).second.first);

--- a/test/regress/GH2883.csv
+++ b/test/regress/GH2883.csv
@@ -1,0 +1,2 @@
+date,description,amount,reference_id
+2025-01-20,New Purchase,-50.00,REF99999

--- a/test/regress/GH2883.test
+++ b/test/regress/GH2883.test
@@ -1,0 +1,29 @@
+; Regression test for GitHub issue #2883.
+;
+; ledger convert would segfault (null dereference of current_context) when
+; the journal contained a tag assertion and an existing transaction already
+; carried that tag.  The crash occurred because journal.current_context was
+; not set when check_all_metadata ran inside add_xact during convert.
+;
+; Reproduces the "second-run" scenario: after a first import is appended to
+; the ledger file, a subsequent convert on a new CSV must correctly evaluate
+; the tag assertion without crashing.
+
+tag reference_id
+    assert value =~ /REF[0-9]+/
+
+; This transaction simulates the output of a prior convert run that was
+; appended to the journal.  Loading it causes check_all_metadata to evaluate
+; the tag assertion during journal read, leaving the expression object in a
+; previously-compiled state before convert_command runs.
+2025/01/10 * Existing Payment
+    ; reference_id: REF12345
+    Assets:Bank                           $-100.00
+    Expenses:Unknown
+
+test convert test/regress/GH2883.csv --input-date-format "%Y-%m-%d" --account Assets:Bank
+2025/01/20 * New Purchase
+    ; reference_id: REF99999
+    Expenses:Unknown                             -50
+    Assets:Bank
+end test


### PR DESCRIPTION
## Summary

- Fixes a use-after-free / segfault that occurred when `ledger convert` was run against a journal that already contained transactions with asserted-tag metadata (e.g., after appending a prior conversion's output to the data file).
- When `check_all_metadata` evaluates a tag assertion expression against a short-lived stack-allocated `val_scope`, the expression's compiled context (`expr_base_t::context`) was left pointing at the destroyed scope. On the next evaluation (e.g., during the `convert` run), the stale pointer could be dereferenced, causing a crash.
- Fix: call `set_context(nullptr)` immediately after each `calc()` call in `register_metadata`, so the expression never retains a pointer to a scope that will be destroyed when the function returns.
- Adds a regression test (`GH2883`) that exercises the "second-run" scenario: a journal with a `tag reference_id assert ...` directive and an existing transaction carrying that tag, followed by a `convert` on a new CSV file.

## Test plan

- [x] New regression test `test/regress/GH2883.test` passes
- [x] Existing tag-assertion tests (`cov8-tag-assert`, `coverage-journal-tag-assert`, `coverage-tag-assert-directive`, `GH2521`) still pass
- [x] Full pre-commit hook suite (cmake build + ctest + doxygen + nix build) passes

Fixes #2883

🤖 Generated with [Claude Code](https://claude.com/claude-code)