### PR TITLE
test(regress): add regression test for issue #563

### DIFF
--- a/test/regress/563.test
+++ b/test/regress/563.test
@@ -1,0 +1,21 @@
+; Regression test for GitHub issue #563:
+; When a transaction has one null-amount real posting and one null-amount
+; balanced-virtual posting, both amounts should be inferrable independently.
+; Real postings balance against real postings; balanced-virtual postings
+; ([Account]) balance against other balanced-virtual postings.
+
+2018/04/10 * Adagio Teas
+    [Assets:Funds:Reserves:Liabilities]     $82.00
+    [Assets:Funds:Toys]
+    Expenses:Thingamabobs                   $82.00
+    Liabilities:Discover
+
+test bal
+                   0  Assets:Funds
+              $82.00    Reserves:Liabilities
+             $-82.00    Toys
+              $82.00  Expenses:Thingamabobs
+             $-82.00  Liabilities:Discover
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

Issue #563 reports that Ledger incorrectly rejects transactions with one
null-amount real posting and one null-amount balanced-virtual posting, even
though each group's missing amount is uniquely inferrable.

The fix was already present in commit `8f7f445b` (\"fix: track real and virtual
posting balances independently\"), which introduced separate balance accumulators
for real vs balanced-virtual ([Account]) postings in `xact_base_t::finalize()`.
Each group independently tracks one null-amount posting and infers its value
from the negation of that group's running balance.

This PR adds the missing regression test to lock in the behaviour and prevent
future regressions.

## Test plan

- [ ] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/563.test` → 1 test passes
- [ ] Full ctest suite passes

Fixes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)