### PR TITLE
Fix forecast with future-start periodic transactions (#591)

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1840,8 +1840,19 @@ void budget_posts::flush() {
  */
 void forecast_posts::add_post(const date_interval_t& period, post_t& post) {
   date_interval_t i(period);
-  if (!i.start && !i.find_period(CURRENT_DATE()))
-    return;
+  if (!i.start && !i.find_period(CURRENT_DATE())) {
+    // find_period failed, but stabilize() (called inside) may have set
+    // i.start to a future date.  If so, the interval is valid for
+    // forecasting.  Step back one period so that flush() generates a
+    // posting at the original start date (via next).
+    if (!i.start || !i.duration || *i.start <= CURRENT_DATE())
+      return;
+    date_t future_start = *i.start;
+    i.start = i.duration->subtract(future_start);
+    i.end_of_duration = none;
+    i.next = none;
+    i.resolve_end();
+  }
 
   generate_posts::add_post(i, post);
 

--- a/test/regress/591.test
+++ b/test/regress/591.test
@@ -1,0 +1,19 @@
+; Forecast with future start date should generate entries (BZ#591)
+; When a periodic transaction's start date is in the future relative to
+; the current date, forecast should still produce entries beginning at
+; that future start date.
+
+~ every 14 days from 2026/04/01
+    Expenses:Bills    $100.00
+    Assets:Checking
+
+test reg --now=2026/03/15 --forecast-while "d<[2026/05/15]"
+26-Apr-01 Forecast transaction  Expenses:Bills              $100.00      $100.00
+26-Apr-01 Forecast transaction  Assets:Checking            $-100.00            0
+26-Apr-15 Forecast transaction  Expenses:Bills              $100.00      $100.00
+26-Apr-15 Forecast transaction  Assets:Checking            $-100.00            0
+26-Apr-29 Forecast transaction  Expenses:Bills              $100.00      $100.00
+26-Apr-29 Forecast transaction  Assets:Checking            $-100.00            0
+26-May-13 Forecast transaction  Expenses:Bills              $100.00      $100.00
+26-May-13 Forecast transaction  Assets:Checking            $-100.00            0
+end test


### PR DESCRIPTION
## Summary

- When a periodic transaction's start date is in the future (e.g. `~ every 14 days from 2026/04/01` with `--now=2026/03/15`), `forecast_posts::add_post()` silently discarded it because `find_period(CURRENT_DATE())` returned false
- Fix detects this case: after `find_period` fails, if `stabilize()` set `start` to a future date, step the interval back one period so `flush()` generates its first posting at the original start date
- Added regression test `test/regress/591.test` verifying future-start forecast output

## Test plan

- [x] New regression test `591.test` passes with the fix
- [x] All 4064 existing tests pass (`ctest --output-on-failure`)
- [x] Existing forecast tests (`370-forecast_period_days.test`, `opt-forecast-basic.test`) unaffected

Fixes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)