### PR TITLE
Fix forecast to respect future from/since dates

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1832,16 +1832,33 @@ void budget_posts::flush() {
 }
 
 /**
- * Add a periodic posting for forecasting, advancing its interval to CURRENT_DATE.
+ * Add a periodic posting for forecasting, initializing its interval.
  *
  * Unlike generate_posts::add_post, this override initializes the interval
- * and advances it past all historical periods so that only future occurrences
- * are generated during flush().
+ * via find_period so that only future occurrences are generated during
+ * flush().  If the period has a 'from'/'since' date in the future, the
+ * interval is adjusted so that forecasting begins at that date rather
+ * than being silently dropped (#1044).
  */
 void forecast_posts::add_post(const date_interval_t& period, post_t& post) {
   date_interval_t i(period);
-  if (!i.start && !i.find_period(CURRENT_DATE()))
-    return;
+  if (!i.start) {
+    if (!i.find_period(CURRENT_DATE())) {
+      // find_period failed.  If it's because CURRENT_DATE is before the
+      // period's 'from'/'since' date, stabilize() will have set start
+      // to the future range begin.  Back up one period so that flush()
+      // — which uses 'next' as the first forecast date — generates a
+      // posting at that date (#1044).  If start is not in the future
+      // (period expired or otherwise invalid), give up.
+      if (!i.start || !i.duration || *i.start <= CURRENT_DATE())
+        return;
+      date_t future_start = *i.start;
+      i.start = i.duration->subtract(future_start);
+      i.end_of_duration = none;
+      i.next = none;
+      i.resolve_end();
+    }
+  }
 
   generate_posts::add_post(i, post);
 

--- a/test/regress/1044.test
+++ b/test/regress/1044.test
@@ -1,0 +1,15 @@
+; Forecast should respect 'from'/'since' in periodic transactions even
+; when --now is before the 'from' date (BZ#1044).
+
+~ Monthly from 2024/06/01
+    Expenses:Rent             $1000.00
+    Assets:Checking
+
+test reg --forecast-while "date < [2024/09/01]" --now "2024/03/15" -> 0
+24-Jun-01 Forecast transaction  Expenses:Rent              $1000.00     $1000.00
+24-Jun-01 Forecast transaction  Assets:Checking           $-1000.00            0
+24-Jul-01 Forecast transaction  Expenses:Rent              $1000.00     $1000.00
+24-Jul-01 Forecast transaction  Assets:Checking           $-1000.00            0
+24-Aug-01 Forecast transaction  Expenses:Rent              $1000.00     $1000.00
+24-Aug-01 Forecast transaction  Assets:Checking           $-1000.00            0
+end test


### PR DESCRIPTION
## Summary

- Fix `forecast_posts::add_post()` to handle periodic transactions with `from`/`since` dates in the future relative to `CURRENT_DATE` (or `--now`)
- Previously, `find_period(CURRENT_DATE())` returned false for future-dated periods, silently dropping them from forecast output
- The fix detects future periods vs expired periods and adjusts the interval so `flush()` generates postings starting at the `from`/`since` date
- Added regression test `test/regress/1044.test`

Fixes #1044

## Test plan

- [x] Regression test `1044.test` verifies forecast with `--now` before `from` date generates correct output
- [x] All 4064 existing tests pass (including 15 forecast-specific tests)
- [x] Coverage test `cov-forecast-expired.test` confirms expired periods are still correctly skipped
- [x] Full nix build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)