### PR TITLE
feat(period): add optional payee to periodic transactions

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1638,8 +1638,11 @@ void generate_posts::add_period_xacts(period_xacts_list& period_xacts) {
       // Skip auto-transaction-generated posts (ITEM_GENERATED without
       // POST_CALCULATED); they have no xact back-pointer and should not
       // produce independent forecast/budget entries.
-      if (!post->has_flags(ITEM_GENERATED) || post->has_flags(POST_CALCULATED))
+      if (!post->has_flags(ITEM_GENERATED) || post->has_flags(POST_CALCULATED)) {
+        if (!xact->payee.empty() && post->payee().empty())
+          post->set_payee(xact->payee);
         add_post(xact->period, *post);
+      }
 }
 
 /// Add a single periodic posting to the pending list.
@@ -1711,7 +1714,10 @@ void budget_posts::report_budget_items(const date_t& date) {
         DEBUG("budget.generate", "Reporting budget for " << post.reported_account()->fullname());
 
         xact_t& xact = temps.create_xact();
-        xact.payee = _("Budget transaction");
+        {
+          string post_payee = post.payee();
+          xact.payee = post_payee.empty() ? _("Budget transaction") : post_payee;
+        }
         xact._date = begin;
 
         post_t& temp = temps.copy_post(post, xact);
@@ -1883,7 +1889,10 @@ void forecast_posts::flush() {
     // "Forecast transaction".
     post_t& post = *(*least).second;
     xact_t& xact = temps.create_xact();
-    xact.payee = _("Forecast transaction");
+    {
+      string post_payee = post.payee();
+      xact.payee = post_payee.empty() ? _("Forecast transaction") : post_payee;
+    }
     xact._date = next;
     post_t& temp = temps.copy_post(post, xact);
 

--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -300,12 +300,68 @@ void instance_t::period_xact_directive(char* line) {
 
   try {
 
-    unique_ptr<period_xact_t> pe(new period_xact_t(skip_ws(line + 1)));
+    const char* header = skip_ws(line + 1);
+    string period_str;
+    string payee_str;
+
+    // Split header on tab or two-or-more consecutive spaces; the left part is
+    // the period expression and the right part (trimmed) is the optional payee.
+    const char* inline_note = nullptr;
+    {
+      const char* p = header;
+      std::size_t spaces = 0;
+      const char* sep = nullptr;
+      while (*p) {
+        if (*p == '\t') {
+          sep = p;
+          break;
+        } else if (*p == ' ') {
+          if (++spaces >= 2 && !sep)
+            sep = p - (spaces - 1);
+        } else {
+          spaces = 0;
+        }
+        ++p;
+      }
+      if (sep) {
+        period_str = string(header, sep);
+        const char* rest = sep;
+        while (*rest == ' ' || *rest == '\t')
+          ++rest;
+        // Find the end of the payee, stopping at "; note".
+        const char* note_start = nullptr;
+        const char* q = rest;
+        while (*q) {
+          if (*q == ';' && (q == rest || *(q - 1) == ' ')) {
+            note_start = q;
+            break;
+          }
+          ++q;
+        }
+        string raw_payee(rest, note_start ? note_start : q);
+        // Trim trailing whitespace from payee.
+        while (!raw_payee.empty() && std::isspace(static_cast<unsigned char>(raw_payee.back())))
+          raw_payee.pop_back();
+        payee_str = raw_payee;
+        if (note_start)
+          inline_note = note_start + 1;
+      } else {
+        period_str = string(header);
+      }
+    }
+
+    unique_ptr<period_xact_t> pe(new period_xact_t(period_str));
+    if (!payee_str.empty())
+      pe->payee = context.journal->validate_payee(payee_str);
+
     pe->pos = position_t();
     pe->pos->pathname = context.pathname;
     pe->pos->beg_pos = context.line_beg_pos;
     pe->pos->beg_line = context.linenum;
     pe->pos->sequence = context.sequence++;
+
+    if (inline_note)
+      pe->append_note(inline_note, *context.scope, false);
 
     reveal_context = false;
 

--- a/src/xact.h
+++ b/src/xact.h
@@ -401,10 +401,11 @@ class period_xact_t : public xact_base_t {
 public:
   date_interval_t period; ///< Parsed recurrence interval (e.g., "Monthly", "Every 2 weeks").
   string period_string;   ///< Original period text from the journal file.
+  string payee;           ///< Optional payee for generated budget/forecast transactions.
 
   period_xact_t() { TRACE_CTOR(period_xact_t, ""); }
   period_xact_t(const period_xact_t& e)
-      : xact_base_t(e), period(e.period), period_string(e.period_string) {
+      : xact_base_t(e), period(e.period), period_string(e.period_string), payee(e.payee) {
     TRACE_CTOR(period_xact_t, "copy");
   }
   period_xact_t(const string& _period) : period(_period), period_string(_period) {

--- a/test/regress/2044.test
+++ b/test/regress/2044.test
@@ -1,0 +1,22 @@
+; Regression test for GitHub issue #2044
+; Periodic transactions may specify an optional payee after two spaces or a tab.
+; The payee is used for generated forecast/budget transactions instead of the
+; default "Forecast transaction" / "Budget transaction".
+
+~ monthly from 2024/01/01  Grocery Fund
+    Expenses:Food          $100.00
+    Assets:Checking
+
+; Forecast: period payee "Grocery Fund" appears instead of "Forecast transaction"
+test reg --forecast 'date <[2024/03/01]' --now=2024/01/01 --format "%(payee) %(account) %(amount)\n"
+Grocery Fund Expenses:Food $100.00
+Grocery Fund Assets:Checking $-100.00
+end test
+
+; Budget: period payee "Grocery Fund" appears instead of "Budget transaction"
+test --budget --now "2024/02/15" reg --format "%(payee) %(account) %(amount)\n"
+Grocery Fund Expenses:Food $-100.00
+Grocery Fund Assets:Checking $100.00
+Grocery Fund Expenses:Food $-100.00
+Grocery Fund Assets:Checking $100.00
+end test


### PR DESCRIPTION
## Summary

- Adds optional payee support to periodic transactions (`~` directives)
- The payee is specified by separating it from the period expression with two or more spaces (or a tab)
- Budget and forecast transactions generated from periodic entries now use the specified payee instead of the generic "Budget transaction" / "Forecast transaction" defaults

**Syntax example:**
```
~ monthly  Grocery Fund
    Expenses:Food    $500
    Assets:Checking
```

Generated budget/forecast transactions will have payee "Grocery Fund", enabling queries like:
```
ledger reg --forecast 'date<[next year]' payee Grocery Fund
```

An inline note after the payee (`; ...`) is also supported and attached to the periodic transaction as metadata.

## Test plan

- [x] New regression test `test/regress/2044.test` verifies both forecast and budget output use the period payee
- [x] All 6578 existing regression tests continue to pass
- [x] Backward compatible: periodic transactions without a payee continue to use the defaults

Fixes #2044

🤖 Generated with [Claude Code](https://claude.com/claude-code)