### PR TITLE
Add regression test for issue #1859: --input-date-format with xact

### DIFF
--- a/test/regress/1859.test
+++ b/test/regress/1859.test
@@ -1,0 +1,26 @@
+; Regression test for GitHub issue #1859:
+; --input-date-format should be respected by the xact/entry command.
+;
+; The original bug: parse_args() called regex_match() on a temporary
+; std::string (from (*begin).to_string()), then immediately used the
+; resulting smatch submatches to call parse_date(what[0]).  Since smatch
+; stores iterators into the input string (not a copy), and the temporary
+; string was destroyed at the semicolon ending the regex_match() call,
+; the what[0] iterators were dangling.  parse_date() then received an
+; empty string and threw "Error: Invalid date: ".
+;
+; The fix (commit efd55c76) assigns (*begin).to_string() to a named local
+; variable so the string stays alive until after what[0] is consumed.
+
+2020/01/01 Test Payee
+    Expenses:Food    $10.00
+    Assets:Cash
+
+; With --input-date-format "%d/%m/%Y", the date "04/02/2020" should be
+; parsed as day=04, month=02, year=2020 (i.e. 2020-Feb-04), not as
+; month=04, day=02 (which would be 2020-Apr-02 in the default %m/%d format).
+test --now "2020/02/05" xact --input-date-format "%d/%m/%Y" "04/02/2020" "Test Payee" "Expenses:Food" 10 "Assets:Cash"
+2020/02/04 Test Payee
+    Expenses:Food                             $10.00
+    Assets:Cash
+end test


### PR DESCRIPTION
## Summary

- Adds regression test `test/regress/1859.test` for issue #1859
- The `xact`/`entry` command failed with `Error: Invalid date: ` (empty string) when `--input-date-format` was specified alongside a date argument
- The root cause was a use-after-free: `parse_args()` passed a temporary `std::string` (from `(*begin).to_string()`) directly to `regex_match()`, then read from the resulting `smatch` submatches after that temporary was destroyed
- The fix (commit `efd55c76` by Tavis Ormandy) assigns the temporary to a named local variable, keeping it alive until after `what[0]` is consumed
- This test verifies that `--input-date-format "%d/%m/%Y"` correctly parses a European-style date `04/02/2020` as February 4, 2020 (day-first format)

## Test plan

- [x] New regression test `test/regress/1859.test` passes: `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1859.test` → `OK (1)`
- [x] Full test suite passes (4000+ tests)
- [x] Build succeeds with cmake

Fixes #1859

🤖 Generated with [Claude Code](https://claude.com/claude-code)