### PR TITLE
Add defaulted copy-assignment operators to silence -Wdeprecated-copy

### DIFF
--- a/src/account.h
+++ b/src/account.h
@@ -126,6 +126,7 @@ public:
         note(other.note), depth(other.depth), accounts(other.accounts) {
     TRACE_CTOR(account_t, "copy");
   }
+  account_t& operator=(const account_t&) = default;
   ~account_t() override;
 
   string description() override { return string(_("account ")) + fullname(); }
@@ -343,6 +344,7 @@ public:
           family_details(other.family_details), sort_values(other.sort_values) {
       TRACE_CTOR(account_t::xdata_t, "copy");
     }
+    xdata_t& operator=(const xdata_t&) = default;
     ~xdata_t() noexcept { TRACE_DTOR(account_t::xdata_t); }
   };
 

--- a/src/annotate.h
+++ b/src/annotate.h
@@ -111,6 +111,7 @@ struct annotation_t : public flags::supports_flags<>, public equality_comparable
         value_expr(other.value_expr) {
     TRACE_CTOR(annotation_t, "copy");
   }
+  annotation_t& operator=(const annotation_t&) = default;
   ~annotation_t() { TRACE_DTOR(annotation_t); }
 
   operator bool() const { return price || date || tag || value_expr; }

--- a/src/compare.h
+++ b/src/compare.h
@@ -107,6 +107,7 @@ public:
   compare_items(const compare_items& other) : sort_order(other.sort_order), report(other.report) {
     TRACE_CTOR(compare_items, "copy");
   }
+  compare_items& operator=(const compare_items&) = delete;
   ~compare_items() noexcept { TRACE_DTOR(compare_items); }
 
   /// Evaluate the sort expression in @p scope and append results to @p sort_values.

--- a/src/context.h
+++ b/src/context.h
@@ -115,6 +115,7 @@ public:
         count(context.count), sequence(context.sequence) {
     std::memcpy(linebuf, context.linebuf, MAX_LINE);
   }
+  parse_context_t& operator=(const parse_context_t&) = default;
 
   /// @brief Return a human-readable "file:line" string for error messages.
   string location() const { return file_context(pathname, linenum); }

--- a/src/filters.h
+++ b/src/filters.h
@@ -944,6 +944,7 @@ protected:
           must_balance(av.must_balance) {
       TRACE_CTOR(acct_value_t, "copy");
     }
+    acct_value_t& operator=(const acct_value_t&) = default;
     ~acct_value_t() noexcept { TRACE_DTOR(acct_value_t); }
   };
 

--- a/src/item.h
+++ b/src/item.h
@@ -179,6 +179,7 @@ public:
     copy_details(item);
     TRACE_CTOR(item_t, "copy");
   }
