### PR TITLE
test(regress): add regression test for issue #1981 custom report intervals

### DIFF
--- a/test/regress/1981.test
+++ b/test/regress/1981.test
@@ -1,0 +1,30 @@
+; Regression test for issue #1981: custom report interval
+;
+; The --align-intervals option combined with a 'from' date enables running
+; monthly reports that start on a day other than the 1st. For example,
+; running a "month" from the 20th to the 19th.
+
+2024/01/15 Mid-January Purchase
+    Expenses:Food           $50.00
+    Assets:Cash
+
+2024/01/20 After-20th Purchase
+    Expenses:Food           $30.00
+    Assets:Cash
+
+2024/02/05 February Purchase
+    Expenses:Food           $40.00
+    Assets:Cash
+
+2024/02/25 Late February Purchase
+    Expenses:Food           $60.00
+    Assets:Cash
+
+2024/03/10 March Purchase
+    Expenses:Food           $20.00
+    Assets:Cash
+
+test reg Expenses -p "monthly from 2024/01/20" --align-intervals
+24-Jan-20 - 24-Feb-19           Expenses:Food                $70.00       $70.00
+24-Feb-20 - 24-Mar-19           Expenses:Food                $80.00      $150.00
+end test


### PR DESCRIPTION
## Summary

Issue #1981 requested support for running monthly reports with a custom start day (e.g., a "month" running from the 20th to the 19th of the following month).

This functionality was already implemented via the `--align-intervals` option (added in PR #2305). Using `--align-intervals` with a period expression like `monthly from 2024/01/20` causes each period to start on that day-of-month rather than the 1st of the month.

This PR adds a regression test to document and verify this behavior, demonstrating that:
- Transactions before Jan 20 are not included in the custom period
- The period Jan 20 – Feb 19 correctly aggregates the relevant transactions
- The period Feb 20 – Mar 19 correctly aggregates the subsequent transactions

## Test plan

- [x] New regression test `test/regress/1981.test` passes
- [x] Full test suite passes (4000+ tests via pre-commit hook)
- [x] Nix flake build passes

Fixes #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)