### PR TITLE
Fix automated transactions not respecting effective dates

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -1387,6 +1387,15 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context) {
           // the automated xact's one.
           auto new_post = std::make_unique<post_t>(account, amt);
           new_post->copy_details(*post);
+
+          // Propagate the matched posting's date overrides to the
+          // generated posting so that auto-generated postings respect
+          // effective dates and posting-level date overrides.
+          if (!post->_date && initial_post->_date)
+            new_post->_date = initial_post->_date;
+          if (!post->_date_aux && initial_post->_date_aux)
+            new_post->_date_aux = initial_post->_date_aux;
+
           if (post->cost)
             new_post->cost = post->cost;
           else if (initial_post->cost && amt.has_annotation() && amt.annotation().price) {

--- a/test/regress/1811.test
+++ b/test/regress/1811.test
@@ -1,0 +1,18 @@
+= /Expenses:Eating Out/
+    [Budget:Eating Out]                           -1
+    [Assets:Checking]                              1
+
+2019-07-18 jones
+    Expenses:Eating Out                          $20 ; [=2019/07/19]
+    Expenses:Eating Out                          $20 ; [=2019/07/20]
+    Assets:Checking
+
+test reg --effective --sort date
+19-Jul-18 jones                 Assets:Checking                $-40         $-40
+19-Jul-19 jones                 Expenses:Eating Out             $20         $-20
+                                [Budget:Eating Out]            $-20         $-40
+                                [Assets:Checking]               $20         $-20
+19-Jul-20 jones                 Expenses:Eating Out             $20            0
+                                [Budget:Eating Out]            $-20         $-20
+                                [Assets:Checking]               $20            0
+end test


### PR DESCRIPTION
## Summary

- When a posting with a posting-level effective date (e.g., `[=2019/07/19]`) matches an automated transaction rule, the generated postings now inherit that effective date
- Previously, `copy_details()` only copied dates from the template posting (which has none), so auto-generated postings fell back to the transaction date, causing them to appear on the wrong date in `--effective` reports
- Added regression test verifying correct date propagation with `reg --effective --sort date`

Fixes #1811

## Test plan

- [x] New regression test `test/regress/1811.test` passes
- [x] Full test suite (4063 tests) passes with zero failures
- [x] Nix flake build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)