### PR TITLE
Document account date checks for closing accounts (#1643)

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -2331,6 +2331,20 @@ The @code{check} and @code{assert} directives warn or raise an error
 (respectively) if the given value expression evaluates to false within
 the context of any posting.
 
+While Ledger does not have explicit open/close directives for
+accounts, you can use @code{check} or @code{assert} to enforce date
+ranges, effectively ``closing'' an account after a certain date:
+
+@smallexample @c input:validate
+account Expenses:Food
+    check date >= [2016-02-03]
+    check date <= [2017-03-03]
+@end smallexample
+
+With the above, any posting to @samp{Expenses:Food} outside the given
+date range will produce a warning.  Use @code{assert} instead of
+@code{check} to make it a hard error.
+
 The @code{eval} directive evaluates the value expression in the
 context of the account at the time of definition.  At the moment this
 has little value.

--- a/test/regress/1643.test
+++ b/test/regress/1643.test
@@ -1,0 +1,25 @@
+; Regression test for issue #1643: Use check/assert on account directives
+; to enforce date ranges, effectively "closing" an account.
+
+account Expenses:Food
+    check date >= [2016-02-03]
+    check date <= [2017-03-03]
+
+; This transaction is within the valid date range (no warning).
+2016/06/15 Grocery Store
+    Expenses:Food    $50.00
+    Assets:Cash
+
+; This transaction is outside the valid date range (warning).
+2018/01/01 Grocery Store
+    Expenses:Food    $25.00
+    Assets:Cash
+
+test bal
+             $-75.00  Assets:Cash
+              $75.00  Expenses:Food
+--------------------
+                   0
+__ERROR__
+Warning: "$FILE", line 16: Transaction check failed: (date <= [2017/03/03])
+end test


### PR DESCRIPTION
## Summary

- Add documentation to the manual showing how to use `check`/`assert` sub-directives on `account` directives to enforce date ranges, effectively simulating account open/close dates
- Add regression test (`test/regress/1643.test`) demonstrating both valid and out-of-range transactions with account date checks

While Ledger doesn't have explicit open/close directives, users can enforce date ranges on accounts using:

```
account Expenses:Food
    check date >= [2016-02-03]
    check date <= [2017-03-03]
```

Postings outside the range produce a warning (`check`) or error (`assert`).

Fixes #1643

## Test plan

- [x] New regression test `1643.test` passes
- [x] All 4083 existing tests pass
- [x] Nix flake build passes
- [x] Documentation builds successfully (doxygen + manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)