### PR TITLE
Add regression test for issue #1671

### DIFF
--- a/test/regress/1671.test
+++ b/test/regress/1671.test
@@ -1,0 +1,18 @@
+; Regression test for issue #1671
+; Period options (-M, --monthly, etc.) should not error when an account
+; has both virtual and non-virtual postings.
+
+2019/04/13 Test1
+    Assets:savings                             $1000
+    Equity:balance
+
+2019/04/13 Test2
+    [Assets:savings]                            $200
+    [Assets:Budget:test]
+
+test register -M
+19-Apr-01 - 19-Apr-30           [Assets:Budget:test]          $-200        $-200
+                                Assets:savings                $1000         $800
+                                [Assets:savings]               $200        $1000
+                                Equity:balance               $-1000            0
+end test


### PR DESCRIPTION
## Summary

- Issue #1671 reported that period options (`-M`, `--monthly`, etc.) threw `'equity' cannot accept virtual and non-virtual postings to the same account` when an account had both virtual and non-virtual postings
- This was already fixed in commit 34049c8b (which addressed the same root cause via #2051) by using a composite key in `subtotal_posts` to accumulate virtual and non-virtual postings separately
- Adds a regression test using the MWE from the issue report to prevent future regressions

Fixes #1671

## Test plan

- [x] New regression test `test/regress/1671.test` passes
- [x] Full test suite (4000+ tests) passes
- [x] Nix flake build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)