### PR TITLE
Fix linker errors for unit tests and librt on older Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,15 @@ check_library_exists(readline add_history "" HAVE_READLINE)
 find_opt_library_and_header(READLINE_PATH readline/history.h READLINE_LIB readline HAVE_READLINE)
 endif()
 
+# On Linux with glibc < 2.17, clock_gettime is in librt rather than libc.
+# Detect and link librt when needed (e.g., older conda/glibc environments).
+if(UNIX AND NOT APPLE)
+  check_library_exists(rt clock_gettime "" HAVE_CLOCK_GETTIME_IN_RT)
+  if(HAVE_CLOCK_GETTIME_IN_RT)
+    find_library(RT_LIBRARY rt)
+  endif()
+endif()
+
 
 #find_package(Gettext)           # Used for running tests
 
@@ -424,6 +433,9 @@ macro(add_ledger_library_dependencies _target)
   target_link_libraries(${_target} ${GMP_LIB})
   target_link_libraries(${_target} ${MPFR_LIB})
   target_link_libraries(${_target} ${PROFILE_LIBS})
+  if(HAVE_CLOCK_GETTIME_IN_RT AND RT_LIBRARY)
+    target_link_libraries(${_target} ${RT_LIBRARY})
+  endif()
   if(HAVE_EDIT)
     target_link_libraries(${_target} ${EDIT_LIB})
   endif()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,8 @@
 macro(add_ledger_test _name)
   target_link_libraries(${_name} libledger)
+  # Unit tests use BOOST_TEST_DYN_LINK and need a direct link to the
+  # Boost.Test shared library so the linker can resolve unit_test_main.
+  target_link_libraries(${_name} Boost::unit_test_framework)
   add_test(Ledger${_name} ${PROJECT_BINARY_DIR}/${_name})
   set_tests_properties(Ledger${_name}
     PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE}")


### PR DESCRIPTION
## Summary

Fixes two linking issues that caused build failures in environments like
conda-forge with older glibc or non-standard Boost configurations (issue #1822):

- **Boost.Test linker error**: Unit test executables (`MathTests`, `UtilTests`,
  `FilterTests`, `TextualTests`) define `BOOST_TEST_DYN_LINK` in their source
  but were only linked against `libledger`, not directly against
  `Boost::unit_test_framework`. This caused `undefined reference to
  boost::unit_test::unit_test_main` at link time. The `add_ledger_test` macro
  in `test/unit/CMakeLists.txt` now links each test target explicitly against
  `Boost::unit_test_framework`.

- **`clock_gettime` / `librt` linker error**: On Linux with glibc < 2.17,
  `clock_gettime` resides in `librt` rather than `libc`. Boost internally calls
  `clock_gettime`, so `libledger.so` would carry an unresolved reference to it
  in those environments. CMake now detects whether `librt` provides
  `clock_gettime` (via `check_library_exists`) and, when so, links `rt` into
  all library-dependent targets.

## Test plan

- [x] `cmake` configure succeeds with the changes applied
- [x] All four unit test executables (`MathTests`, `UtilTests`, `FilterTests`,
  `TextualTests`) build and link without errors
- [x] All four unit tests pass (`ctest -R "LedgerMathTests|LedgerUtilTests|LedgerFilterTests|LedgerTextualTests"`)
- [x] Full test suite passes (4000+ tests via pre-commit hook)
- [x] `nix build .` succeeds

Fixes #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)