### PR TITLE
fix: apply default commodity to bare amounts in xact command

### DIFF
--- a/src/draft.cc
+++ b/src/draft.cc
@@ -63,6 +63,7 @@
 #include "post.h"
 #include "account.h"
 #include "journal.h"
+#include "pool.h"
 #include "session.h"
 #include "report.h"
 #include "lookup.h"
@@ -573,6 +574,20 @@ xact_t* draft_t::insert(journal_t& journal) {
 
         new_post->amount = new_post->amount.rounded();
         DEBUG("draft.xact", "Rounded posting amount to: " << new_post->amount);
+      }
+
+      // If the amount is still uncommoditized, apply the default
+      // commodity from the D directive so that the display format
+      // (precision, symbol) is preserved.
+      if (!new_post->amount.is_null() && !new_post->amount.has_commodity()) {
+        commodity_t* default_commodity = commodity_pool_t::current_pool->default_commodity;
+        if (default_commodity && *default_commodity) {
+          new_post->amount.set_commodity(*default_commodity);
+          DEBUG("draft.xact", "Applied default commodity: " << new_post->amount.commodity());
+
+          new_post->amount = new_post->amount.rounded();
+          DEBUG("draft.xact", "Rounded to default commodity precision: " << new_post->amount);
+        }
       }
 
       added->add_post(new_post.release());

--- a/test/regress/809.test
+++ b/test/regress/809.test
@@ -1,0 +1,15 @@
+; Regression test for bug #809
+; The xact command should apply the default commodity (D directive) to
+; bare amounts so that precision and symbol are preserved.
+
+D $1,000.00
+
+2012/07/18 Someone
+    Expenses:Food    $12.00
+    Assets:Cash
+
+test xact 2012/07/19 "New Payee" 12.00 Expenses:Food
+2012/07/19 New Payee
+    Expenses:Unknown                          $12.00
+    Expenses:Food
+end test


### PR DESCRIPTION
## Summary

- The `xact` command (used by Emacs `C-c C-a`) parsed bare amounts like `12.00` without applying the default commodity from the `D` directive. This caused precision to be lost on output (displaying `12` instead of `$12.00`).
- After applying the historical commodity from a matching transaction, now falls back to the journal's default commodity for any amounts that remain uncommoditized, preserving both the commodity symbol and its display precision.

## Test plan

- [x] Added regression test `test/regress/809.test` verifying bare amounts get the default commodity
- [x] All 4054 tests pass (including new regression test)
- [x] Nix flake build passes
- [x] Doxygen and manual generation pass

Fixes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)