### PR TITLE
fix(pool): report error for self-referential price directives

### DIFF
--- a/src/pool.cc
+++ b/src/pool.cc
@@ -486,6 +486,10 @@ commodity_pool_t::parse_price_directive(char* line, bool do_not_add_price, bool 
 
   DEBUG("commodity.download", "Looking up symbol: " << symbol);
   if (commodity_t* commodity = find_or_create(symbol)) {
+    if (point.price.has_commodity() && commodity->referent() == point.price.commodity().referent())
+      throw_(parse_error,
+             _f("A price directive may not use the same commodity for both source and price: %1%") %
+                 symbol);
     DEBUG("commodity.download",
           "Adding price for " << symbol << ": " << point.when << " " << point.price);
     if (!do_not_add_price)

--- a/test/regress/1940.test
+++ b/test/regress/1940.test
@@ -1,0 +1,11 @@
+P 2020-01-01 EUR 10.00 EUR
+
+2020-01-01 Test
+    Expenses:Food     10 EUR
+    Assets:Cash      -10 EUR
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 1:
+Error: A price directive may not use the same commodity for both source and price: EUR
+end test


### PR DESCRIPTION
## Summary

- A `P` directive like `P 2020-01-01 EUR 10.00 EUR` (same commodity on both sides) previously caused an assertion failure deep in `commodity_history_impl_t::add_price()` with an unhelpful crash message
- Added a validation check in `parse_price_directive()` that detects when the source commodity and price commodity are the same, throwing a descriptive `parse_error` with a clear message before the assertion is reached
- Added regression test `test/regress/1940.test` to verify the fix

## Test plan

- [ ] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1940.test` passes
- [ ] `cd build && ctest -R 1940` passes
- [ ] Full test suite passes (validated by pre-commit hook)

Fixes #1940

🤖 Generated with [Claude Code](https://claude.com/claude-code)