### PR TITLE
Add regression test for issue #1094

### DIFF
--- a/test/regress/1094.test
+++ b/test/regress/1094.test
@@ -1,0 +1,25 @@
+; Multiple balance resets should not error about null amounts
+2014/12/28 Insert
+  Source
+  Target  2 Foo
+
+2014/12/28 Insert
+  Source
+  Target  1 Bar
+
+2014/12/29 Check
+  Target  = 2 Bar
+  Source
+
+2014/12/29 Check
+  Target  = 2 Foo
+  Source
+
+test balance
+              -2 Bar
+              -2 Foo  Source
+               2 Bar
+               2 Foo  Target
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Issue #1094 reported that multiple balance resets (using `= X` syntax on null postings) in separate transactions caused "Only one posting with null amount allowed per transaction"
- This has been fixed by prior commits; this PR adds a regression test to prevent future regressions
- The test verifies that two balance assignments (`= 2 Bar` and `= 2 Foo`) in separate transactions on the same account work correctly

## Test plan

- [x] Regression test `test/regress/1094.test` passes
- [x] Full test suite passes (4000+ tests via ctest)
- [x] Nix flake build passes

Fixes #1094

🤖 Generated with [Claude Code](https://claude.ai/code)