### PR TITLE
test: add regression test for issue #1179

### DIFF
--- a/test/regress/1179.test
+++ b/test/regress/1179.test
@@ -1,0 +1,18 @@
+; Regression test for issue #1179
+; --daily --average should divide running total by number of periods,
+; not by number of postings across all accounts.
+
+2016/08/01
+    A:B         10.00
+    Equity
+
+2016/08/02
+    A:B         10.00
+    A:B:C        1.00
+    Equity
+
+test reg --columns 80 --daily --average A:B
+16-Aug-01 - 16-Aug-01           A:B                              10           10
+16-Aug-02 - 16-Aug-02           A:B                              10           10
+                                A:B:C                             1          0.5
+end test


### PR DESCRIPTION
## Summary
- Add regression test validating that `--daily --average` divides running totals by the number of time periods, not by the number of postings across all accounts
- The underlying bug was fixed in a prior commit; this test prevents regression

## Test plan
- [x] Regression test `test/regress/1179.test` passes via `ctest -R 1179`
- [x] Full test suite passes (4000+ tests via pre-commit hooks)

Fixes #1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)