### PR TITLE
Fix: commodity directive now handles price-conversion syntax

### DIFF
--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -656,6 +656,22 @@ void instance_t::account_rewrite_directive(char* line) {
 
 void instance_t::commodity_directive(char* line) {
   char* p = skip_ws(line);
+
+  // If the argument starts with a digit AND contains '=', treat it as a price
+  // conversion of the form "N X = M Y" (e.g., "commodity 1 eur = 2 slices"),
+  // equivalent to the C directive.  Without this, parse_symbol() would silently
+  // extract just "1" as the symbol and discard "eur = 2 slices", causing the
+  // intended price conversion to be silently ignored.
+  if (std::isdigit(static_cast<unsigned char>(*p))) {
+    if (char* eq = std::strchr(p, '=')) {
+      *eq++ = '\0';
+      amount_t::parse_conversion(p, eq);
+      return;
+    }
+    // No '=': fall through and let the normal parse_symbol() path handle it
+    // (e.g., "commodity 1,000.00 USD" defines a format style).
+  }
+
   string symbol; // NOLINT(bugprone-unused-local-non-trivial-variable)
   commodity_t::parse_symbol(p, symbol);
 

--- a/test/regress/1828.test
+++ b/test/regress/1828.test
@@ -1,0 +1,31 @@
+; Regression test for issue #1828:
+; "commodity 1 eur = 2 slices" should set up a price conversion, equivalent
+; to "C 1 eur = 2 slices".  Previously the directive silently created a
+; commodity named "1" and discarded the rest, so the conversion was never
+; registered and an imbalanced transaction was accepted without error.
+
+commodity eur
+commodity slices
+commodity 1 eur = 2 slices
+
+account Foo
+account Bar
+
+; 3 eur != 2 slices (since 1 eur = 2 slices, 3 eur = 6 slices).
+2019/09/20 Unbalanced
+    Foo          -2 slices
+    Bar           3 eur
+
+test bal --explicit --pedantic -> 1
+__ERROR__
+While parsing file "$FILE", line 17:
+While balancing transaction from "$FILE", lines 15-17:
+> 2019/09/20 Unbalanced
+>     Foo          -2 slices
+>     Bar           3 eur
+Unbalanced remainder is:
+            4 slices
+Amount to balance against:
+               3 eur
+Error: Transaction does not balance
+end test


### PR DESCRIPTION
## Summary

- `commodity 1 eur = 2 slices` was silently creating a phantom commodity named `"1"` and discarding the rest of the line, so the intended price conversion was never registered
- This caused imbalanced transactions (e.g., `-2 slices + 3 eur` where 1 eur = 2 slices) to pass silently instead of being rejected
- The fix detects the `N X = M Y` pattern (digit + `=`) in `commodity_directive` and delegates to `amount_t::parse_conversion`, making it equivalent to the `C` directive

## Test plan

- [ ] `test/regress/1828.test` added: verifies that `commodity 1 eur = 2 slices` now sets up the correct price conversion and detects the unbalanced transaction
- [ ] All 4038 existing tests pass
- [ ] `commodity 1,000.00 USD` (format-style declarations without `=`) still work unchanged

Fixes #1828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)