### PR TITLE
Fix balance assertions for accounts with only virtual postings (#1699)

### DIFF
--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -389,7 +389,24 @@ void detail::parse_amount_expr(std::istream& in, scope_t& scope, post_t& post, a
  */
 static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t* xact,
                                       bool strip_annotations, parse_context_t& context) {
-  bool real_only = !post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG);
+  // A real posting uses real_only=true so that the real and virtual balances
+  // of an account can be asserted independently (#543).  Exception: if the
+  // account has no prior real postings at all, fall back to the combined
+  // (real + virtual) total so that patterns like setting up an account with
+  // a virtual balance assignment and then settling with a real posting
+  // remain assertable (#1699).
+  bool real_only;
+  if (!post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG)) {
+    real_only = false;
+    for (const post_t* p : post->account->posts) {
+      if (!p->has_flags(POST_VIRTUAL | POST_IS_TIMELOG)) {
+        real_only = true;
+        break;
+      }
+    }
+  } else {
+    real_only = false;
+  }
   value_t account_total;
   if (item_t::use_aux_date && post->aux_date()) {
     // When using effective dates and the current posting has an explicit
@@ -439,8 +456,7 @@ static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t*
   // Subtract amounts from previous posts to this account in the xact.
   for (post_t* p : xact->posts) {
     if (p->account == post->account && !p->amount.is_null() &&
-        (!p->has_flags(POST_VIRTUAL | POST_IS_TIMELOG) ||
-         post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG))) {
+        (!real_only || !p->has_flags(POST_VIRTUAL | POST_IS_TIMELOG))) {
       amount_t p_amt(strip_annotations ? p->amount.strip_annotations(keep_details_t()) : p->amount);
       diff -= p_amt;
       DEBUG("textual.parse", "line " << context.linenum << ": "

--- a/test/regress/1699.test
+++ b/test/regress/1699.test
@@ -1,0 +1,21 @@
+; Balance assertions on real postings should include virtual postings
+; when the account has no prior real posting history.
+;
+; When an account's only prior postings are virtual, a real posting's
+; balance assertion must check the combined (real + virtual) total,
+; not just the real total (which would be zero).
+
+2018-08-27 Setting it up
+   (Assets:Wallet)  = BYN 108.40
+
+2018-08-28 Bus to home
+    Expenses:Transportation  BYN 1
+    Assets:Wallet  BYN -1 = BYN 107.40
+
+test balance Wallet
+          BYN 107.40  Assets:Wallet
+end test
+
+test balance Wallet -R
+           BYN -1.00  Assets:Wallet
+end test


### PR DESCRIPTION
## Summary
- When an account's only prior postings are virtual (e.g., `(Account) = BYN 108.40`), a subsequent real posting's balance assertion now correctly checks the combined (real + virtual) total instead of only the real total (which would be zero)
- Preserves backward compatibility with #543 budget envelope semantics: when an account has prior real postings, balance assertions on real postings still check only the real balance

## Details
The root cause was in `compute_balance_diff()` in `src/textual_xacts.cc`. The `real_only` flag was unconditionally set to `true` for real postings, which excluded virtual postings from balance calculations. This meant a real posting to an account that was only initialized via virtual postings would assert against a balance of 0 instead of the actual combined balance.

The fix scans the account's existing post list: if any prior real post exists, `real_only` remains `true` (preserving #543 semantics). If all prior posts are virtual, `real_only` is set to `false` so assertions use the combined total.

Closes #1699

## Test plan
- [x] New regression test `test/regress/1699.test` validates the fix
- [x] All four #543 regression tests (543_a through 543_d) still pass
- [x] `virt-balance-after-real-post.test` still passes
- [x] Full test suite (4096 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)