### PR TITLE
feat(post): add capital_gain value expression variable

### DIFF
--- a/src/post.cc
+++ b/src/post.cc
@@ -395,6 +395,54 @@ value_t get_price(post_t& post) {
 }
 
 /**
+ * @brief Return the realized capital gain (or loss) for a sell posting.
+ *
+ * Computes the capital gain by subtracting the market value of the amount
+ * (looked up in the price history at the posting's value_date) from the
+ * cost basis stored on the posting.  Returns a positive value for a profit
+ * and a negative value for a loss.
+ *
+ * Only applicable to sell postings (negative amount) that carry a lot-price
+ * annotation, e.g. "-50 AAPL {$30.00} @ $45.00".  For such a posting the
+ * cost basis (after transaction finalization) equals the lot value
+ * (lot_price × |quantity|, with the sign of the amount), and the market
+ * value is the sell price × quantity from the price history.  The gain is
+ * therefore cost_basis − market_value.
+ *
+ * Returns zero for:
+ *   - buy or hold postings (non-negative amount),
+ *   - postings without a lot-price annotation,
+ *   - postings for which no market price can be determined.
+ */
+value_t get_capital_gain(post_t& post) {
+  // Only applicable to sell postings (negative amount).
+  if (post.amount.is_null() || post.amount.sign() >= 0)
+    return 0L;
+
+  // Require a lot-price annotation to establish the cost basis.
+  if (!post.amount.has_annotation() || !post.amount.annotation().price)
+    return 0L;
+
+  // Use the posting's effective value_date for market price lookup.
+  date_t vdate;
+  if (post.has_xdata() && !post.xdata().value_date.is_not_a_date())
+    vdate = post.xdata().value_date;
+  else
+    vdate = post.date();
+
+  // Look up the market value of the amount at vdate.
+  std::optional<amount_t> market_opt = post.amount.value(datetime_t(vdate));
+  if (!market_opt)
+    return 0L;
+
+  // capital_gain = cost_basis − market_value.
+  // Both values are negative for a sell posting; subtracting a more-negative
+  // market value from a less-negative cost basis yields a positive gain.
+  // Example: cost = −$1500, market = −$2500 → gain = −$1500 − (−$2500) = $1000.
+  return get_cost(post) - value_t(*market_opt);
+}
+
+/**
  * @brief Return the running total, or the amount if no total is accumulated.
  */
 value_t get_total(post_t& post) {
@@ -632,6 +680,8 @@ expr_t::ptr_op_t post_t::lookup(const symbol_t::kind_t kind, const string& name)
       return WRAP_FUNCTOR(get_wrapper<&get_code>);
     else if (name == "cost")
       return WRAP_FUNCTOR(get_wrapper<&get_cost>);
+    else if (name == "capital_gain")
+      return WRAP_FUNCTOR(get_wrapper<&get_capital_gain>);
     else if (name == "cost_calculated")
       return WRAP_FUNCTOR(get_wrapper<&get_is_cost_calculated>);
     else if (name == "count")

--- a/test/regress/1996.test
+++ b/test/regress/1996.test
@@ -1,0 +1,48 @@
+; Test for issue #1996: capital_gain value expression variable
+;
+; capital_gain returns the realized capital gain (positive) or loss (negative)
+; for a sell posting that has a lot-price annotation.  It computes:
+;   cost_basis - market_value_at_value_date
+; where cost_basis is the post's cost (basis_cost after finalization) and
+; market_value is looked up from the commodity price history at value_date.
+;
+; Returns zero for:
+;   - buy postings (non-negative amount),
+;   - postings without a lot-price annotation, and
+;   - postings for which no market price can be determined.
+
+P 2004/05/01 00:00:00 AAPL $30.00
+P 2005/08/01 00:00:00 AAPL $50.00
+P 2006/06/01 00:00:00 AAPL $60.00
+
+= Assets:Broker
+  (Income:Capital Gains)    (-(capital_gain))
+  (Expenses:Taxes)          (capital_gain * 0.3)
+
+2004/05/01 Stock purchase
+    Assets:Broker                     50 AAPL @ $30.00
+    Assets:Cash                      $-1,500.00
+
+2005/08/01 Stock sale
+    Assets:Broker                    -50 AAPL {$30.00} @ $50.00
+    Income:Capital Gains           $-1,000.00
+    Assets:Cash                    $2,500.00
+
+2006/06/01 Second sale
+    Assets:Broker                    -25 AAPL {$30.00} @ $60.00
+    Assets:Cash
+
+; capital_gain returns 0 for buy postings and non-zero for sells with lot annotation
+test reg --format '%(date) %(account) %(capital_gain)\n' Assets:Broker
+2004/05/01 Assets:Broker 0
+2005/08/01 Assets:Broker $1,000.00
+2006/06/01 Assets:Broker $750.00
+end test
+
+; capital_gain works in automatic transaction expressions
+test bal Income Expenses
+             $525.00  Expenses:Taxes
+          $-2,750.00  Income:Capital Gains
+--------------------
+          $-2,225.00
+end test


### PR DESCRIPTION
## Summary

Adds a `capital_gain` posting-scope expression variable (issue #1996) that returns the realized capital gain or loss for sell postings with lot-price annotations.

### How it works

For a posting like `-50 AAPL {$30.00} @ $50.00`, the variable computes:

```
capital_gain = cost_basis − market_value_at_value_date
```

where:
- `cost_basis` = the posting's cost field after transaction finalization (= `lot_price × |quantity|`, with the amount's sign)
- `market_value` = the commodity's market price at the posting's effective `value_date`, looked up from the price history

Returns a **positive** value for a profit and **negative** for a loss.

Returns **zero** for:
- Buy/hold postings (non-negative amount)
- Postings without a lot-price annotation (`{price}`)
- Postings for which no market price can be determined

### Example

```ledger
P 2005/08/01 AAPL $50.00

2004/05/01 Buy
    Assets:Broker    50 AAPL @ $30.00
    Assets:Cash

2005/08/01 Sell
    Assets:Broker   -50 AAPL {$30.00} @ $50.00
    Assets:Cash
```

```
$ ledger reg --format '%(capital_gain)\n' Assets:Broker
0              ; buy posting — no gain
$1,000.00      ; sell posting — $1000 realized gain
```

### Use in automatic transactions

The primary motivation (from the issue) is to compute capital gains taxes automatically across multiple lots without manual calculation:

```ledger
= Assets:Broker
  (Income:Capital Gains)    (-(capital_gain))
  (Expenses:Taxes)          (capital_gain * 0.3)
```

With this, selling stock with lot annotations automatically generates the corresponding income and tax postings.

### Implementation

- Added `get_capital_gain(post_t&)` static function in `src/post.cc`
- Registered as `"capital_gain"` in `post_t::lookup()` (the `'c'` case switch)
- Added regression test `test/regress/1996.test`

### Test plan

- [x] All 4000+ existing regression and baseline tests pass
- [x] New regression test for the feature passes
- [x] Verified with multiple lot scenarios and automatic transactions

Fixes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)