### PR TITLE
test: add regression test for -M with --group-by (#1162)

### DIFF
--- a/test/regress/1162.test
+++ b/test/regress/1162.test
@@ -1,0 +1,39 @@
+; Regression test for issue #1162
+; -M should work properly with --group-by, showing each group's
+; monthly subtotals independently without cross-contamination.
+
+2024/01/15 Grocery Store
+    Expenses:Food    $50.00
+    Assets:Checking
+
+2024/01/20 Gas Station
+    Expenses:Gas     $30.00
+    Assets:Checking
+
+2024/02/10 Grocery Store
+    Expenses:Food    $60.00
+    Assets:Checking
+
+2024/02/15 Gas Station
+    Expenses:Gas     $25.00
+    Assets:Checking
+
+2024/03/05 Grocery Store
+    Expenses:Food    $45.00
+    Assets:Checking
+
+2024/03/20 Gas Station
+    Expenses:Gas     $35.00
+    Assets:Checking
+
+test reg expenses -M --group-by account
+Expenses:Food
+24-Jan-01 - 24-Jan-31           Expenses:Food                $50.00       $50.00
+24-Feb-01 - 24-Feb-29           Expenses:Food                $60.00      $110.00
+24-Mar-01 - 24-Mar-31           Expenses:Food                $45.00      $155.00
+
+Expenses:Gas
+24-Jan-01 - 24-Jan-31           Expenses:Gas                 $30.00       $30.00
+24-Feb-01 - 24-Feb-29           Expenses:Gas                 $25.00       $55.00
+24-Mar-01 - 24-Mar-31           Expenses:Gas                 $35.00       $90.00
+end test


### PR DESCRIPTION
## Summary

- Adds a dedicated regression test for issue #1162 where `-M` (monthly grouping) did not work properly with `--group-by`
- The underlying bug (monthly interval posts leaking between group-by groups) was already fixed in cee6fce5 as part of #2511
- This test confirms the fix and prevents future regressions

## Test plan

- [x] New regression test `test/regress/1162.test` passes
- [x] Existing related test `test/regress/2511.test` still passes
- [x] Full test suite (4083 tests) passes
- [x] Nix flake build succeeds

Fixes #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)