### PR TITLE
Fix year directive leaking into xact/entry commands (#707)

### DIFF
--- a/src/draft.cc
+++ b/src/draft.cc
@@ -629,8 +629,7 @@ value_t template_command(call_scope_t& args) {
   optional<int> saved_year_directive = year_directive_year;
   optional<datetime_t> saved_epoch;
   year_directive_year = none;
-  if (saved_year_directive && epoch &&
-      epoch->date() == date_t(*saved_year_directive, 12, 31)) {
+  if (saved_year_directive && epoch && epoch->date() == date_t(*saved_year_directive, 12, 31)) {
     saved_epoch = epoch;
     epoch = none;
   }
@@ -658,8 +657,7 @@ value_t xact_command(call_scope_t& args) {
   optional<int> saved_year_directive = year_directive_year;
   optional<datetime_t> saved_epoch;
   year_directive_year = none;
-  if (saved_year_directive && epoch &&
-      epoch->date() == date_t(*saved_year_directive, 12, 31)) {
+  if (saved_year_directive && epoch && epoch->date() == date_t(*saved_year_directive, 12, 31)) {
     saved_epoch = epoch;
     epoch = none;
   }

--- a/src/draft.cc
+++ b/src/draft.cc
@@ -367,24 +367,7 @@ xact_t* draft_t::insert(journal_t& journal) {
         c = '/';
     }
 
-    // Check if the date string contains a year (has at least 2 slashes or a 4-digit year)
-    size_t slash_count = std::count(date_str.begin(), date_str.end(), '/');
-    bool has_year = slash_count >= 2 || (date_str.find_first_of("0123456789") != string::npos &&
-                                         date_str.length() > 5); // Rough check for year presence
-
     added->_date = parse_date(date_str);
-
-    // If no explicit year in the date and we have a year directive,
-    // ensure we use the year directive's year
-    if (!has_year && added->_date && year_directive_year) {
-      // Only adjust if the year differs
-      if (added->_date->year() != *year_directive_year) {
-        added->_date = date_t(*year_directive_year, added->_date->month(), added->_date->day());
-        DEBUG("draft.xact",
-              "Adjusted xact date to use year from year directive: " << *added->_date);
-      }
-    }
-
     DEBUG("draft.xact",
           "Setting date to parsed date string: " << *tmpl->date_string << " -> " << added->_date);
   }
@@ -642,7 +625,22 @@ value_t template_command(call_scope_t& args) {
   args.value().dump(out);
   out << '\n' << '\n';
 
+  // Suppress year directive state, same as xact_command.  (#707)
+  optional<int> saved_year_directive = year_directive_year;
+  optional<datetime_t> saved_epoch;
+  year_directive_year = none;
+  if (saved_year_directive && epoch &&
+      epoch->date() == date_t(*saved_year_directive, 12, 31)) {
+    saved_epoch = epoch;
+    epoch = none;
+  }
+
   draft_t draft(args.value());
+
+  year_directive_year = saved_year_directive;
+  if (saved_epoch)
+    epoch = saved_epoch;
+
   out << _("--- Transaction template ---") << '\n';
   draft.dump(out);
 
@@ -651,9 +649,29 @@ value_t template_command(call_scope_t& args) {
 
 value_t xact_command(call_scope_t& args) {
   report_t& report(find_scope<report_t>(args));
+
+  // The xact command drafts a new transaction whose date should be
+  // relative to "now" (--now or the wall clock), not to any year
+  // directive in the journal.  Temporarily suppress the year
+  // directive state so that CURRENT_DATE() and parse_date() use the
+  // intended date context.  (#707)
+  optional<int> saved_year_directive = year_directive_year;
+  optional<datetime_t> saved_epoch;
+  year_directive_year = none;
+  if (saved_year_directive && epoch &&
+      epoch->date() == date_t(*saved_year_directive, 12, 31)) {
+    saved_epoch = epoch;
+    epoch = none;
+  }
+
   draft_t draft(args.value());
 
   unique_ptr<xact_t> new_xact(draft.insert(*report.session.journal.get()));
+
+  year_directive_year = saved_year_directive;
+  if (saved_epoch)
+    epoch = saved_epoch;
+
   if (new_xact.get()) {
     // Only consider actual postings for the "xact" command
     report.HANDLER(limit_).on("#xact", "actual");

--- a/test/regress/2413.test
+++ b/test/regress/2413.test
@@ -27,14 +27,16 @@ test reg --effective
                                 Account                     $-10.00            0
 end test
 
-# The issue author expected 2025 for both 03-03 and 03/03 formats
-test xact 03-03 Shop 10
+# The xact command should use --now (or today) for the year, not the
+# year directive.  With --now 2025/04/01, a partial date 03-03 gives
+# 2025/03/03.  (#707)
+test --now 2025/04/01 xact 03-03 Shop 10
 2025/03/03 Shop  ; for =2025-03-06
     Expenses:Food                             $10.00
     Account
 end test
 
-test xact 03/03 Shop 10
+test --now 2025/04/01 xact 03/03 Shop 10
 2025/03/03 Shop  ; for =2025-03-06
     Expenses:Food                             $10.00
     Account

--- a/test/regress/2413_apply.test
+++ b/test/regress/2413_apply.test
@@ -1,8 +1,6 @@
 # Test case related to issue #2413
-# Verify that "end apply year" properly reverts year_directive_year
-# so that a subsequent "year" directive is correctly used by xact.
-# Without the fix, "end apply year" would leave year_directive_year stuck
-# at the old value, causing xact to use the wrong year.
+# The xact command uses --now (or today) for the year, not the year
+# directive.  (#707)
 
 apply year 2020
 
@@ -18,7 +16,7 @@ year 2025
     Expenses:Food                             $10.00
     Account
 
-test xact 03-03 Shop 10
+test --now 2025/04/01 xact 03-03 Shop 10
 2025/03/03 Shop
     Expenses:Food                             $10.00
     Account

--- a/test/regress/707.test
+++ b/test/regress/707.test
@@ -22,3 +22,10 @@ test --now 2012/03/25 entry thursday "Test Transaction"
     Expenses:Food                             $10.00
     Assets:Cash
 end test
+
+; Partial date (month/day only) should use --now year, not year directive
+test --now 2012/03/25 xact 03/20 "Test Transaction"
+2012/03/20 Test Transaction
+    Expenses:Food                             $10.00
+    Assets:Cash
+end test

--- a/test/regress/cov6-draft-year-adjust.test
+++ b/test/regress/cov6-draft-year-adjust.test
@@ -1,4 +1,4 @@
-; Coverage for draft.cc year directive adjusting draft date
+; Coverage for draft.cc: year directive does not affect xact date (#707)
 
 Y 2024
 
@@ -6,8 +6,8 @@ Y 2024
     Expenses:Food    $10.00
     Assets:Cash
 
-test xact 2/15 Payee Expenses:Food 20 Assets:Cash
-2024/02/15 Payee
+test --now 2026/03/01 xact 2/15 Payee Expenses:Food 20 Assets:Cash
+2026/02/15 Payee
     Expenses:Food                             $20.00
     Assets:Cash
 end test

--- a/test/regress/coverage-draft-year-adjust.test
+++ b/test/regress/coverage-draft-year-adjust.test
@@ -1,7 +1,6 @@
-; Coverage test for draft.cc year directive with year adjustment
-; When a date without an explicit year is parsed, and a Y year directive
-; specifies a different year than what parse_date would default to,
-; the year is adjusted to match the directive
+; Coverage test for draft.cc: year directive does not affect xact date (#707)
+; When a date without an explicit year is parsed, the current date's year
+; is used, not the year from the year directive
 
 Y 2025
 
@@ -9,8 +8,8 @@ Y 2025
     Expenses:Food    $50.00
     Assets:Cash
 
-test xact 3/20 Grocery
-2025/03/20 Grocery Store
+test --now 2026/04/01 xact 3/20 Grocery
+2026/03/20 Grocery Store
     Expenses:Food                             $50.00
     Assets:Cash
 end test

--- a/test/regress/coverage-draft-year-directive.test
+++ b/test/regress/coverage-draft-year-directive.test
@@ -1,12 +1,12 @@
-; Coverage for draft.cc year directive adjusts xact date
+; Coverage for draft.cc: year directive does not affect xact date (#707)
 year 2023
 
 2024/06/15 Grocery Store
     Expenses:Food    $10.00
     Assets:Cash
 
-test xact "06/15" "Grocery"
-2023/06/15 Grocery Store
+test --now 2026/07/01 xact "06/15" "Grocery"
+2026/06/15 Grocery Store
     Expenses:Food                             $10.00
     Assets:Cash
 end test

--- a/test/regress/coverage-draft_year.test
+++ b/test/regress/coverage-draft_year.test
@@ -1,6 +1,6 @@
-; Coverage test for draft.cc year directive in draft
+; Coverage test for draft.cc: year directive does not affect xact date (#707)
 ; When the xact command is used with a date without an explicit year,
-; and a Y year directive is present, the year from the directive is used
+; the year from the current date (--now) is used, not the year directive
 
 Y 2023
 
@@ -8,8 +8,8 @@ Y 2023
     Expenses:Food    $50.00
     Assets:Cash
 
-test xact 3/20 Grocery
-2023/03/20 Grocery Store
+test --now 2026/04/01 xact 3/20 Grocery
+2026/03/20 Grocery Store
     Expenses:Food                             $50.00
     Assets:Cash
 end test

--- a/test/regress/coverage-wave8-draft-year.test
+++ b/test/regress/coverage-wave8-draft-year.test
@@ -1,5 +1,4 @@
-; Coverage tests for draft.cc year directive adjustment
-; Targets (year directive adjustment in xact command)
+; Coverage tests for draft.cc: year directive does not affect xact date (#707)
 
 year 2024
 
@@ -7,10 +6,10 @@ year 2024
     Expenses:Food            $50.00
     Assets:Cash
 
-; Using xact with a month/day date (no year) and year directive
-; Triggers (year adjustment)
-test xact 03/01 Grocery
-2024/03/01 (CHK001) Grocery Store  ;a purchase
+; Using xact with a month/day date (no year) — the year comes from --now,
+; not the year directive
+test --now 2026/04/01 xact 03/01 Grocery
+2026/03/01 (CHK001) Grocery Store  ;a purchase
     Expenses:Food                             $50.00
     Assets:Cash
 end test


### PR DESCRIPTION
## Summary
- The `xact` and `entry` commands draft new transactions whose dates should be relative to "now" (`--now` or wall clock), not any `year` directive in the journal
- The global `year_directive_year` leaked from journal parsing into draft creation, causing partial dates like `03/20` to resolve against the directive's year instead of the current year
- Save and clear `year_directive_year` (and the directive-set `epoch`) before draft creation in `xact_command()` and `template_command()`, restoring them afterward

## Test plan
- [x] Moved confirmation test from `test/todo/707.test` to `test/regress/707.test` and updated to test correct behavior
- [x] Added partial-date test case (`xact 03/20`) to regression test
- [x] Updated 7 existing tests that asserted old buggy behavior to use `--now` flags
- [x] All 4179 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)