### PR TITLE
test: add regression test for issue #1158

### DIFF
--- a/test/regress/1158.test
+++ b/test/regress/1158.test
@@ -1,0 +1,24 @@
+; Regression test for issue #1158
+; Automatic transactions on null-amount postings should fire for all
+; commodities when the posting balances multiple commodities.
+
+= /^Income:Capital/
+    Budget:Income:Capital  -1
+    Budget:Total  1
+
+2016/01/01 Sell
+    Assets:EUR  400 EUR
+    Assets:XBT  -1 XBT
+    Income:Capital
+
+test reg
+16-Jan-01 Sell                  Assets:EUR                  400 EUR      400 EUR
+                                Assets:XBT                   -1 XBT      400 EUR
+                                                                          -1 XBT
+                                Income:Capital             -400 EUR       -1 XBT
+                                Income:Capital                1 XBT            0
+                                Budget:Income:Capital       400 EUR      400 EUR
+                                Budget:Total               -400 EUR            0
+                                Budget:Income:Capital        -1 XBT       -1 XBT
+                                Budget:Total                  1 XBT            0
+end test


### PR DESCRIPTION
## Summary

- Adds regression test confirming that automatic transactions on null-amount postings correctly fire for **all** commodities when the posting balances multiple commodities
- The underlying bug (auto txns only triggering for one commodity) has already been fixed in a prior commit; this PR adds test coverage to prevent regressions

Fixes #1158

## Test plan

- [x] New regression test `test/regress/1158.test` passes
- [x] Full test suite (4000+ tests) passes
- [x] Nix flake build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)