### PR TITLE
Support inline alias in payee directive

### DIFF
--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -627,7 +627,11 @@ void instance_t::account_value_directive(account_t* account, const string& expr_
 /*--- Payee Directives ---*/
 
 void instance_t::payee_directive(char* line) {
+  char* alias = next_element(line, true);
   string payee = context.journal->register_payee(line);
+
+  if (alias)
+    payee_alias_directive(payee, alias);
 
   while (peek_whitespace_line()) {
     read_line(line);

--- a/test/regress/767.test
+++ b/test/regress/767.test
@@ -1,0 +1,27 @@
+; Regression test for issue #767
+; payee directive supports inline alias on the same line,
+; separated by double space or tab.
+
+payee Amazon.com  B.*k Store
+payee BestBuy	Best.*Buy
+
+2024/01/15 Book Store Online
+    Expenses:Books    $25.00
+    Assets:Cash
+
+2024/01/20 BestBuy Electronics
+    Expenses:Electronics    $50.00
+    Assets:Cash
+
+2024/01/25 Grocery Store
+    Expenses:Food    $15.00
+    Assets:Cash
+
+test reg --format "%(payee)\n"
+Amazon.com
+Amazon.com
+BestBuy
+BestBuy
+Grocery Store
+Grocery Store
+end test


### PR DESCRIPTION
## Summary

- The `payee` directive now accepts an optional alias regex on the same line, separated by double space or tab
- `payee Amazon.com  B.*k Store` is now equivalent to writing `payee Amazon.com` followed by an indented `alias B.*k Store`
- Uses `next_element(line, true)` to split the payee name from the inline alias, consistent with how other directives handle variable-width fields

Fixes #767

## Test plan

- [x] New regression test `test/regress/767.test` verifies double-space and tab-separated inline aliases
- [x] Test includes non-matching payee to confirm no false positives
- [x] All 4083 existing tests pass
- [x] Full validation: cmake + build + ctest + doxygen + manual + nix build

🤖 Generated with [Claude Code](https://claude.com/claude-code)