### PR TITLE
fix: strip outer quotes and unescape backslash-quote in init-file option values

### DIFF
--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -201,6 +201,29 @@ void instance_t::option_directive(char* line) {
       *p++ = '\0';
   }
 
+  // Strip outer quotes and process escape sequences in the option value.
+  // Double-quoted strings: process only \" -> " and \\ -> \ (leave all other
+  // escape sequences such as \n and \t for the format parser).
+  // Single-quoted strings: strip quotes with no escape processing at all.
+  string unquoted;
+  if (p && *p == '"') {
+    const char* s = p + 1;
+    while (*s && *s != '"') {
+      if (*s == '\\' && (*(s + 1) == '"' || *(s + 1) == '\\')) {
+        unquoted += *(s + 1);
+        s += 2;
+      } else {
+        unquoted += *s++;
+      }
+    }
+    p = const_cast<char*>(unquoted.c_str());
+  } else if (p && *p == '\'') {
+    const char* s = p + 1;
+    while (*s && *s != '\'')
+      unquoted += *s++;
+    p = const_cast<char*>(unquoted.c_str());
+  }
+
   if (!process_option(context.pathname.string(), line + 2, *context.scope, p, line))
     throw_(option_error, _f("Illegal option --%1%") % (line + 2));
 }

--- a/test/regress/1884.ledgerrc
+++ b/test/regress/1884.ledgerrc
@@ -1,0 +1,1 @@
+--balance-format "%(justify(scrub(display_total), 20, -1, true, color))  %(!options.flat ? depth_spacer : \"\")%-(ansify_if(partial_account(options.flat), blue if color))\n%/%$1\n%/--------------------\n"

--- a/test/regress/1884.test
+++ b/test/regress/1884.test
@@ -1,0 +1,33 @@
+; Test for issue #1884: --balance-format with quoted value in init file.
+;
+; When specifying --balance-format (or other format options) in a .ledgerrc
+; init file, the value is read as raw text without shell processing.  Users
+; need to wrap the value in double-quotes to handle spaces, and use \" inside
+; those quotes to embed a literal double-quote (e.g., for empty string
+; literals in expressions like `depth_spacer : ""`).
+;
+; This test verifies that:
+;   1. Double-quoted option values in init files have their outer quotes
+;      stripped and \" sequences unescaped to ".
+;   2. The resulting format string is parsed correctly, including expressions
+;      that use "" (empty string literal).
+
+2024/01/01 Groceries
+    Expenses:Food    $50.00
+    Assets:Cash
+
+2024/01/15 Books
+    Expenses:Books   $25.00
+    Assets:Cash
+
+; Verify that \" inside a double-quoted init-file option value is unescaped.
+; The format uses the expression `!options.flat ? depth_spacer : ""` which
+; requires a literal double-quote inside the init-file quoted value.
+test bal --init-file $sourcepath/test/regress/1884.ledgerrc
+             $-75.00  Assets:Cash
+              $75.00  Expenses
+              $25.00    Books
+              $50.00    Food
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

Fixes #1884.

When users specify format options such as `--balance-format` in a `.ledgerrc`
init file, the value is read as raw text without any shell processing.
Multi-word values must therefore be wrapped in double quotes. However,
`option_directive()` previously passed the surrounding quotes through verbatim,
causing two problems:

1. The surrounding `"..."` appeared as literal `"` characters in the formatted output.
2. Escaped quotes `\"` inside format expressions (e.g. `depth_spacer : ""`)
   triggered `Error: Invalid char '\'` from the expression parser.

**Root cause:** `option_directive()` called `next_element()` to split the
line at the first whitespace and obtained the option value as a raw `char*`.
If the user wrote `--balance-format "some format"`, `p` pointed to
`"some format"` (outer quotes included), and this was passed as-is to
`process_option()`.

**Fix:** After extracting `p`, detect and process quoted strings:

- **Double-quoted values** – strip outer `"..."`, unescape `\"` → `"` and
  `\\` → `\`, but leave all other `\x` sequences (e.g. `\n`, `\t`) intact
  for the format parser to interpret.
- **Single-quoted values** – strip outer `'...'` with no escape processing
  (matching shell single-quote semantics).
- **Unquoted values** – no change to existing behavior.

Users can now write the exact format documented in the manual directly into
their init file:

```
--balance-format "%(justify(scrub(display_total), 20, -1, true, color))  %(!options.flat ? depth_spacer : \"\")%-(ansify_if(partial_account(options.flat), blue if color))\n%/%$1\n%/--------------------\n"
```

## Test plan

- [x] New regression test `test/regress/1884.test` exercises the exact format
      from the issue report via `--init-file`, verifying that `\"` inside a
      double-quoted init-file option value is correctly unescaped.
- [x] All 4065 existing tests pass.
- [x] Format-related tests (coverage-format-*.test, cov2-format-opts.test) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)