### PR TITLE
fix(amount): accept unary '+' sign in amount parsing

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -1444,6 +1444,8 @@ void parse_quantity(std::istream& in, string& value) {
     *p++ = c;
     max--;
     in.get();
+  } else if (c == '+') {
+    in.get(); // consume unary '+'; value is positive by default
   }
   READ_INTO(in, p, max, c,
             std::isdigit(static_cast<unsigned char>(c)) || c == '.' || c == ',' || c == '\'');
@@ -1525,6 +1527,9 @@ bool amount_t::parse(std::istream& in, const parse_flags_t& flags) {
   if (c == '-') {
     negative = true;
     in.get();
+    c = peek_next_nonws(in);
+  } else if (c == '+') {
+    in.get(); // consume unary '+'; value is positive by default
     c = peek_next_nonws(in);
   }
 

--- a/test/regress/1990.test
+++ b/test/regress/1990.test
@@ -1,0 +1,28 @@
+; Regression test for issue #1990: unary '+' in amounts should be accepted.
+
+; Prefix symbol with unary '+' after symbol ($+10.00)
+2015/10/12 Exxon
+    Expenses:Gas             $+10.00
+    Liabilities:MasterCard   $-10.00
+
+test bal Expenses:Gas
+              $10.00  Expenses:Gas
+end test
+
+; Unary '+' before prefix symbol (+$5.00)
+2015/10/13 Groceries
+    Expenses:Food            +$5.00
+    Liabilities:MasterCard   -$5.00
+
+test bal Expenses:Food
+               $5.00  Expenses:Food
+end test
+
+; Unary '+' before bare number with suffix commodity (+10.00 USD)
+2015/10/14 Gas Station
+    Expenses:Fuel            +10.00 USD
+    Liabilities:CreditCard   -10.00 USD
+
+test bal Expenses:Fuel
+           10.00 USD  Expenses:Fuel
+end test


### PR DESCRIPTION
## Summary

Ledger's amount parser handled a leading `-` as the unary negation operator but rejected a leading `+`, producing `Error: No quantity specified for amount` for inputs like:

```
Expenses:Auto:Gas   $+10.00
```

This fix handles unary `+` in two complementary code paths in `src/amount.cc`:

- **`parse_quantity()`**: consume a leading `+` before the digit loop so that suffix-symbol amounts like `$+10.00` parse correctly.
- **`amount_t::parse()`**: consume a leading `+` before the commodity-vs-digit dispatch so that prefix-sign amounts like `+$10.00` and bare numeric amounts like `+10.00 USD` also parse correctly.

In both cases the `+` is simply discarded — the value remains positive, which is the default.

## Test plan

- [ ] New regression test `test/regress/1990.test` covers all three forms: `$+10.00`, `+$5.00`, and `+10.00 USD`
- [ ] All 4033 tests pass (including the new regression test)
- [ ] Unit tests (Util, Math, Filter, Textual) pass
- [ ] Nix flake build passes

Fixes #1990

🤖 Generated with [Claude Code](https://claude.com/claude-code)