### PR TITLE
test(regress): add regression test for issue #1827

### DIFF
--- a/test/regress/1827.test
+++ b/test/regress/1827.test
@@ -1,0 +1,30 @@
+; Regression test for GitHub issue #1827:
+; Balanced-virtual postings ([Account]) must balance against one another,
+; not against real postings.  A transaction where real and virtual amounts
+; cross-cancel globally but neither group balances independently must be
+; rejected.
+;
+; The real postings here sum to $1.00 (not zero) and the balanced-virtual
+; postings sum to $-1.00 (not zero).
+
+2019-09-12 Test
+  Assets:Bank:Checking  $-10.00
+  Expenses:Food  $11.00
+  [Budgets:Total]  $10.00
+  [Budgets:Food]  $-11.00
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 14:
+While balancing transaction from "$FILE", lines 10-14:
+> 2019-09-12 Test
+>   Assets:Bank:Checking  $-10.00
+>   Expenses:Food  $11.00
+>   [Budgets:Total]  $10.00
+>   [Budgets:Food]  $-11.00
+Unbalanced remainder is:
+               $1.00
+Amount to balance against:
+              $21.00
+Error: Transaction does not balance
+end test


### PR DESCRIPTION
## Summary

- Issue #1827 reported that bracketed virtual postings (`[Account]`) were incorrectly balanced against real postings in the whole transaction, rather than only against other virtual postings
- The fix was already applied in commit `8f7f445b` (which addressed issue #2105), which introduced separate `balance` and `virtual_balance` accumulators in `xact_base_t::finalize()`
- This PR adds a regression test using the exact scenario from the issue report to prevent future regressions

## Test case

The test file `test/regress/1827.test` contains the original example from the issue:

```ledger
2019-09-12 Test
  Assets:Bank:Checking  $-10.00
  Expenses:Food  $11.00
  [Budgets:Total]  $10.00
  [Budgets:Food]  $-11.00
```

- Real postings sum to `$1.00` (unbalanced)
- Balanced-virtual postings sum to `$-1.00` (unbalanced)
- Combined they would sum to `$0` — the old bug silently accepted this
- With the fix, the transaction is correctly rejected with a balance error

## Test plan

- [x] Run `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1827.test` — passes
- [x] Pre-commit hooks passed (cmake build + 4000+ tests + nix build)

Closes #1827

🤖 Generated with [Claude Code](https://claude.com/claude-code)