### PR TITLE
fix: clean include error and support quoted paths (#1862)

### DIFF
--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -224,6 +224,18 @@ void instance_t::include_directive(char* line) {
   if (include_depth > 100)
     throw_(parse_error, _("Maximum include depth exceeded (100)"));
 
+  // Strip balanced surrounding quotes (" or ') from the include path so that
+  // both `include "file.ledger"` and `include 'file.ledger'` work as expected.
+  // We also avoid the confusing case where a stray trailing quote (e.g.
+  // `include test.ledger"`) is silently embedded in the filename.
+  {
+    std::size_t line_len = std::strlen(line);
+    if (line_len >= 2 && (line[0] == '"' || line[0] == '\'') && line[line_len - 1] == line[0]) {
+      line[line_len - 1] = '\0';
+      ++line;
+    }
+  }
+
   path filename;
 
   DEBUG("textual.include", "include: " << line);
@@ -335,7 +347,7 @@ void instance_t::include_directive(char* line) {
   }
 
   if (!files_found)
-    throw_(std::runtime_error, _f("File to include was not found: %1%") % filename);
+    throw_(std::runtime_error, _f("File to include was not found: %1%") % filename.string());
 }
 
 /*--- Apply / Scope Directives ---*/

--- a/test/regress/1660.test
+++ b/test/regress/1660.test
@@ -8,5 +8,5 @@ include 1660.DAT
 test bal -> 1
 __ERROR__
 While parsing file "$FILE", line 6:
-Error: File to include was not found: "$sourcepath/test/regress/1660.DAT"
+Error: File to include was not found: $sourcepath/test/regress/1660.DAT
 end test

--- a/test/regress/1862-quoted-include.test
+++ b/test/regress/1862-quoted-include.test
@@ -1,0 +1,13 @@
+; Regression test for issue #1862 (quote stripping in include paths).
+;
+; Balanced surrounding double-quotes and single-quotes are now stripped from
+; include paths, so `include "file.ledger"` and `include 'file.ledger'` work
+; as expected.  The error message also shows the raw (stripped) path.
+
+include "/nonexistent-1862/quoted.ledger"
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 7:
+Error: File to include was not found: /nonexistent-1862/quoted.ledger
+end test

--- a/test/regress/1862.test
+++ b/test/regress/1862.test
@@ -1,0 +1,15 @@
+; Regression test for issue #1862.
+;
+; A stray or unbalanced trailing quote in an include path (e.g.
+; `include test.ledger"`) used to produce a confusing error message
+; containing a stray `&` (old Boost) or backslash-escaped quote `\"` (C++17
+; std::filesystem::path with std::quoted).  The error must show the raw
+; filename without any extra backslash escaping.
+
+include /nonexistent-1862/test.ledger"
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 9:
+Error: File to include was not found: /nonexistent-1862/test.ledger"
+end test

--- a/test/regress/6188B0EC.test
+++ b/test/regress/6188B0EC.test
@@ -5,6 +5,6 @@
 test bal -> 1
 __ERROR__
 While parsing file "$FILE", line 3:
-Error: File to include was not found: "$sourcepath/test/regress/6188B0EC-does-not-exist.dat"
+Error: File to include was not found: $sourcepath/test/regress/6188B0EC-does-not-exist.dat
 end test
 

--- a/test/regress/BF3C1F82-2.test
+++ b/test/regress/BF3C1F82-2.test
@@ -4,11 +4,11 @@ include non-existent-ledger-file-BF3C1F82
 test -f - reg -> 1
 __ERROR__
 While parsing file "", line 2:
-Error: File to include was not found: "$sourcepath/non-existent-ledger-file-BF3C1F82"
+Error: File to include was not found: $sourcepath/non-existent-ledger-file-BF3C1F82
 end test
 
 test -f /dev/stdin reg -> 1
 __ERROR__
 While parsing file "", line 2:
-Error: File to include was not found: "$sourcepath/non-existent-ledger-file-BF3C1F82"
+Error: File to include was not found: $sourcepath/non-existent-ledger-file-BF3C1F82
 end test

--- a/test/regress/coverage-error-include-not-found.test
+++ b/test/regress/coverage-error-include-not-found.test
@@ -9,5 +9,5 @@ include /nonexistent/path/to/file.dat
 test bal -> 1
 __ERROR__
 While parsing file "$FILE", line 3:
-Error: File to include was not found: "/nonexistent/path/to/file.dat"
+Error: File to include was not found: /nonexistent/path/to/file.dat
 end test

--- a/test/regress/coverage-session-parse-error.test
+++ b/test/regress/coverage-session-parse-error.test
@@ -6,5 +6,5 @@ include /nonexistent/file.dat
 test bal -> 1
 __ERROR__
 While parsing file "$FILE", line 4:
-Error: File to include was not found: "/nonexistent/file.dat"
+Error: File to include was not found: /nonexistent/file.dat
 end test


### PR DESCRIPTION
## Summary

- Fixes the confusing error message when an include path contains special characters like `"`. Previously, `std::filesystem::path::operator<<` used `std::quoted`, so `include test.ledger"` produced `Error: File to include was not found: "/path/test.ledger\""` with a confusing backslash escape (in older Boost versions this appeared as a stray `&`).
- Changes `% filename` to `% filename.string()` so the raw path is shown verbatim.
- Adds support for balanced quoted include paths: `include "file.ledger"` and `include 'file.ledger'` now strip the surrounding quotes and find the file as expected.

## Test plan

- [ ] New regression test `test/regress/1862.test` verifies the stray-quote error message shows the raw path without backslash escaping
- [ ] New regression test `test/regress/1862-quoted-include.test` verifies double-quoted paths are stripped correctly
- [ ] All existing include-related tests updated to expect the new plain-path format
- [ ] Full test suite (4039 tests) passes, nix build passes

Fixes #1862

🤖 Generated with [Claude Code](https://claude.com/claude-code)