### PR TITLE
fix(parse): warn when amount precision exceeds declared commodity format

### DIFF
--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -567,6 +567,23 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
             post->add_flags(POST_AMOUNT_USER_DATE);
         }
 
+        if (post->amount.commodity().has_flags(COMMODITY_STYLE_NO_MIGRATE) &&
+            post->amount.precision() > post->amount.commodity().precision()) {
+          if (context.journal->checking_style == journal_t::CHECK_WARNING) {
+            context.warning(
+                _f("Amount for commodity '%1%' has %2% decimal places but declared format only "
+                   "shows %3%") %
+                post->amount.commodity().symbol() % post->amount.precision() %
+                post->amount.commodity().precision());
+          } else if (context.journal->checking_style == journal_t::CHECK_ERROR) {
+            throw_(parse_error,
+                   _f("Amount for commodity '%1%' has %2% decimal places but declared format only "
+                      "shows %3%") %
+                       post->amount.commodity().symbol() % post->amount.precision() %
+                       post->amount.commodity().precision());
+          }
+        }
+
         context.journal->register_commodity(post->amount.commodity(), post.get());
 
         if (!post->amount.has_annotation()) {

--- a/test/regress/1941.test
+++ b/test/regress/1941.test
@@ -1,0 +1,39 @@
+; Regression test for issue #1941: warn when an amount has more decimal places
+; than the declared commodity format precision (requires --strict).
+;
+; When a commodity format is declared with limited precision (e.g. "1,000.00
+; USD" for 2 decimal places) and --strict is active, any posting with a
+; higher-precision amount (e.g. 1.12345 USD) should produce a warning.
+
+commodity USD
+  format 1,000.00 USD
+
+account Assets:Portfolio
+account Assets:Cash
+
+2024/01/01 Investment Purchase
+    Assets:Portfolio    1.12345 USD
+    Assets:Cash        -1.12345 USD
+
+; Without --strict: no warning, amount displayed at declared precision
+test reg --format "%(amount)\n" Assets:Portfolio
+1.12 USD
+end test
+
+; With --strict: warns about excess precision on both postings
+test reg --strict --format "%(amount)\n" Assets:Portfolio
+1.12 USD
+__ERROR__
+Warning: "$FILE", line 15: Amount for commodity 'USD' has 5 decimal places but declared format only shows 2
+Warning: "$FILE", line 16: Amount for commodity 'USD' has 5 decimal places but declared format only shows 2
+end test
+
+; With --pedantic: throws an error on excess precision
+test reg --pedantic --format "%(amount)\n" Assets:Portfolio -> 1
+__ERROR__
+While parsing file "$FILE", line 15:
+While parsing posting:
+  Assets:Portfolio    1.12345 USD
+                      ^^^^^^^^^^^
+Error: Amount for commodity 'USD' has 5 decimal places but declared format only shows 2
+end test


### PR DESCRIPTION
## Summary

- Adds `--strict` / `--pedantic` validation for amounts whose precision exceeds a declared commodity format
- When a commodity format is declared via `commodity X\n  format ...` or the `D` directive, the `COMMODITY_STYLE_NO_MIGRATE` flag is set, locking the display precision
- Previously, an amount with more decimal places (e.g., `1.98547473 USD` when `format 1,000.00 USD` was declared) was silently accepted and displayed at the declared precision — hiding the discrepancy
- Now, under `--strict` a warning is emitted; under `--pedantic` it becomes a parse error

## Example

```ledger
commodity USD
  format 1,000.00 USD

2024/01/01 Oops
    Expenses:Food    1.98547473 USD
    Assets:Cash
```

```
$ ledger -f example.journal reg --strict
Warning: "example.journal", line 5: Amount for commodity 'USD' has 8 decimal places but declared format only shows 2
...
```

## Test plan

- [x] `test/regress/1941.test` covers three cases: no-flag (no warning), `--strict` (warning), `--pedantic` (error)
- [x] All existing 4027 tests pass (the 4 "Not Run" are pre-existing unit test configuration issues unrelated to this change)
- [x] Existing tests for `--round` / `--unround` that intentionally use higher precision continue to pass (they do not use `--strict`)

Fixes #1941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)