### PR TITLE
Fix docs: remove stale Equity:Capital Losses claim

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -1970,15 +1970,17 @@ both exist, you ask?  To support things like this:
 
 @smallexample @c input:validate
 2009/01/01 Shell
-    Expenses:Gasoline             11 GAL @{=$2.299@} @@ $2.30
+    Expenses:Gasoline             11 GAL @{=$2.299@} @@ $25.30
     Assets:Checking
 @end smallexample
 
 This transaction says that you bought 11 gallons priced at $2.299 per
-gallon at a @emph{cost to you} of $2.30 per gallon.  Ledger
-auto-generates a balance posting in this case to Equity:Capital Losses
-to reflect the 1.1 cent difference, which is then balanced by
-Assets:Checking because its amount is null.
+gallon at a @emph{cost to you} of $25.30 in total.  Since the fixed lot
+price totals $25.289 (11 x $2.299) while the actual cost
+is $25.30, Ledger adjusts the cost to match the fixed lot price so
+that the transaction balances.  The 1.1 cent difference is absorbed
+into the cost, so Assets:Checking will reflect $25.289 rather than
+$25.30.
 
 @node Complete control over commodity pricing,  , Fixing Lot Prices, Currency and Commodities
 @subsection Complete control over commodity pricing

--- a/test/regress/1773.test
+++ b/test/regress/1773.test
@@ -1,0 +1,18 @@
+; Fixed lot price with different total cost should not generate
+; an Equity:Capital Losses posting.  The gain/loss difference is
+; absorbed into the cost instead.
+
+2009/01/01 Shell
+    Expenses:Gasoline             11 GAL {=$2.299} @@ $25.30
+    Assets:Checking
+
+test bal
+            $-25.289  Assets:Checking
+              11 GAL  Expenses:Gasoline
+--------------------
+            $-25.289
+              11 GAL
+end test
+
+test bal Equity
+end test


### PR DESCRIPTION
## Summary

- Fix documentation in `ledger3.texi` that incorrectly claims Ledger auto-generates `Equity:Capital Losses` postings when a fixed lot price differs from the actual cost. This code was disabled long ago (`#if 0` in `xact.cc`); the current behavior absorbs the gain/loss difference into the cost.
- Fix the example amount from `@@ $2.30` to `@@ $25.30` to match the prose description of 11 gallons.
- Add regression test `test/regress/1773.test` verifying no Equity account is created.

Fixes #1773

## Test plan

- [x] New regression test passes (2 test blocks: `bal` and `bal Equity`)
- [x] Full test suite passes (4082/4082 tests)
- [x] Nix flake build passes
- [x] Doxygen and manual build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)