### PR TITLE
fix(assert): check total balance when account has no real post history

### DIFF
--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -389,7 +389,24 @@ void detail::parse_amount_expr(std::istream& in, scope_t& scope, post_t& post, a
  */
 static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t* xact,
                                       bool strip_annotations, parse_context_t& context) {
-  bool real_only = !post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG);
+  // A real posting uses real_only=true so that the real and virtual balances
+  // of an account can be asserted independently (#543). Exception: if the
+  // account has no prior real postings at all, fall back to the combined
+  // (real + virtual) total so that patterns like tracking reimbursements
+  // with virtual postings and then settling with a real posting remain
+  // assertable (#1959).
+  bool real_only;
+  if (!post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG)) {
+    real_only = false;
+    for (const post_t* p : post->account->posts) {
+      if (!p->has_flags(POST_VIRTUAL | POST_IS_TIMELOG)) {
+        real_only = true;
+        break;
+      }
+    }
+  } else {
+    real_only = false;
+  }
   value_t account_total;
   if (item_t::use_aux_date) {
     // When using effective dates, only count posts whose effective date is on
@@ -436,8 +453,8 @@ static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t*
 
   // Subtract amounts from previous posts to this account in the xact.
   for (post_t* p : xact->posts) {
-    if (p->account == post->account && (!p->has_flags(POST_VIRTUAL | POST_IS_TIMELOG) ||
-                                        post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG))) {
+    if (p->account == post->account &&
+        (!real_only || !p->has_flags(POST_VIRTUAL | POST_IS_TIMELOG))) {
       amount_t p_amt(strip_annotations ? p->amount.strip_annotations(keep_details_t()) : p->amount);
       diff -= p_amt;
       DEBUG("textual.parse", "line " << context.linenum << ": "

--- a/test/regress/1959.test
+++ b/test/regress/1959.test
@@ -1,0 +1,37 @@
+; Regression test for issue #1959: balance assertions mixing virtual and real
+; postings with the same account should work correctly.
+;
+; When an account has only virtual postings in its history, a real posting with
+; a balance assertion should check the combined (real + virtual) total, not just
+; the real balance.  This matches the behaviour of `bal` which shows the total.
+
+commodity $
+  note American Dollars
+  format $1,000.00
+  alias USD
+
+account Assets:Current Assets:Checking Account
+account Assets:Debts:Reimb
+account Expenses:Miscellaneous
+account Liabilities:Credit Card
+
+2020-04-04 Amazon.com
+  Expenses:Miscellaneous  USD 10
+  Liabilities:Credit Card  USD -10
+  (Assets:Debts:Reimb)  USD 10
+
+2020-04-11 Amazon.com
+  Expenses:Miscellaneous  USD 20
+  Liabilities:Credit Card  USD -20
+  (Assets:Debts:Reimb)  USD 20
+
+2020-04-15 reimb
+  Assets:Current Assets:Checking Account  USD 30
+  Assets:Debts:Reimb  USD -30 = 0
+
+test bal Assets:Debts:Reimb
+end test
+
+test bal -R Assets:Debts:Reimb
+             $-30.00  Assets:Debts:Reimb
+end test


### PR DESCRIPTION
## Summary

- Balance assertions on a real posting now check the combined (real + virtual) total when the account has no prior real postings, restoring pre-3.2.1 behaviour for issue #1959
- When the account **does** have prior real postings the existing real-only assertion semantics (from the #543 fix) are preserved unchanged
- The same `real_only` flag now consistently governs which same-transaction posts are subtracted, keeping both halves of the diff computation in sync

## Background

Commit 0018c884 (PR fixing #543) changed balance assertions for real postings to use `real_only=true`, so the asserted value is compared only against the real (non-virtual) balance. This allowed independent assertion of real vs virtual balances in mixed-posting accounts (e.g. budget envelopes).

However, this broke a common off-budget tracking pattern where an account is populated entirely through unbalanced virtual postings `(Account)` and then settled by a single real posting with a combined-balance assertion:

```ledger
2020-04-04 Amazon.com
  Expenses:Miscellaneous  USD 10
  Liabilities:Credit Card  USD -10
  (Assets:Debts:Reimb)  USD 10

2020-04-11 Amazon.com
  Expenses:Miscellaneous  USD 20
  Liabilities:Credit Card  USD -20
  (Assets:Debts:Reimb)  USD 20

2020-04-15 reimb
  Assets:Checking  USD 30
  Assets:Debts:Reimb  USD -30 = 0   ; ← should pass; total is 0
```

`ledger bal Assets:Debts:Reimb` correctly shows zero, but the `= 0` assertion raised _"Balance assertion off by $30.00 (expected to see $-30.00)"_ because only the real balance (−30) was checked.

## Fix

In `compute_balance_diff()` (`src/textual_xacts.cc`): when the posting is real, scan `post->account->posts` for any prior real posting.

* **Prior real post found** → `real_only = true` (existing #543 behaviour)
* **No prior real post found** → `real_only = false` (check combined total, fixes #1959)

Closes #1959.

## Test plan

- [x] New regression test `test/regress/1959.test` passes (both `bal` and `bal -R` cases)
- [x] Existing regression tests `543_a`–`543_d` all pass unchanged
- [x] Full test suite (4005 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)