### PR TITLE
fix(budget): make separator line adapt to amount_width

### DIFF
--- a/src/report.h
+++ b/src/report.h
@@ -621,7 +621,8 @@ public:
                  "%-(ansify_if(partial_account(options.flat), blue if color))\n"
                  "%/%$1 %$2 %$3 %$4\n%/"
                  "%(prepend_width ? \" \" * int(prepend_width) : \"\")"
-                 "------------ ------------ ------------ -----\n");
+                 "%(\"-\" * int(amount_width)) %(\"-\" * int(amount_width))"
+                 " %(\"-\" * int(amount_width)) -----\n");
       });
 
   OPTION(report_t, by_payee); // -P

--- a/test/regress/2374.test
+++ b/test/regress/2374.test
@@ -1,0 +1,21 @@
+~ yearly
+    Expenses:Necessary    13,000,000 CUR
+    Expenses:Unnecessary  31,000,000 CUR
+    Assets
+
+2024-02-01 * Necessities
+    Expenses:Necessary    3,456,789 CUR
+    Assets
+
+2024-02-01 * Nice-To-Haves
+    Expenses:Unnecessary  23,456,789 CUR
+    Assets
+
+test budget --amount-width 20 -p "2024"
+     -26,913,578 CUR      -44,000,000 CUR       17,086,422 CUR   61%  Assets
+      26,913,578 CUR       44,000,000 CUR      -17,086,422 CUR   61%  Expenses
+       3,456,789 CUR       13,000,000 CUR       -9,543,211 CUR   27%    Necessary
+      23,456,789 CUR       31,000,000 CUR       -7,543,211 CUR   76%    Unnecessary
+-------------------- -------------------- -------------------- -----
+                   0                    0                    0     0
+end test


### PR DESCRIPTION
## Summary

- The `budget` report footer separator (`------------ ------------ ------------ -----`) was hardcoded to 12 dashes per column, matching only the default `amount_width` computed for an 80-column terminal
- When amounts are wide (large numbers or explicit `--amount-width`) the separator no longer aligned with the data columns above it
- Replace the literal dashes with dynamic `%("-" * int(amount_width))` expressions (one per amount column), mirroring the technique already used in `balance_format_`
- The percentage column stays as a fixed `-----` since it is always 5 characters wide

**Before** (with `--amount-width 20`):
```
      26,913,578 CUR       44,000,000 CUR      -17,086,422 CUR   61%  Expenses
------------ ------------ ------------ -----
```

**After** (with `--amount-width 20`):
```
      26,913,578 CUR       44,000,000 CUR      -17,086,422 CUR   61%  Expenses
-------------------- -------------------- -------------------- -----
```

## Test plan

- [ ] New regression test `test/regress/2374.test` verifies the separator adapts to `--amount-width 20`
- [ ] All existing budget baseline tests continue to pass unchanged (default 80-column width still produces 12-dash separator)
- [ ] Full test suite (4000+ tests) passes

Fixes #2374

🤖 Generated with [Claude Code](https://claude.com/claude-code)