### PR TITLE
test(regress): add regression test for issue #1826

### DIFF
--- a/test/regress/1826.test
+++ b/test/regress/1826.test
@@ -1,0 +1,23 @@
+; Regression test for issue #1826
+; A null posting in a balanced-virtual ([Account]) transaction with multiple
+; commodities should generate additional virtual (not real) balancing postings.
+; Previously, the second generated posting lost its virtual flags and was
+; treated as a real posting, corrupting the real-account balance.
+
+2019/08/30 * I-Bond Virtual Movement
+    [Assets:LTS:Future Plans]     2000 "IB0719"
+    [Assets:LTS:Future Plans]     1000 "IB0819"
+    [Assets:Investments:I-Bonds]
+
+test bal --real
+end test
+
+test bal
+                   0  Assets
+        -2000 IB0719
+        -1000 IB0819    Investments:I-Bonds
+         2000 IB0719
+         1000 IB0819    LTS:Future Plans
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Issue #1826 reported that a null posting in a balanced-virtual (`[Account]`) transaction with multiple commodities generated a spurious non-virtual (real) posting for the second commodity
- The root cause was that generated balancing postings did not copy the `POST_VIRTUAL | POST_MUST_BALANCE` flags from the null posting (fixed in commit `debce12a` and later strengthened by `8f7f445b`)
- This PR adds a regression test using the exact scenario from the bug report to prevent future regressions

## Test plan

- [ ] `test bal --real` returns empty (no real postings generated by the virtual-only transaction)
- [ ] `test bal` shows both virtual accounts with correct balanced amounts
- [ ] Both test cases pass with `python3 test/RegressTests.py`

Fixes #1826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)