### PR TITLE
Fix C directive not working with -X option (#1066)

### DIFF
--- a/src/report.cc
+++ b/src/report.cc
@@ -721,7 +721,7 @@ void report_t::commodities_report(post_handler_ptr handler) {
 
 value_t report_t::display_value(const value_t& val) {
   value_t temp(val.strip_annotations(what_to_keep()));
-  if (HANDLED(base))
+  if (HANDLED(base) || HANDLED(exchange_))
     return temp;
   else
     return temp.unreduced();

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -165,6 +165,20 @@ void instance_t::default_account_directive(char* line) {
 void instance_t::price_conversion_directive(char* line) {
   if (char* p = std::strchr(line + 1, '=')) {
     *p++ = '\0';
+
+    // Parse the larger and smaller amounts to register a price in the
+    // commodity history graph, so that -X (--exchange) can use
+    // C-directive rates.  Only journal-level C directives get this
+    // treatment; built-in unit conversions (e.g. hours/minutes) do not.
+    amount_t larger, smaller;
+    (void)larger.parse(line + 1, PARSE_NO_REDUCE);
+    (void)smaller.parse(p, PARSE_NO_REDUCE);
+    if (larger.commodity() && smaller.commodity()) {
+      amount_t per_unit_price(smaller);
+      per_unit_price /= larger.number();
+      larger.commodity().add_price(datetime_t(date_t(1970, 1, 1)), per_unit_price, true);
+    }
+
     amount_t::parse_conversion(line + 1, p);
   }
 }

--- a/test/regress/1066.test
+++ b/test/regress/1066.test
@@ -2,10 +2,8 @@
 ; https://github.com/ledger/ledger/issues/1066
 ;
 ; The C directive defines a commodity conversion rate (C 1.00 EUR = $1.30),
-; but -X (--exchange) fails to use it for currency conversion.
-; By contrast, the P directive works correctly with -X.
+; but -X (--exchange) failed to use it for currency conversion.
 ; Expected: both C and P directives should enable -X to convert currencies.
-; Actual: C directive is ignored by -X, amounts remain in original commodity.
 
 C 1.00 EUR = $1.30
 
@@ -14,8 +12,13 @@ C 1.00 EUR = $1.30
     Assets:Cash
 
 test bal -X '$'
-          -10.00 EUR  Assets:Cash
-           10.00 EUR  Expenses:Food
+             $-13.00  Assets:Cash
+              $13.00  Expenses:Food
 --------------------
                    0
+end test
+
+test reg -X '$'
+24-Jan-01 Purchase              Expenses:Food                $13.00       $13.00
+                                Assets:Cash                 $-13.00            0
 end test


### PR DESCRIPTION
## Summary
- Register C directive conversion rates in the commodity price history graph (via `add_price()` in `price_conversion_directive()`), so `-X`/`--exchange` can find them through Dijkstra shortest-path lookup
- Skip `unreduced()` in `display_value()` when `--exchange` is active, preventing auto-reduced amounts from being converted back to the original commodity
- Only journal-level C directives inject prices; built-in time unit conversions (`1h = 60m`, `1m = 60s`) from session init are unaffected

## Test plan
- [x] New regression test `test/regress/1066.test` with balance and register reports
- [x] Verified `-X '$'`, `-X EUR`, register `-X '$'`, and no-`-X` cases
- [x] Verified multiple C directives (EUR + GBP) convert correctly
- [x] Verified time-based C directives (h/m) unaffected
- [x] Verified P directive still works with `-X`
- [x] Full test suite: 4169/4169 passed, 0 failures

Closes #1066

🤖 Generated with [Claude Code](https://claude.ai/code)