### PR TITLE
test: add regression test for issue #1137

### DIFF
--- a/test/regress/1137.test
+++ b/test/regress/1137.test
@@ -1,0 +1,34 @@
+; Balance assignment that results in zero change should not error.
+; When a balance assignment computes a zero diff (the account is already
+; at the target balance), ledger must not treat the posting as null and
+; must not produce "Only one posting with null amount allowed per
+; transaction".
+1/1 A
+    a  10 p
+    z
+
+1/2 B
+    a  = 0 p
+    b
+
+1/3 C
+    a  = 0 p
+    c
+
+test bal --empty
+                 0 p  a
+                10 p  b
+                 0 p  c
+               -10 p  z
+--------------------
+                   0
+end test
+
+test reg --empty
+26-Jan-01 A                     a                              10 p         10 p
+                                z                             -10 p            0
+26-Jan-02 B                     a                             -10 p        -10 p
+                                b                              10 p            0
+26-Jan-03 C                     a                                 0            0
+                                c                                 0            0
+end test


### PR DESCRIPTION
## Summary
- Adds regression test for issue #1137: balance assignment that results in zero change
- The fix (assigning `amt - amt` to preserve the commodity instead of leaving the posting null) is already in `textual_xacts.cc`; this adds the missing test coverage
- Tests both `bal --empty` and `reg --empty` to verify zero-diff balance assignments work correctly

## Test plan
- [x] Regression test `test/regress/1137.test` passes (2 test blocks)
- [x] Full test suite passes (4054/4054 tests)
- [x] `nix build .` succeeds

Fixes #1137

🤖 Generated with [Claude Code](https://claude.ai/code)