### PR TITLE
test(regress): add regression test for issue #1852

### DIFF
--- a/test/regress/1852.test
+++ b/test/regress/1852.test
@@ -1,0 +1,19 @@
+; Regression test for issue #1852: assertion failure when using `ledger equity`
+; with a transaction that has a total-cost annotation (@@ price) in a foreign
+; currency.  The compare_by_commodity comparator used to hit assert(false) when
+; two annotated commodities had prices in different currencies whose numeric
+; values compared equal during the recursive call.
+
+2019/09/16=2019/09/18 * Test
+    Liabilities:Credit Card   -13.33 CAD @@ $10.08
+    Assets:Receivables                   $13.33
+    Expenses:Test
+
+test equity
+2019/09/16 Opening Balances
+    Assets:Receivables                        $13.33
+    Expenses:Test                             $-3.25
+    Liabilities:Credit Card               -13.33 CAD
+    Equity:Opening Balances                  $-10.08
+    Equity:Opening Balances                13.33 CAD
+end test


### PR DESCRIPTION
## Summary

- Add `test/regress/1852.test` to verify that `ledger equity` does not crash with an assertion failure when a transaction uses a total-cost annotation (`@@` price) in a foreign currency.

## Background

Issue #1852 reported that `ledger equity` triggered an assertion failure in `commodity_t::compare_by_commodity::operator()` with this type of transaction:

```
2019/09/16=2019/09/18 * Test
    Liabilities:Credit Card   -13.33 CAD @@ $10.08
    Assets:Receivables                   $13.33
    Expenses:Test
```

The comparator hit `assert(false)` when two annotated commodities had prices in different currencies (CAD vs USD) whose **numeric** values compared as equal during the first recursive call — but there was no fallback path for that case.

The fix was already applied in commit `b155f892` (which also addressed the related issue #1998): when the numeric-value recursive call returns 0 (equal), the comparator now falls back to comparing the prices with their original commodity symbols as a tie-breaker, producing a stable ordering instead of crashing.

This PR adds a regression test using the exact transaction from the bug report to prevent the assertion failure from being re-introduced.

## Test plan

- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1852.test` passes
- [x] Full `ctest` suite passes (4066 tests)
- [x] `nix build .` succeeds

Fixes #1852

🤖 Generated with [Claude Code](https://claude.com/claude-code)