### PR TITLE
fix(query): preserve backslash escapes in regex patterns

### DIFF
--- a/src/query.cc
+++ b/src/query.cc
@@ -126,11 +126,18 @@ bool query_t::lexer_t::unbalanced_braces(const string& str) {
 query_t::lexer_t::token_t query_t::lexer_t::scan_quoted_pattern() {
   string pat;
   char closing = *arg_i;
+  bool is_regex = (closing == '/');
   bool found_closing = false;
   for (++arg_i; arg_i != arg_end; ++arg_i) {
     if (*arg_i == '\\') {
       if (++arg_i == arg_end)
         throw_(parse_error, _("Unexpected '\\' at end of pattern"));
+      if (is_regex && *arg_i != closing) {
+        // For regex patterns /.../: preserve the backslash so the regex engine
+        // can interpret escape sequences (e.g., \| for literal pipe). Only
+        // \/ is consumed as a delimiter escape (backslash stripped).
+        pat.push_back('\\');
+      }
     } else if (*arg_i == closing) {
       ++arg_i;
       found_closing = true;

--- a/src/token.cc
+++ b/src/token.cc
@@ -393,16 +393,42 @@ void expr_t::token_t::next(std::istream& in, const parse_flags_t& pflags) {
     if (pflags.has_flags(PARSE_OP_CONTEXT)) { // operator context
       kind = SLASH;
     } else { // terminal context
-      // Read in the regexp
-      char buf[4096];
-      READ_INTO_(in, buf, 4095, c, length, c != '/');
-      if (c != '/')
+      // Read the regexp pattern, preserving backslash sequences for the regex
+      // engine. Only \/ is treated as an escaped delimiter (the backslash is
+      // stripped so that / does not terminate the pattern early); all other
+      // \X sequences are passed through unchanged so that the regex engine can
+      // interpret them (e.g., \| for literal pipe, \d for digit class).
+      string pat;
+      bool found_closing = false;
+      while (in.good() && !in.eof()) {
+        c = in.get();
+        if (in.eof())
+          break;
+        length++;
+        if (c == '\\') {
+          int next = in.peek();
+          if (next == '/') {
+            // Escaped delimiter: consume the slash and emit just '/'
+            in.get();
+            length++;
+            pat.push_back('/');
+          } else {
+            // All other escape sequences: pass the backslash through so the
+            // regex engine sees the full \X pair (e.g., \| → literal pipe)
+            pat.push_back('\\');
+          }
+        } else if (c == '/') {
+          found_closing = true;
+          break;
+        } else {
+          pat.push_back(static_cast<char>(c));
+        }
+      }
+      if (!found_closing)
         expected('/', c);
-      in.get();
-      length++;
 
       kind = VALUE;
-      value.set_mask(buf);
+      value.set_mask(pat);
     }
     break;
   }

--- a/test/regress/1781.test
+++ b/test/regress/1781.test
@@ -1,0 +1,36 @@
+; Regression test for issue #1781
+; Backslash escaping in regex patterns required double-escaping (\\|) instead
+; of the standard single-escaping (\|). In /.../ regex literals, backslash
+; sequences should be passed through to the regex engine unchanged, so that
+; \| matches a literal pipe character, \d matches a digit, etc.
+; Only \/ needs special treatment (stripping the backslash) to allow a literal
+; slash inside a /.../  pattern without terminating it early.
+
+2019-01-01 * Test 1
+    Assets:A                1.00 EUR
+    Assets:B               -1.00 EUR
+
+2019-02-01 * Test 2 | Test 2
+    Assets:A                2.00 EUR
+    Assets:B               -2.00 EUR
+
+2019-03-01 * Test 3 | Test 3
+    Assets:A                3.00 EUR
+    Assets:B               -3.00 EUR
+
+; Single backslash should escape | in a value expression regex (token.cc path)
+; The argument is single-quoted so the shell passes the literal backslash to ledger
+test payees -l 'payee =~ /\|/'
+Test 2 | Test 2
+Test 3 | Test 3
+end test
+
+; Single backslash should escape | in a query regex (query.cc path)
+; @/regex/ uses the payee matching context; the argument is single-quoted so
+; the shell passes the literal backslash to ledger's query parser
+test reg '@/\|/'
+19-Feb-01 Test 2 | Test 2       Assets:A                   2.00 EUR     2.00 EUR
+                                Assets:B                  -2.00 EUR            0
+19-Mar-01 Test 3 | Test 3       Assets:A                   3.00 EUR     3.00 EUR
+                                Assets:B                  -3.00 EUR            0
+end test


### PR DESCRIPTION
## Summary

Fixes #1781 — backslash escaping in `/…/` regex literals required double-escaping (`/\\|/`) instead of the standard single-escaping (`/\|/`).

### Root Cause

Regex patterns delimited by `/` were parsed in two places, both of which silently dropped backslashes before passing the pattern to the Boost regex engine:

- **`src/token.cc`** — the value-expression tokenizer used `READ_INTO_`, which performs C-style escape processing and consumes any backslash before passing the next character. Replaced with a manual loop that only strips `\` before the closing `/` delimiter (so `\/` embeds a literal `/` without ending the pattern), and passes all other `\X` sequences through unchanged.

- **`src/query.cc` `scan_quoted_pattern()`** — the query-language lexer also dropped backslashes unconditionally. For regex patterns (`closing == '/'`), the fix preserves the backslash for every non-delimiter character so the regex engine receives the full escape sequence.

### Correct Behaviour After Fix

| Pattern | Regex engine sees | Matches |
|---------|-------------------|---------|
| `/\|/`  | `\|`              | literal `\|` pipe character ✓ |
| `/\d+/` | `\d+`             | one or more digits ✓ |
| `/\//`  | `/`               | literal slash ✓ |

## Test Plan

- [x] New regression test `test/regress/1781.test` covers both the value-expression path (`-l 'payee =~ /\|/'`) and the query path (`@/\|/`)
- [x] All 4051+ existing regression/baseline tests continue to pass
- [x] `clang-format` reports no violations
- [x] Full `nix build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)