### PR TITLE
Fix ansify_if documentation to show correct 2-arg signature

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -1262,17 +1262,18 @@ Return the amount of the posting.
 Return the calculated amount of the posting according to the
 .Fl \-amount
 option.
-.It Fn ansify_if value color bool
+.It Fn ansify_if value color
 Render the given
 .Ar value
 as a string, applying the proper ANSI escape codes to display it in the given
+.Ar color .
+If
 .Ar color
-if
-.Ar bool
-is true.  It typically checks the value of the option
-.Fl \-color ,
-for example:
-.Dl Li ansify_if(amount, "blue", options.color)
+is not provided, the value is returned unchanged.  The condition is
+typically embedded in the color argument using an
+.Li if
+expression, for example:
+.Dl Li ansify_if(amount, blue if options.color)
 .It Sy beg_line
 Line number where entry for posting begins.
 .It Sy beg_pos

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -9485,16 +9485,19 @@ Return the calculated amount of the posting according to the @option{--amount}
 option.
 @end defun
 
-@defun ansify_if value color bool
-Render the given @var{expression} as a string, applying the proper ANSI escape
-codes to display it in the given @var{color} if @var{bool} is true.  It
-typically checks the value of the option @option{--color}.  Since ANSI escape
-codes include non-printable character sequences, such as escape @kbd{^[}
-the following example may not appear as the final result on the command-line.
-@smallexample @c command:4D836EE,with_input:3406FC1
-$ ledger -f expr.dat --format "%(ansify_if(account, blue, options.color))\n" reg
+@defun ansify_if value color
+Render the given @var{value} as a string, applying the proper ANSI escape
+codes to display it in the given @var{color}.  If @var{color} is not
+provided, the value is returned unchanged.  The condition is typically
+embedded in the color argument using an @code{if} expression, e.g.,
+@code{blue if color}, which checks the value of the option
+@option{--color}.  Since ANSI escape codes include non-printable character
+sequences, such as escape @kbd{^[} the following example may not appear
+as the final result on the command-line.
+@smallexample @c command:51FA103,with_input:3406FC1
+$ ledger -f expr.dat --format "%(ansify_if(account, blue))\n" reg
 @end smallexample
-@smallexample @c output:4D836EE
+@smallexample @c output:51FA103
 [34mAssets:Cash[0m
 [34mExpenses:Office Supplies[0m
 @end smallexample

--- a/test/regress/1741.test
+++ b/test/regress/1741.test
@@ -1,0 +1,17 @@
+; Regression test for issue #1741
+; ansify_if takes two arguments (value, color), not three.
+; The condition is embedded in the color argument using "X if Y" syntax.
+
+2024/01/01 Test
+    Expenses:Food    $10.00
+    Assets:Cash
+
+; Two-argument form with conditional color (the correct documented usage)
+test reg --force-color --format "%(ansify_if(account, blue if options.color))\n" Expenses
+[34mExpenses:Food[0m
+end test
+
+; When condition is false, no color is applied
+test reg --format "%(ansify_if(account, blue if 0))\n" Expenses
+Expenses:Food
+end test


### PR DESCRIPTION
## Summary
- Fix documentation for `ansify_if` function which was incorrectly documented as taking 3 arguments (value, color, bool) when it actually takes 2 (value, color)
- The boolean condition is embedded in the color argument using `X if Y` expression syntax (e.g., `blue if options.color`), not passed as a separate parameter
- Updated both `doc/ledger3.texi` and `doc/ledger.1` with correct signature, description, and examples
- Added regression test `test/regress/1741.test` verifying both the color-applied and color-suppressed cases

Fixes #1741

## Test plan
- [x] Regression test with `--force-color` confirms ANSI codes are emitted for `ansify_if(account, blue if options.color)`
- [x] Regression test without `--force-color` confirms no ANSI codes for `ansify_if(account, blue if 0)`
- [x] Full test suite passes (4112 tests via ctest)
- [x] Doctest hash updated to match new example text
- [x] Nix flake build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)