### PR TITLE
Delegate CSV file includes to csv_reader sub-parser

### DIFF
--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -354,8 +354,7 @@ void instance_t::include_directive(char* line) {
             // This allows `include bank.csv` in journal files, with the CSV
             // transactions inheriting the active apply-account and apply-tag
             // context from the parent parser.
-            account_t* unknown =
-                journal->master->find_account(_("Expenses:Unknown"));
+            account_t* unknown = journal->master->find_account(_("Expenses:Unknown"));
 
             std::vector<string> apply_tags;
             get_applications<string>(apply_tags);
@@ -373,8 +372,7 @@ void instance_t::include_directive(char* line) {
 
                 if (!journal->add_xact(xact)) {
                   checked_delete(xact);
-                  throw_(std::runtime_error,
-                         _("Failed to finalize derived CSV transaction"));
+                  throw_(std::runtime_error, _("Failed to finalize derived CSV transaction"));
                 }
                 count++;
               }
@@ -392,10 +390,9 @@ void instance_t::include_directive(char* line) {
             optional<int> saved_year_directive_year = year_directive_year;
 
             try {
-              instance_t instance(context_stack, context_stack.get_current(),
-                                  this, no_assertions, hash_type);
-              instance.apply_stack.push_front(
-                  application_t("account", master));
+              instance_t instance(context_stack, context_stack.get_current(), this, no_assertions,
+                                  hash_type);
+              instance.apply_stack.push_front(application_t("account", master));
               instance.parse();
             } catch (...) {
               errors += context_stack.get_current().errors;

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -73,6 +73,7 @@
  */
 
 #include "textual_internal.h"
+#include "csv.h"
 
 namespace ledger {
 
@@ -311,11 +312,30 @@ void instance_t::include_directive(char* line) {
         }
         if (glob.match(base)) {
           journal_t* journal = context.journal;
-          account_t* master = top_account();
           scope_t* scope = context.scope;
           std::size_t& errors = context.errors;
           std::size_t& count = context.count;
           std::size_t& sequence = context.sequence;
+
+          // Detect CSV files by extension for sub-parser delegation.
+          string ext = path(*iter).extension().string();
+          std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+          bool is_csv = (ext == ".csv");
+
+          account_t* master;
+          if (is_csv) {
+            // For CSV includes, the master account becomes the balancing
+            // posting's account.  Prefer an explicit apply-account scope,
+            // fall back to the journal's bucket directive, then to
+            // Equity:Unknown (matching convert command behavior).
+            master = top_account();
+            if (master == journal->master)
+              master = journal->bucket;
+            if (!master)
+              master = journal->master->find_account(_("Equity:Unknown"));
+          } else {
+            master = top_account();
+          }
 
           DEBUG("textual.include", "Including: " << *iter);
           DEBUG("textual.include", "Master account: " << master->fullname());
@@ -329,37 +349,74 @@ void instance_t::include_directive(char* line) {
           parse_context_t* save_current_context = journal->current_context;
           journal->current_context = &context_stack.get_current();
 
-          // Save year state so that year/Y directives inside the included
-          // file do not bleed back into the parent file after the include
-          // returns.  This mirrors what end_apply_directive does for the
-          // "apply year" / "end apply year" pair.
-          optional<datetime_t> saved_epoch = epoch;
-          optional<int> saved_year_directive_year = year_directive_year;
+          if (is_csv) {
+            // CSV sub-parser: delegate to csv_reader instead of instance_t.
+            // This allows `include bank.csv` in journal files, with the CSV
+            // transactions inheriting the active apply-account and apply-tag
+            // context from the parent parser.
+            account_t* unknown =
+                journal->master->find_account(_("Expenses:Unknown"));
 
-          try {
-            instance_t instance(context_stack, context_stack.get_current(), this, no_assertions,
-                                hash_type);
-            instance.apply_stack.push_front(application_t("account", master));
-            instance.parse();
-          } catch (...) {
-            errors += context_stack.get_current().errors;
-            count += context_stack.get_current().count;
-            sequence += context_stack.get_current().sequence;
+            std::vector<string> apply_tags;
+            get_applications<string>(apply_tags);
+
+            try {
+              csv_reader reader(context_stack.get_current());
+              while (xact_t* xact = reader.read_xact(false)) {
+                for (const string& tag : apply_tags) {
+                  if (!xact->has_tag(tag))
+                    xact->set_tag(tag);
+                }
+
+                if (xact->posts.front()->account == nullptr)
+                  xact->posts.front()->account = unknown;
+
+                if (!journal->add_xact(xact)) {
+                  checked_delete(xact);
+                  throw_(std::runtime_error,
+                         _("Failed to finalize derived CSV transaction"));
+                }
+                count++;
+              }
+            } catch (...) {
+              journal->current_context = save_current_context;
+              context_stack.pop();
+              throw;
+            }
+          } else {
+            // Save year state so that year/Y directives inside the included
+            // file do not bleed back into the parent file after the include
+            // returns.  This mirrors what end_apply_directive does for the
+            // "apply year" / "end apply year" pair.
+            optional<datetime_t> saved_epoch = epoch;
+            optional<int> saved_year_directive_year = year_directive_year;
+
+            try {
+              instance_t instance(context_stack, context_stack.get_current(),
+                                  this, no_assertions, hash_type);
+              instance.apply_stack.push_front(
+                  application_t("account", master));
+              instance.parse();
+            } catch (...) {
+              errors += context_stack.get_current().errors;
+              count += context_stack.get_current().count;
+              sequence += context_stack.get_current().sequence;
+
+              epoch = saved_epoch;
+              year_directive_year = saved_year_directive_year;
+
+              journal->current_context = save_current_context;
+              context_stack.pop();
+              throw;
+            }
 
             epoch = saved_epoch;
             year_directive_year = saved_year_directive_year;
 
-            journal->current_context = save_current_context;
-            context_stack.pop();
-            throw;
+            errors += context_stack.get_current().errors;
+            count += context_stack.get_current().count;
+            sequence += context_stack.get_current().sequence;
           }
-
-          epoch = saved_epoch;
-          year_directive_year = saved_year_directive_year;
-
-          errors += context_stack.get_current().errors;
-          count += context_stack.get_current().count;
-          sequence += context_stack.get_current().sequence;
 
           journal->current_context = save_current_context;
           context_stack.pop();

--- a/test/regress/670.csv
+++ b/test/regress/670.csv
@@ -1,0 +1,3 @@
+date,payee,amount
+2024/01/15,Grocery Store,$50
+2024/01/20,Salary,$-3000

--- a/test/regress/670.test
+++ b/test/regress/670.test
@@ -1,0 +1,14 @@
+; Regression test for issue #670: include directive handles CSV files
+; When a .csv file is included, the textual parser delegates to csv_reader
+; as a sub-parser, adding transactions directly to the journal.
+
+bucket Assets:Checking
+
+include 670.csv
+
+test bal
+               $2950  Assets:Checking
+              $-2950  Expenses:Unknown
+--------------------
+                   0
+end test

--- a/test/regress/670b.csv
+++ b/test/regress/670b.csv
@@ -1,0 +1,3 @@
+date,payee,amount
+2024/03/01,Coffee Shop,$5
+2024/03/05,Bookstore,$20

--- a/test/regress/670b.test
+++ b/test/regress/670b.test
@@ -1,0 +1,19 @@
+; Regression test for issue #670: CSV include with apply account
+; Verifies that the apply-account directive sets the balancing account
+; for CSV transactions, and that payee-to-account mappings work.
+
+account Expenses:Coffee
+    payee Coffee
+
+apply account Assets:Checking
+include 670b.csv
+end apply
+
+test bal
+                $-25  Assets:Checking
+                 $25  Expenses
+                  $5    Coffee
+                 $20    Unknown
+--------------------
+                   0
+end test

--- a/test/regress/670c.test
+++ b/test/regress/670c.test
@@ -1,0 +1,22 @@
+; Regression test for issue #670: CSV include mixed with journal entries
+; Verifies that CSV-included transactions coexist with regular journal
+; transactions and that the register command shows them in date order.
+
+bucket Assets:Checking
+
+2024/01/01 Opening Balance
+    Assets:Checking          $1000
+    Equity:Opening
+
+include 670.csv
+
+2024/02/01 Rent
+    Expenses:Rent             $800
+    Assets:Checking
+
+test reg Assets:Checking
+24-Jan-01 Opening Balance       Assets:Checking               $1000        $1000
+24-Jan-15 Grocery Store         Assets:Checking                $-50         $950
+24-Jan-20 Salary                Assets:Checking               $3000        $3950
+24-Feb-01 Rent                  Assets:Checking               $-800        $3150
+end test


### PR DESCRIPTION
## Summary
- When `include` encounters a `.csv` file, delegate to `csv_reader` instead of creating a child `instance_t` textual parser
- CSV transactions inherit the active `apply account` context for the balancing posting account, with fallback to `bucket` directive then `Equity:Unknown`
- Active `apply tag` directives are propagated to CSV transactions
- Primary posting accounts resolved via `payees_for_unknown_accounts`, defaulting to `Expenses:Unknown`

## Test plan
- [x] `670.test` — basic CSV include with bucket directive
- [x] `670b.test` — CSV include with `apply account` and payee-to-account mapping
- [x] `670c.test` — mixed journal and CSV transactions in register output
- [x] Full test suite (4180 tests) passes with zero failures

Fixes #670

🤖 Generated with [Claude Code](https://claude.ai/claude-code)