### PR TITLE
Fix Python TypeError accessing boost::optional fields like note

### DIFF
--- a/src/pyutils.h
+++ b/src/pyutils.h
@@ -63,7 +63,44 @@ struct register_python_conversion {
 
 template <typename T>
 struct register_optional_to_python : public boost::noncopyable {
-  // Converters for std::optional<T> (used by C++17-migrated wrapper functions)
+  // Converters for boost::optional<T> (still used by members declared with
+  // unqualified `optional`, which resolves to boost::optional via
+  // `using namespace boost` in utils.h)
+  struct boost_optional_to_python {
+    static PyObject* convert(const boost::optional<T>& value) {
+      return boost::python::incref(value ? boost::python::to_python_value<T>()(*value)
+                                         : boost::python::detail::none());
+    }
+  };
+
+  struct boost_optional_from_python {
+    static void* convertible(PyObject* source) {
+      using namespace boost::python::converter;
+      if (source == Py_None)
+        return source;
+      const registration& converters(registered<T>::converters);
+      if (implicit_rvalue_convertible_from_python(source, converters)) {
+        rvalue_from_python_stage1_data data = rvalue_from_python_stage1(source, converters);
+        return data.convertible;
+      }
+      return nullptr;
+    }
+
+    static void construct(PyObject* source,
+                          boost::python::converter::rvalue_from_python_stage1_data* data) {
+      using namespace boost::python::converter;
+      const T value = typename boost::python::extract<T>(source);
+      void* storage = ((rvalue_from_python_storage<boost::optional<T>>*)data)->storage.bytes;
+      if (source == Py_None)
+        new (storage) boost::optional<T>();
+      else
+        new (storage) boost::optional<T>(value);
+      data->convertible = storage;
+    }
+  };
+
+  // Converters for std::optional<T> (used by explicitly migrated fields
+  // like xact_t::code and wrapper function return types)
   struct std_optional_to_python {
     static PyObject* convert(const std::optional<T>& value) {
       return boost::python::incref(value ? boost::python::to_python_value<T>()(*value)
@@ -98,6 +135,8 @@ struct register_optional_to_python : public boost::noncopyable {
   };
 
   explicit register_optional_to_python() {
+    register_python_conversion<boost::optional<T>, boost_optional_to_python,
+                               boost_optional_from_python>();
     register_python_conversion<std::optional<T>, std_optional_to_python,
                                std_optional_from_python>();
   }

--- a/test/regress/2929.py
+++ b/test/regress/2929.py
@@ -1,0 +1,23 @@
+import ledger
+
+# Regression test for GitHub issue #2929:
+# post.xact.note throws TypeError after migration to std::optional.
+#
+# The note field on item_t is declared as unqualified `optional<string>`,
+# which resolves to boost::optional<string> via `using namespace boost` in
+# utils.h.  The std::optional migration (7bff9ea6) replaced the
+# boost::optional Python converter with a std::optional converter, but did
+# not change the field type, so accessing `note` from Python raised:
+#   TypeError: No to_python (by-value) converter found for C++ type:
+#     boost::optional<std::string>
+
+session = ledger.Session()
+j = session.read_journal_from_string("""
+2025/01/15 Test transaction  ; a note
+    expenses:food      10 USD
+    assets:checking
+""")
+
+for xact in j:
+    for post in xact:
+        print(post.xact.note)

--- a/test/regress/2929_py.test
+++ b/test/regress/2929_py.test
@@ -1,0 +1,4 @@
+test python test/regress/2929.py
+ a note
+ a note
+end test


### PR DESCRIPTION
## Summary

- Restore `boost::optional<T>` Python converters that were removed during the `std::optional` migration (7bff9ea6)
- The migration replaced `boost::optional` converters with `std::optional` converters, but most data members (like `item_t::note`, `item_t::pos`, `item_t::_date`, etc.) still use unqualified `optional` which resolves to `boost::optional` via `using namespace boost` in `utils.h`
- `register_optional_to_python<T>` now registers converters for **both** `boost::optional<T>` and `std::optional<T>`, so all optional fields work regardless of which variant they use

## Test plan

- [x] New regression test `test/regress/2929_py.test` verifies `post.xact.note` is accessible from Python
- [x] All 4081 tests pass
- [x] Full pre-commit validation: cmake, build, ctest, doxygen, manual, nix build

Fixes #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)