### PR TITLE
Fix forecast for future periodic transactions

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1840,8 +1840,16 @@ void budget_posts::flush() {
  */
 void forecast_posts::add_post(const date_interval_t& period, post_t& post) {
   date_interval_t i(period);
-  if (!i.start && !i.find_period(CURRENT_DATE()))
-    return;
+  if (!i.start && !i.find_period(CURRENT_DATE())) {
+    // find_period fails when CURRENT_DATE is outside the interval.
+    // There are two distinct cases:
+    //  (a) The period starts in the future — keep the posting so
+    //      flush() generates it when the time comes.
+    //  (b) The period has expired (finish <= CURRENT_DATE) or could
+    //      not be initialized — drop it.
+    if (!i.start || (i.finish && CURRENT_DATE() >= *i.finish))
+      return;
+  }
 
   generate_posts::add_post(i, post);
 

--- a/src/times.cc
+++ b/src/times.cc
@@ -1834,10 +1834,21 @@ void date_interval_t::stabilize(const optional<date_t>& date, bool align_interva
 
       // Phase 3: Clamp to the original range boundaries
       if (initial_start && (!start || *start < *initial_start)) {
-        // Using the discovered start, find the end of the period
+        // Compute end_of_duration from the quantum-aligned start before
+        // clamping, so that weekly/monthly periods keep their natural
+        // period boundary.
         resolve_end();
 
         start = initial_start;
+
+        // If end_of_duration (computed from the old start) is no longer
+        // past the clamped start, it is stale and must be recomputed.
+        // This happens for daily periods where the old start was before
+        // initial_start (e.g. --now is before the "from" date).
+        if (end_of_duration && *end_of_duration <= *start) {
+          end_of_duration = none;
+          next = none;
+        }
         DEBUG("times.interval", "stabilize: start reset to initial start");
       }
       if (initial_finish && (!finish || *finish > *initial_finish)) {

--- a/test/regress/1161.test
+++ b/test/regress/1161.test
@@ -1,0 +1,22 @@
+; Forecast with --now before periodic transaction start date (Bug #1161)
+;
+; When --now is set to a date before the periodic transaction's "from"
+; date, forecast postings should still be generated.
+
+2016/4/8
+    E               50
+    Cash
+
+~ daily from 2016/4/8 to 2016/4/9
+    E              100
+    Cash          -100
+
+test reg --forecast "d<=[2017/3/1]" cash --now 2016/4/7
+16-Apr-08 <Unspecified payee>   Cash                            -50          -50
+16-Apr-09 Forecast transaction  Cash                           -100         -150
+end test
+
+test reg --forecast "d<=[2017/3/1]" cash --now 2016/4/8
+16-Apr-08 <Unspecified payee>   Cash                            -50          -50
+16-Apr-09 Forecast transaction  Cash                           -100         -150
+end test


### PR DESCRIPTION
## Summary
- Fix `--forecast` not generating postings when `--now` is before a periodic transaction's `from` date
- `forecast_posts::add_post()` now distinguishes future periods (kept) from expired periods (dropped)
- `date_interval_t::stabilize()` Phase 3 recomputes stale `end_of_duration` after clamping start to `initial_start`
- Adds regression test for issue #1161

## Details

When `--now` is set to a date before a periodic transaction's "from" date (e.g., `--now 2016/4/7` with `~ daily from 2016/4/8 to 2016/4/9`), forecast postings were silently dropped. Two root causes:

1. **`forecast_posts::add_post()`** unconditionally returned early when `find_period(CURRENT_DATE)` failed, but `find_period` fails for both future periods (start > CURRENT_DATE) and expired periods (finish <= CURRENT_DATE). Only expired periods should be dropped.

2. **`date_interval_t::stabilize()` Phase 3** left `end_of_duration` stale after clamping `start` to `initial_start`. For daily periods where `--now < from_date`, the pre-clamped `end_of_duration` ended up at or before the new start, causing assertion failures.

## Test plan
- [x] New regression test `test/regress/1161.test` verifies both `--now` before and at the period start produce identical forecast output
- [x] All 4064 existing tests pass (including `cov-forecast-expired` for expired period handling)
- [x] Nix flake build passes

Fixes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)