### PR TITLE
test(regress): add regression test for issue #1943

### DIFF
--- a/test/regress/1943.test
+++ b/test/regress/1943.test
@@ -1,0 +1,28 @@
+; Bug #1943: --invert not applied when --collapse combines multiple sub-accounts
+; When multiple transactions on the same day post to different sub-accounts,
+; --collapse (optionally combined with --daily) must still negate the display
+; amount and running total when --invert is active.
+
+2020/07/11 Entry 1
+  Expenses:Example1    1000.00 EUR
+  Assets:Example      -1000.00 EUR
+
+2020/07/11 Entry 2
+  Expenses:Example2     100.00 EUR
+  Assets:Example        -100.00 EUR
+
+; Without --invert: collapsed daily total is positive
+test reg Expenses --daily --collapse
+20-Jul-11 - 20-Jul-11           <Total>                 1100.00 EUR  1100.00 EUR
+end test
+
+; With --invert: collapsed daily total must be negated
+test reg Expenses --daily --collapse --invert
+20-Jul-11 - 20-Jul-11           <Total>                -1100.00 EUR -1100.00 EUR
+end test
+
+; --invert without period grouping: individual entries are negated
+test reg Expenses --invert
+20-Jul-11 Entry 1               Expenses:Example1      -1000.00 EUR -1000.00 EUR
+20-Jul-11 Entry 2               Expenses:Example2       -100.00 EUR -1100.00 EUR
+end test


### PR DESCRIPTION
## Summary

- Issue #1943 reported that `--invert` was not applied when `--collapse` combines multiple sub-accounts from different transactions on the same day (using `--daily`)
- The bug was already fixed by the changes in #1908 (which made `--invert` operate on `display_amount`/`display_total` rather than the accumulation amounts)
- This PR adds a regression test to ensure the `--daily --collapse --invert` combination continues to work correctly

## Test plan

- [ ] Verify `reg Expenses --daily --collapse` shows positive total (1100.00 EUR)
- [ ] Verify `reg Expenses --daily --collapse --invert` shows negated total (-1100.00 EUR)
- [ ] Verify `reg Expenses --invert` (no collapse) shows individual entries negated

🤖 Generated with [Claude Code](https://claude.com/claude-code)