### PR TITLE
Trigger price download even when no prior price exists (#652)

### DIFF
--- a/test/regress/652.test
+++ b/test/regress/652.test
@@ -1,0 +1,15 @@
+; Regression test for issue #652: download should be triggered even when no
+; prior price exists for a commodity.
+;
+; When --download is used and a commodity has no price history at all,
+; check_for_updated_price must still be called so that getquote can fetch
+; a price.  Previously, the download was gated behind an if (point) check
+; that prevented it from firing when find_price returned nullopt.
+
+2024/01/15 Buy Stock
+    Assets:Brokerage        10 AAPL
+    Equity:Opening          -10 AAPL
+
+test bal --market --download --getquote $sourcepath/test/scripts/mock-getquote.sh Assets:Brokerage -> 0
+            $1500.00  Assets:Brokerage
+end test


### PR DESCRIPTION
## Summary

- Remove the `if (point)` guard on `check_for_updated_price()` in `amount_t::value()` so that `--download`/`-Q` triggers getquote even when a commodity has no existing price history
- The comment above the guard explicitly stated the check should happen "whether a price was found or not" — the code only handled stale prices (case b), not missing prices (case a)
- `check_for_updated_price()` already handles `nullopt` correctly by treating it as infinitely stale

## Test plan

- [x] New regression test `test/regress/652.test` verifies download is triggered for a commodity with no price history
- [x] All 4180 existing tests pass
- [x] All 32 quote-related tests pass (coverage-quote-*, 996, 1869)

Fixes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)