### PR TITLE
Fix negative Assets:Savings balance in drewr3.dat example journal

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -494,11 +494,9 @@ $ ledger -f drewr3.dat balance
 Ledger will generate:
 
 @smallexample @c output:1071890
-         $ -3,804.00  Assets
-          $ 1,396.00    Checking
-             $ 30.00      Business
-         $ -5,200.00    Savings
-         $ -1,000.00  Equity:Opening Balances
+          $ 1,396.00  Assets:Checking
+             $ 30.00    Business
+         $ -6,200.00  Equity:Opening Balances
           $ 6,654.00  Expenses
           $ 5,500.00    Auto
              $ 20.00    Books
@@ -527,16 +525,14 @@ $ ledger -f drewr3.dat balance Assets Liabilities
 @end smallexample
 
 @smallexample @c output:5BF4D8E
-         $ -3,804.00  Assets
-          $ 1,396.00    Checking
-             $ 30.00      Business
-         $ -5,200.00    Savings
+          $ 1,396.00  Assets:Checking
+             $ 30.00    Business
             $ -63.60  Liabilities
             $ -20.00    MasterCard
             $ 200.00    Mortgage:Principal
            $ -243.60    Tithe
 --------------------
-         $ -3,867.60
+          $ 1,332.40
 @end smallexample
 
 @node Register Report, Cleared Report, Balance Report, Run a Few Reports
@@ -555,7 +551,8 @@ Ledger will generate:
 
 @smallexample @c output:66E3A2C
 10-Dec-01 Checking balance      Assets:Checking          $ 1,000.00   $ 1,000.00
-                                Equit:Opening Balances  $ -1,000.00            0
+                                Assets:Savings           $ 5,200.00   $ 6,200.00
+                                Equit:Opening Balances  $ -6,200.00            0
 10-Dec-20 Organic Co-op         Expense:Food:Groceries      $ 37.50      $ 37.50
                                 Expense:Food:Groceries      $ 37.50      $ 75.00
                                 Expense:Food:Groceries      $ 37.50     $ 112.50
@@ -655,11 +652,11 @@ $ ledger -f drewr3.dat cleared
 @end smallexample
 
 @smallexample @c output:B86F6A6
-     $ -3,804.00            $ 775.00                 Assets
+      $ 1,396.00          $ 5,975.00                 Assets
       $ 1,396.00            $ 775.00    10-Dec-20      Checking
          $ 30.00                   0                     Business
-     $ -5,200.00                   0                   Savings
-     $ -1,000.00         $ -1,000.00    10-Dec-01    Equity:Opening Balances
+               0          $ 5,200.00    10-Dec-01      Savings
+     $ -6,200.00         $ -6,200.00    10-Dec-01    Equity:Opening Balances
       $ 6,654.00            $ 225.00                 Expenses
       $ 5,500.00                   0                   Auto
          $ 20.00                   0                   Books
@@ -4827,11 +4824,9 @@ $ ledger balance -f drewr3.dat
 which will print the balances of every account in your journal.
 
 @smallexample @c output:1D00D56
-         $ -3,804.00  Assets
-          $ 1,396.00    Checking
-             $ 30.00      Business
-         $ -5,200.00    Savings
-         $ -1,000.00  Equity:Opening Balances
+          $ 1,396.00  Assets:Checking
+             $ 30.00    Business
+         $ -6,200.00  Equity:Opening Balances
           $ 6,654.00  Expenses
           $ 5,500.00    Auto
              $ 20.00    Books
@@ -6823,11 +6818,9 @@ $ ledger -f drewr3.dat bal --no-total --master-account HUMBUG
 
 @smallexample @c output:A76BB56
                    0  HUMBUG
-         $ -3,804.00    Assets
-          $ 1,396.00      Checking
-             $ 30.00        Business
-         $ -5,200.00      Savings
-         $ -1,000.00    Equity:Opening Balances
+          $ 1,396.00    Assets:Checking
+             $ 30.00      Business
+         $ -6,200.00    Equity:Opening Balances
           $ 6,654.00    Expenses
           $ 5,500.00      Auto
              $ 20.00      Books
@@ -11519,6 +11512,7 @@ features, include automatic and virtual transactions,
 
 2010/12/01 * Checking balance
   Assets:Checking                   $1,000.00
+  Assets:Savings                    $5,200.00
   Equity:Opening Balances
 
 2010/12/20 * Organic Co-op

--- a/test/baseline/opt-cleared-format.test
+++ b/test/baseline/opt-cleared-format.test
@@ -1,9 +1,9 @@
 test cleared --file test/input/drewr3.dat --cleared-format "%-30(account) %15(get_at(total_expr, 0)) %15(get_at(total_expr, 1))\n%/"
-Assets                             $ -3,804.00        $ 775.00
+Assets                              $ 1,396.00      $ 5,975.00
 Assets:Checking                     $ 1,396.00        $ 775.00
 Assets:Checking:Business               $ 30.00               0
-Assets:Savings                     $ -5,200.00               0
-Equity:Opening Balances            $ -1,000.00     $ -1,000.00
+Assets:Savings                               0      $ 5,200.00
+Equity:Opening Balances            $ -6,200.00     $ -6,200.00
 Expenses                            $ 6,654.00        $ 225.00
 Expenses:Auto                       $ 5,500.00               0
 Expenses:Books                         $ 20.00               0

--- a/test/input/drewr3.dat
+++ b/test/input/drewr3.dat
@@ -13,6 +13,7 @@
 
 2010/12/01 * Checking balance
   Assets:Checking                   $1,000.00
+  Assets:Savings                    $5,200.00
   Equity:Opening Balances
 
 2010/12/20 * Organic Co-op

--- a/test/regress/coverage-include-directive.test
+++ b/test/regress/coverage-include-directive.test
@@ -3,10 +3,8 @@
 include ../input/drewr3.dat
 
 test bal Assets -> 0
-         $ -3,804.00  Assets
-          $ 1,396.00    Checking
-             $ 30.00      Business
-         $ -5,200.00    Savings
+          $ 1,396.00  Assets:Checking
+             $ 30.00    Business
 --------------------
-         $ -3,804.00
+          $ 1,396.00
 end test


### PR DESCRIPTION
## Summary

- The opening balance transaction in `test/input/drewr3.dat` only set up a starting balance for `Assets:Checking` but omitted `Assets:Savings`
- This caused `Assets:Savings` to show a negative balance (-$5,200) in reports, which is unrealistic and confusing to new users
- Added `Assets:Savings $5,200.00` to the `2010/12/01` opening balance transaction so that savings ends at $0 after the Jan 25 car purchase transfer

With the fix, the account narrative becomes coherent: the person saved $5,200, made one $300 monthly deposit (Jan 14), then transferred the full $5,500 to checking to cover the car purchase (Jan 25), leaving savings at zero.

## Changes

- `test/input/drewr3.dat`: Add `Assets:Savings $5,200.00` to opening balance
- `doc/ledger3.texi`: Update all affected output examples (balance, register, cleared, master-account HUMBUG, and the appendix copy of the file)
- `test/baseline/opt-cleared-format.test`: Update expected output
- `test/regress/coverage-include-directive.test`: Update expected output

## Test plan

- [x] All pre-commit hooks pass (cmake configure, build, 4000+ tests, doxygen, manual, nix build)
- [x] `coverage-include-directive` regression test passes
- [x] `opt-cleared-format` baseline test passes
- [x] Documentation examples validated by `DocTests.py`

Fixes #1890

🤖 Generated with [Claude Code](https://claude.com/claude-code)