### PR TITLE
test(regress): add regression test for issue #872

### DIFF
--- a/test/regress/872.test
+++ b/test/regress/872.test
@@ -1,0 +1,27 @@
+; Regression test for issue #872:
+; "parse error in '= expr has_tag("TAG")'"
+;
+; When an automated transaction uses 'expr has_tag("TAG")' with double-quoted
+; string arguments in the value expression, the query parser must correctly
+; parse the full expression including the closing parenthesis.
+;
+; Previously, the closing ')' in has_tag("TAG") was mis-tokenized as an
+; RPAREN boundary rather than being consumed as part of the expression,
+; causing a parse error: "Invalid token '<end of input>' (wanted ')')".
+
+= expr has_tag("SecondTag")
+    Expenses:Cookies  $1
+    $account         -$1
+
+2004/05/27 Book Store
+    ; This note applies to all postings. :SecondTag:
+    Expenses:Books                 20 BOOK @  $10
+    ; Metadata: Some Value
+    ; Typed:: $100 + $200
+    ; :ExampleTag:
+    ; Here follows a note describing the posting.
+    Liabilities:MasterCard        $-200.00
+
+test bal Expenses:Cookies -> 0
+               $2.00  Expenses:Cookies
+end test


### PR DESCRIPTION
## Summary

- Adds `test/regress/872.test` to verify that automated transactions
  using `expr has_tag("TAG")` with double-quoted string arguments parse
  correctly
- Issue #872 reported a parse error when using `= expr has_tag("TAG")`
  in a journal file: the closing `)` was mis-tokenized as an RPAREN
  boundary, producing "Invalid token '<end of input>' (wanted ')')"
- The bug was fixed as part of the query parser rewrite in PR #2900;
  this test ensures it stays fixed

## Test plan

- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/872.test` passes
- [x] All existing tests continue to pass (verified by pre-commit hook)

Fixes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)