### PR TITLE
test: add regression test for balance assignment no-op (#1140)

### DIFF
--- a/test/regress/1140.test
+++ b/test/regress/1140.test
@@ -1,0 +1,29 @@
+; Balance assignment should be a no-op when the account already has the
+; target balance, and the transaction must still balance correctly.
+2014/01/01  Opening Balances
+  Expenses:Food  1.00
+  Expenses:Rent  2.00
+  Expenses:Auto  0.00
+  Equity:Opening Balances
+
+2014/12/31  Closing Balances
+  Expenses:Food  =2.00
+  Expenses:Rent  =2.00
+  Expenses:Auto  =2.00
+  Equity:Retained Earnings
+
+test bal Expenses
+                   6  Expenses
+                   2    Auto
+                   2    Food
+                   2    Rent
+--------------------
+                   6
+end test
+
+test reg Expenses
+14-Jan-01 Opening Balances      Expenses:Food                     1            1
+                                Expenses:Rent                     2            3
+14-Dec-31 Closing Balances      Expenses:Food                     1            4
+                                Expenses:Auto                     2            6
+end test


### PR DESCRIPTION
## Summary

- Adds a regression test for issue #1140 where balance assignments produced incorrect results when the target account already had the assigned balance
- The bug has been fixed in a prior commit; this test guards against future regressions
- Test verifies both `bal` and `reg` output for a scenario with balance assignments that are no-ops (account already at target) and ones that require adjustment

## Test plan

- [x] New regression test `test/regress/1140.test` passes (2 sub-tests: `bal Expenses` and `reg Expenses`)
- [x] Full test suite passes (4054/4054 tests)
- [x] Build succeeds with no warnings

Fixes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)