### PR TITLE
Add regression test for --depth register collapse (#987)

### DIFF
--- a/test/regress/987.test
+++ b/test/regress/987.test
@@ -1,0 +1,27 @@
+; Regression test for issue #987
+; --depth in register should collapse sub-accounts and accumulate amounts
+; into the parent account, not just hide the deeper postings.
+
+2013/08/06 The Shop
+    Expenses:Food                   £10.10
+    Expenses:Food:Gum               £1.10
+    Assets:Cash
+
+2013/08/07 The Shop
+    Expenses:Food                   £0.02
+    Expenses:Food:Gum               £0.01
+    Assets:Cash
+
+test reg --depth 2
+13-Aug-06 The Shop              Expenses:Food                £11.20       £11.20
+                                Assets:Cash                 £-11.20            0
+13-Aug-07 The Shop              Expenses:Food                 £0.03        £0.03
+                                Assets:Cash                  £-0.03            0
+end test
+
+test bal --depth 2
+             £-11.23  Assets:Cash
+              £11.23  Expenses:Food
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary
- Issue #987 requested that `--depth` in register reports collapse sub-accounts and accumulate their amounts into the parent account, rather than simply hiding deeper postings
- This feature was implemented in PR #1901 (merged). This PR adds a regression test to prevent future regressions
- The test uses the exact scenario from the original issue: `Expenses:Food:Gum` amounts are accumulated into `Expenses:Food` when using `--depth 2`

## Test plan
- [x] Regression test `test/regress/987.test` passes (register and balance with `--depth 2`)
- [x] Full test suite passes (4000+ tests via ctest)
- [x] Nix flake build passes

Fixes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>