### PR TITLE
Fix --effective to use effective dates for lot annotations

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -630,7 +630,7 @@ bool xact_base_t::finalize() {
 
       cost_breakdown_t breakdown = commodity_pool_t::current_pool->exchange(
           post->amount, *post->cost, false, !post->has_flags(POST_COST_VIRTUAL),
-          datetime_t(post->primary_date(), time_duration(0, 0, 0, 0)), std::nullopt, lot_date);
+          datetime_t(post->date(), time_duration(0, 0, 0, 0)), std::nullopt, lot_date);
 
       if (post->amount.has_annotation() && post->amount.annotation().price) {
         if (breakdown.basis_cost.commodity() == breakdown.final_cost.commodity()) {

--- a/test/regress/1837.test
+++ b/test/regress/1837.test
@@ -1,0 +1,21 @@
+; Test that --effective uses effective dates for lot annotations.
+; When a posting has an effective date (via [=date] in a comment),
+; the --effective flag should cause that date to appear as the lot date.
+
+2019/10/20 Buy of shares
+    Assets:Stocks  10 AAPL @@ 50.00 EUR
+    Assets:Stocks  10 AAPL @@ 55.00 EUR  ; [=2019/10/21]
+    Assets:Stocks  10 AAPL @@ 60.00 EUR  ; [=2019/10/25]
+    Ingress        -165.00 EUR
+
+test bal Stock --lots
+10 AAPL {5.00 EUR} [2019/10/20]
+10 AAPL {5.50 EUR} [2019/10/20]
+10 AAPL {6.00 EUR} [2019/10/20]  Assets:Stocks
+end test
+
+test bal Stock --lots --effective
+10 AAPL {5.00 EUR} [2019/10/20]
+10 AAPL {5.50 EUR} [2019/10/21]
+10 AAPL {6.00 EUR} [2019/10/25]  Assets:Stocks
+end test


### PR DESCRIPTION
## Summary

- In `xact_base_t::finalize()`, the `moment` argument passed to
  `commodity_pool_t::exchange()` was always `datetime_t(post->primary_date(), ...)`.
  When no explicit lot date was provided by the user, `exchange()` used
  `moment->date()` as the lot annotation date — always the primary transaction date.
- This meant `--effective`/`--aux-date` had no effect on lot acquisition dates,
  even when postings carried distinct effective dates via `; [=YYYY/MM/DD]`.
- Fix: change `post->primary_date()` to `post->date()`, which returns the
  effective date when `item_t::use_aux_date` is set (i.e. `--effective` is active).

## Test plan

- [ ] Run `test/regress/1837.test` — two test cases:
  1. Without `--effective`: all lots show the primary transaction date (unchanged behavior)
  2. With `--effective`: lots show their respective effective dates
- [ ] Full regression suite passes: `ctest --output-on-failure` (4034/4038 tests pass; 4 unit test binaries not built)

Fixes #1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)