### PR TITLE
fix(bal): --percent uses display_parent for elided accounts

### DIFF
--- a/src/account.cc
+++ b/src/account.cc
@@ -415,6 +415,21 @@ value_t get_parent_account(account_t& account) {
   return scope_value(account.parent);
 }
 
+value_t get_display_parent_account(account_t& account) {
+  // Returns the nearest non-elided ancestor for percentage calculations.
+  // An ancestor is "elided" when it has exactly 1 child to display AND
+  // does not itself have ACCOUNT_EXT_TO_DISPLAY set.
+  // If all ancestors are elided (e.g., account is at display depth 0),
+  // falls back to the direct structural parent to preserve existing behavior.
+  for (account_t* acct = account.parent; acct && acct->parent; acct = acct->parent) {
+    std::size_t count = acct->children_with_flags(ACCOUNT_EXT_TO_DISPLAY);
+    if (count > 1 || acct->has_xflags(ACCOUNT_EXT_TO_DISPLAY))
+      return scope_value(acct);
+  }
+  // All ancestors were elided; fall back to direct parent
+  return scope_value(account.parent);
+}
+
 value_t fn_any(call_scope_t& args) {
   account_t& account(args.context<account_t>());
   expr_t::ptr_op_t expr(args.get<expr_t::ptr_op_t>(0));
@@ -483,6 +498,8 @@ expr_t::ptr_op_t account_t::lookup(const symbol_t::kind_t kind, const string& fn
       return WRAP_FUNCTOR(get_wrapper<&get_depth_parent>);
     else if (fn_name == "depth_spacer")
       return WRAP_FUNCTOR(get_wrapper<&get_depth_spacer>);
+    else if (fn_name == "display_parent")
+      return WRAP_FUNCTOR(get_wrapper<&get_display_parent_account>);
     break;
 
   case 'e':

--- a/src/report.cc
+++ b/src/report.cc
@@ -213,10 +213,11 @@ void report_t::normalize_options(const string& verb) {
   if (HANDLED(percent)) {
     commodity_t::decimal_comma_by_default = false;
     if (HANDLED(market)) {
-      HANDLER(total_).on("?normalize", "(__tmp = market(parent.total, value_date, exchange);"
-                                       " ((is_account & parent & __tmp) ?"
-                                       "   percent(scrub(market(total, value_date, exchange)), "
-                                       "           scrub(__tmp)) : 0))");
+      HANDLER(total_).on("?normalize",
+                         "(__tmp = market(display_parent.total, value_date, exchange);"
+                         " ((is_account & display_parent & __tmp) ?"
+                         "   percent(scrub(market(total, value_date, exchange)), "
+                         "           scrub(__tmp)) : 0))");
     }
   }
 

--- a/src/report.h
+++ b/src/report.h
@@ -1024,8 +1024,8 @@ public:
 
   OPTION_(
       report_t, percent, DO() { // -%
-        OTHER(total_).on(whence, "((is_account&parent&parent.total)?"
-                                 "  percent(scrub(total), scrub(parent.total)):0)");
+        OTHER(total_).on(whence, "((is_account&display_parent&display_parent.total)?"
+                                 "  percent(scrub(total), scrub(display_parent.total)):0)");
       });
 
   OPTION_(

--- a/test/regress/2033.test
+++ b/test/regress/2033.test
@@ -1,0 +1,19 @@
+; Regression test for issue #2033:
+; --percent for accounts with an elided intermediate parent (compound names
+; like "Travel:Airfare" where Travel has only one child) should report the
+; percentage relative to the nearest non-elided ancestor, not relative to the
+; elided intermediate parent (which always gives 100%).
+
+2024/01/01 Test
+    Expenses:Travel:Airfare    $500.00
+    Expenses:Food              $300.00
+    Expenses:Gas               $200.00
+    Assets:Checking            -$1000.00
+
+test bal --percent
+             100.00%  Assets:Checking
+                   0  Expenses
+              30.00%    Food
+              20.00%    Gas
+              50.00%    Travel:Airfare
+end test

--- a/test/regress/coverage-wave7-report-opts.test
+++ b/test/regress/coverage-wave7-report-opts.test
@@ -43,8 +43,8 @@ end test
 ; --- Test 4: fn_percent (line 836) with --percent ---
 test bal --percent --no-total Expenses
              100.00%  Expenses
-             100.00%    Auto:Gas
-             100.00%    Food:Groceries
+              41.18%    Auto:Gas
+              58.82%    Food:Groceries
 end test
 
 ; --- Test 5: lot_date (lines 912-919) ---

--- a/test/regress/coverage-wave9-report-opts-a.test
+++ b/test/regress/coverage-wave9-report-opts-a.test
@@ -108,7 +108,7 @@ end test
 ; Test --percent option with balance
 test bal --percent Expenses
              100.00%  Expenses
-             100.00%    Auto:Gas
+              31.82%    Auto:Gas
               68.18%    Food
               66.67%      Groceries
               33.33%      Restaurant


### PR DESCRIPTION
## Summary

- Fixes `--percent` always reporting 100% for compound account names (e.g., `Auto:Gas`) where the intermediate parent account (`Auto`) has only one child to display and is therefore elided in the output
- Adds a `display_parent` account property that walks up the ancestor chain using the same elision logic already used by `partial_name()` and `get_depth_parent()`, returning the nearest non-elided ancestor
- Updates the `--percent` total expression (both plain and `--market` variants) to use `display_parent` instead of `parent` as the denominator

**Before:** `Expenses:Auto:Gas` always shows 100% (compared to elided `Auto.total == Gas.total`)

**After:** `Expenses:Auto:Gas` shows 31.82% (correct percentage of `Expenses.total`)

Top-level compound accounts (e.g., `Assets:Checking`) retain the existing 100% behavior via fallback to the structural parent when all ancestors are elided.

## Test plan

- [x] All 4033 existing tests pass
- [x] New regression test `test/regress/2033.test` demonstrates the fix
- [x] Updated `coverage-wave7-report-opts.test` and `coverage-wave9-report-opts-a.test` baselines to reflect corrected percentages

Fixes #2033

🤖 Generated with [Claude Code](https://claude.com/claude-code)