### PR TITLE
Add regression test for issue #1083

### DIFF
--- a/test/regress/1083.test
+++ b/test/regress/1083.test
@@ -1,0 +1,30 @@
+; Regression test for issue #1083
+; Verify that --pedantic and --strict correctly detect undeclared
+; accounts containing special characters like '&', without needing
+; --explicit (which is now a no-op since its behavior is the default).
+
+account A
+account C
+
+2014-09-30 * Test
+    A&B                  10 USD
+    C
+
+test bal --pedantic -> 1
+__ERROR__
+While parsing file "$FILE", line 10:
+While parsing posting:
+  A&B                  10 USD
+
+Error: Unknown account 'A&B'
+end test
+
+test bal --strict
+              10 USD  A&B
+             -10 USD  C
+--------------------
+                   0
+__ERROR__
+Warning: "$FILE", line 10: Unknown account 'A&B'
+Warning: "$FILE", line 10: Unknown commodity 'USD'
+end test


### PR DESCRIPTION
## Summary

- Issue #1083 reported that `--explicit` was not documented (docs only said "FIX THIS ENTRY")
- The `--explicit` option was made a no-op in v3.2.0 (commit 43b07fba, PR #1819) because its behavior — requiring accounts to be predeclared before use — became the default
- The documentation placeholder was removed in that same commit
- Adds a regression test confirming that `--pedantic` and `--strict` correctly detect undeclared accounts containing special characters (like `&`) without needing `--explicit`

Fixes #1083

## Test plan

- [x] New regression test `test/regress/1083.test` passes (2 test cases: `--pedantic` exits with error, `--strict` emits warnings)
- [x] All 4112 existing tests pass
- [x] Nix flake build succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)