### PR TITLE
Fix parsing of amounts starting with a decimal point (issue #1933)

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -1534,7 +1534,7 @@ bool amount_t::parse(std::istream& in, const parse_flags_t& flags) {
   }
 
   char n;
-  if (std::isdigit(static_cast<unsigned char>(c))) {
+  if (std::isdigit(static_cast<unsigned char>(c)) || c == '.') {
     parse_quantity(in, quant);
 
     n = in.eof() ? '\n' : static_cast<char>(in.peek());

--- a/test/regress/1933.test
+++ b/test/regress/1933.test
@@ -1,0 +1,21 @@
+; Regression test for issue #1933:
+; Numbers starting with a decimal point (no leading digit) should parse
+; correctly when the commodity symbol follows the number as a suffix.
+; E.g., ".10USD" and ".10$" should parse the same as "0.10 USD" / "0.10 $".
+
+2020-06-19 * Suffix commodity after leading-dot number
+    A
+    B          .10USD
+
+2020-06-20 * Dollar sign suffix after leading-dot number
+    A           .10$
+    B
+
+test bal
+               0.10$
+            -0.10USD  A
+              -0.10$
+             0.10USD  B
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Amounts like `.10USD` and `.10$` (decimal without a leading digit, with the commodity as a suffix) failed to parse with an \"Unexpected char\" error
- Root cause: `amount_t::parse()` dispatched to the \"commodity first\" branch when it saw a leading `.`, since `.` is not a digit; this left the commodity suffix in the stream after `parse_quantity()` read only the number
- Fix: extend the \"number first\" branch condition in `amount_t::parse()` to also trigger when `c == '.'`, so numbers like `.10` are correctly identified as quantities even without a leading zero

## Test plan

- [ ] New regression test `test/regress/1933.test` covers both failing cases from the issue (`.10USD` and `.10$`)
- [ ] All 4000+ existing tests pass (validated by pre-commit hook)
- [ ] Previously-working forms (`$-.10`, `USD.10`, `$.10`) continue to work

Fixes #1933

🤖 Generated with [Claude Code](https://claude.com/claude-code)