+  item_t& operator=(const item_t&) = default;
   ~item_t() override { TRACE_DTOR(item_t); }
 
   /** @brief Copy all mutable fields from another item.

--- a/src/iterators.h
+++ b/src/iterators.h
@@ -93,6 +93,7 @@ public:
   iterator_facade_base(const iterator_facade_base& i) : m_node(i.m_node) {
     TRACE_CTOR(iterator_facade_base, "copy");
   }
+  iterator_facade_base& operator=(const iterator_facade_base&) = default;
   ~iterator_facade_base() noexcept { TRACE_DTOR(iterator_facade_base); }
 
   explicit iterator_facade_base(node_base p) : m_node(p) {}
@@ -136,6 +137,7 @@ public:
         posts_i(i.posts_i), posts_end(i.posts_end), posts_uninitialized(i.posts_uninitialized) {
     TRACE_CTOR(xact_posts_iterator, "copy");
   }
+  xact_posts_iterator& operator=(const xact_posts_iterator&) = default;
   ~xact_posts_iterator() noexcept { TRACE_DTOR(xact_posts_iterator); }
 
   /// Point the iterator at a new transaction and advance to its first posting.
@@ -184,6 +186,7 @@ public:
         xacts_i(i.xacts_i), xacts_end(i.xacts_end), xacts_uninitialized(i.xacts_uninitialized) {
     TRACE_CTOR(xacts_iterator, "copy");
   }
+  xacts_iterator& operator=(const xacts_iterator&) = default;
   ~xacts_iterator() noexcept { TRACE_DTOR(xacts_iterator); }
 
   /// Point the iterator at all transactions in a journal.
@@ -224,6 +227,7 @@ public:
         xacts(i.xacts), posts(i.posts) {
     TRACE_CTOR(journal_posts_iterator, "copy");
   }
+  journal_posts_iterator& operator=(const journal_posts_iterator&) = default;
   ~journal_posts_iterator() noexcept { TRACE_DTOR(journal_posts_iterator); }
 
   void reset(journal_t& journal);
@@ -268,6 +272,7 @@ public:
         temps(i.temps), latest_only(i.latest_only) {
     TRACE_CTOR(posts_commodities_iterator, "copy");
   }
+  posts_commodities_iterator& operator=(const posts_commodities_iterator&) = default;
   ~posts_commodities_iterator() noexcept { TRACE_DTOR(posts_commodities_iterator); }
 
   void reset(journal_t& journal);
@@ -304,6 +309,7 @@ public:
         accounts_i(i.accounts_i), accounts_end(i.accounts_end) {
     TRACE_CTOR(basic_accounts_iterator, "copy");
   }
+  basic_accounts_iterator& operator=(const basic_accounts_iterator&) = default;
   ~basic_accounts_iterator() noexcept { TRACE_DTOR(basic_accounts_iterator); }
 
   void increment();
@@ -358,6 +364,7 @@ public:
         sorted_accounts_end(i.sorted_accounts_end) {
     TRACE_CTOR(sorted_accounts_iterator, "copy");
   }
+  sorted_accounts_iterator& operator=(const sorted_accounts_iterator&) = delete;
   ~sorted_accounts_iterator() noexcept { TRACE_DTOR(sorted_accounts_iterator); }
 
   void increment();

--- a/src/journal.h
+++ b/src/journal.h
@@ -131,6 +131,7 @@ public:
         : filename(info.filename), modtime(info.modtime), from_stream(info.from_stream) {
       TRACE_CTOR(journal_t::fileinfo_t, "copy");
     }
+    fileinfo_t& operator=(const fileinfo_t&) = default;
     ~fileinfo_t() noexcept { TRACE_DTOR(journal_t::fileinfo_t); }
   };
 

--- a/src/post.h
+++ b/src/post.h
@@ -152,6 +152,7 @@ public:
     copy_details(post);
     TRACE_CTOR(post_t, "copy");
   }
+  post_t& operator=(const post_t&) = default;
   ~post_t() override { TRACE_DTOR(post_t); }
 
   string description() override {
@@ -319,6 +320,7 @@ public:
           account(other.account), sort_values(other.sort_values) {
       TRACE_CTOR(post_t::xdata_t, "copy");
     }
+    xdata_t& operator=(const xdata_t&) = default;
     ~xdata_t() noexcept { TRACE_DTOR(post_t::xdata_t); }
   };
 

--- a/src/scope.h
+++ b/src/scope.h
@@ -112,6 +112,7 @@ struct symbol_t {
   symbol_t(const symbol_t& sym) : kind(sym.kind), name(sym.name), definition(sym.definition) {
     TRACE_CTOR(symbol_t, "copy");
   }
+  symbol_t& operator=(const symbol_t&) = default;
   ~symbol_t() noexcept { TRACE_DTOR(symbol_t); }
 
   bool operator<(const symbol_t& sym) const { return kind < sym.kind || name < sym.name; }

--- a/src/times.h
+++ b/src/times.h
@@ -319,6 +319,7 @@ struct date_duration_t {
   date_duration_t(const date_duration_t& dur) : quantum(dur.quantum), length(dur.length) {
     TRACE_CTOR(date_duration_t, "copy");
   }
+  date_duration_t& operator=(const date_duration_t&) = default;
   ~date_duration_t() noexcept { TRACE_DTOR(date_duration_t); }
 
   /// @brief Advance a date forward by this duration.
@@ -559,6 +560,7 @@ public:
         end_inclusive(other.end_inclusive) {
     TRACE_CTOR(date_range_t, "date_range_t");
   }
+  date_range_t& operator=(const date_range_t&) = default;
   ~date_range_t() noexcept { TRACE_DTOR(date_range_t); }
 
   /// @brief Resolve the start of the range to a concrete date, or none if unbounded.
@@ -628,6 +630,7 @@ public:
       : specifier_or_range(other.specifier_or_range) {
     TRACE_CTOR(date_specifier_or_range_t, "copy");
   }
+  date_specifier_or_range_t& operator=(const date_specifier_or_range_t&) = default;
   date_specifier_or_range_t(const date_specifier_t& specifier) : specifier_or_range(specifier) {
     TRACE_CTOR(date_specifier_or_range_t, "date_specifier_t");
   }

--- a/src/xact.h
+++ b/src/xact.h
@@ -108,6 +108,7 @@ public:
 
   xact_base_t() : item_t(), journal(nullptr) { TRACE_CTOR(xact_base_t, ""); }
   xact_base_t(const xact_base_t& e);
+  xact_base_t& operator=(const xact_base_t&) = default;
 
   ~xact_base_t() override;
 
@@ -198,6 +199,7 @@ public:
 
   xact_t() { TRACE_CTOR(xact_t, ""); }
   xact_t(const xact_t& e);
+  xact_t& operator=(const xact_t&) = default;
 
   ~xact_t() override { TRACE_DTOR(xact_t); }
 
@@ -325,6 +327,7 @@ public:
         active_post(other.active_post) {
     TRACE_CTOR(auto_xact_t, "copy");
   }
+  auto_xact_t& operator=(const auto_xact_t&) = default;
   auto_xact_t(const predicate_t& _predicate)
       : predicate(_predicate), name(none), try_quick_match(true), enabled(true),
         active_post(nullptr) {
@@ -407,6 +410,7 @@ public:
       : xact_base_t(e), period(e.period), period_string(e.period_string) {
     TRACE_CTOR(period_xact_t, "copy");
   }
+  period_xact_t& operator=(const period_xact_t&) = default;
   period_xact_t(const string& _period) : period(_period), period_string(_period) {
     TRACE_CTOR(period_xact_t, "const string&");
   }


### PR DESCRIPTION
## Summary

GCC 9+ emits `-Wdeprecated-copy` for any class that has a user-defined
copy constructor but no explicit copy assignment operator, because C++11
deprecated the implicit generation of copy assignment in that case.

The affected classes all followed the same pattern: a copy constructor
whose body only calls `TRACE_CTOR` (a no-op outside of debug builds),
performing standard member-wise initialisation.  The fix adds an explicit
`= default` copy-assignment declaration adjacent to each copy constructor,
making the implicit behaviour explicit and silencing the warning.

Two classes — `sorted_accounts_iterator` and `compare_items<T>` — hold
reference members and therefore cannot have a working copy-assignment
operator.  For those, the declaration uses `= delete` to make the intent
clear rather than relying on the implicit deletion.

### Files changed

| File | Classes fixed |
|------|--------------|
| `src/times.h` | `date_duration_t`, `date_range_t`, `date_specifier_or_range_t` |
| `src/annotate.h` | `annotation_t` |
| `src/scope.h` | `symbol_t` |
| `src/iterators.h` | `iterator_facade_base`, `xact_posts_iterator`, `xacts_iterator`, `journal_posts_iterator`, `posts_commodities_iterator`, `basic_accounts_iterator`, `sorted_accounts_iterator` (deleted) |
| `src/context.h` | `parse_context_t` |
| `src/item.h` | `item_t` |
| `src/xact.h` | `xact_base_t`, `xact_t`, `auto_xact_t`, `period_xact_t` |
| `src/post.h` | `post_t`, `post_t::xdata_t` |
| `src/account.h` | `account_t`, `account_t::xdata_t` |
| `src/journal.h` | `journal_t::fileinfo_t` |
| `src/compare.h` | `compare_items<T>` (deleted) |
| `src/filters.h` | `acct_value_t` |

## Test plan

- [x] All 4065 tests pass (`ctest` in `build/`)
- [x] Clean build with no `-Wdeprecated-copy` warnings
- [x] No new warnings of any kind introduced

Fixes #1927

🤖 Generated with [Claude Code](https://claude.com/claude-code)