### PR TITLE
fix(cmake): use OUTPUT_NAME instead of PREFIX for shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,8 +196,7 @@ if(BUILD_LIBRARY)
   add_library(libledger SHARED ${LEDGER_SOURCES})
   add_ledger_library_dependencies(libledger)
   set_target_properties(libledger PROPERTIES
-    PREFIX ""
-    INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+    OUTPUT_NAME "ledger"
     VERSION ${Ledger_VERSION_MAJOR}
     SOVERSION ${Ledger_VERSION_MAJOR})
   set_source_files_properties(


### PR DESCRIPTION
## Summary

- Replaces `PREFIX "" + INSTALL_NAME_DIR` with `OUTPUT_NAME "ledger"` in the `libledger` shared library target properties
- The `INSTALL_NAME_DIR` approach embedded an absolute install-prefix path into the dylib's `install_name` at build time, breaking staged installs used by package managers like PkgSrc on macOS
- `OUTPUT_NAME "ledger"` produces the same `libledger.dylib` filename while letting CMake handle the `install_name` correctly: `@rpath` in the build tree, rewritten via `install_name_tool` during `cmake --install`

## Test plan

- [x] All 3995+ tests pass with `cmake-checks` hook
- [x] `nix build` succeeds
- [x] Library filename is still `libledger.dylib` (CMake prepends the standard `lib` prefix to `OUTPUT_NAME "ledger"`)

Fixes #1926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)