### PR TITLE
Fix --effective balance assertions for posts without aux dates

### DIFF
--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -391,11 +391,13 @@ static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t*
                                       bool strip_annotations, parse_context_t& context) {
   bool real_only = !post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG);
   value_t account_total;
-  if (item_t::use_aux_date) {
-    // When using effective dates, only count posts whose effective date is on
-    // or before the current posting's effective date, so that balance
-    // assertions respect --effective ordering rather than file order
-    // (fixes #2071).
+  if (item_t::use_aux_date && post->aux_date()) {
+    // When using effective dates and the current posting has an explicit
+    // effective date, only count posts whose effective date is on or before
+    // the current posting's effective date, so that balance assertions
+    // respect --effective ordering rather than file order (fixes #2071).
+    // Only apply this filtering when the posting itself has an aux date;
+    // postings without aux dates use file-order accumulation (fixes #2966).
     date_t cutoff = post->date();
     std::set<const post_t*> seen;
     for (const post_t* p : post->account->posts) {

--- a/test/regress/2966.test
+++ b/test/regress/2966.test
@@ -1,0 +1,30 @@
+; Regression test for issue #2966: balance assertions fail in --effective mode
+; when transactions with effective dates are followed by transactions without.
+;
+; The second transaction has an effective date of 2024/10/01 (via the xact
+; header "2024/09/25=2024/10/01").  The third transaction has no effective
+; date (2024/09/30).  Without the fix, compute_balance_diff() excluded the
+; second transaction's posting from the account total when checking the third
+; transaction's balance assertion, because 10/01 > 09/30 in effective-date
+; ordering.  The fix restricts effective-date filtering to postings that
+; themselves have an explicit effective date.
+
+2024/09/13 * Cafe
+    Expenses:Dining                          $5
+    Liabilities:CreditCard
+
+2024/09/25=2024/10/01 * Visa
+    Liabilities:CreditCard                   $5 = $0
+    Assets:Checking
+
+2024/09/30 * Cafe
+    Expenses:Dining                          $5
+    Liabilities:CreditCard                  -$5 = -$5
+
+test bal --effective
+                 $-5  Assets:Checking
+                 $10  Expenses:Dining
+                 $-5  Liabilities:CreditCard
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Fix regression from #2071 where `--effective` broke balance assertions on postings that lack an explicit effective date
- Restrict effective-date-filtered balance computation in `compute_balance_diff()` to postings that themselves have an aux date (either directly or inherited from their parent transaction)
- Postings without aux dates now use file-order accumulation as before

## Details

The #2071 fix filtered account posts by effective date when `use_aux_date` was globally set. This caused postings with later effective dates to be excluded from the account total when checking assertions on postings without effective dates, producing incorrect balance assertion failures.

The fix changes the condition in `compute_balance_diff()` from `item_t::use_aux_date` to `item_t::use_aux_date && post->aux_date()`, so the date-filtered path is only taken when the posting being checked actually has an effective date.

Fixes #2966.

## Test plan

- [ ] New regression test `test/regress/2966.test` reproduces the exact scenario from the issue
- [ ] Existing `test/regress/2071.test` continues to pass (effective-date assertions with inline `[=date]` notes)
- [ ] Full test suite passes (4083 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)