### PR TITLE
Sort by converted value when -X is active (#1556)

### DIFF
--- a/src/compare.cc
+++ b/src/compare.cc
@@ -84,6 +84,25 @@ public:
 
 } // anonymous namespace
 
+/*--- Exchange conversion for sort values ---*/
+
+/**
+ * When -X (exchange) is active, convert any amount or balance sort
+ * values to the target commodity so that cross-commodity comparisons
+ * sort by converted value rather than raw quantity.
+ */
+static void convert_sort_values_for_exchange(std::list<sort_value_t>& sort_values,
+                                             report_t& report) {
+  if (report.HANDLED(exchange_)) {
+    string comm = report.HANDLER(exchange_).str();
+    for (auto& sv : sort_values) {
+      if (sv.value.is_amount() || sv.value.is_balance()) {
+        sv.value = sv.value.exchange_commodities(comm, false, datetime_t());
+      }
+    }
+  }
+}
+
 /*--- Sort value evaluation ---*/
 
 void push_sort_value(std::list<sort_value_t>& sort_values, expr_t::ptr_op_t node, scope_t& scope) {
@@ -149,6 +168,7 @@ bool compare_items<post_t>::operator()(post_t* left, post_t* right) {
     } else {
       find_sort_values(lxdata.sort_values, *left);
     }
+    convert_sort_values_for_exchange(lxdata.sort_values, report);
     lxdata.add_flags(POST_EXT_SORT_CALC);
   }
 
@@ -160,6 +180,7 @@ bool compare_items<post_t>::operator()(post_t* left, post_t* right) {
     } else {
       find_sort_values(rxdata.sort_values, *right);
     }
+    convert_sort_values_for_exchange(rxdata.sort_values, report);
     rxdata.add_flags(POST_EXT_SORT_CALC);
   }
 
@@ -204,6 +225,7 @@ bool compare_items<account_t>::operator()(account_t* left, account_t* right) {
         find_sort_values(xdata.sort_values, acct);
       }
     }
+    convert_sort_values_for_exchange(xdata.sort_values, report);
     xdata.add_flags(ACCOUNT_EXT_SORT_CALC);
   };
 

--- a/test/regress/1556.test
+++ b/test/regress/1556.test
@@ -1,9 +1,5 @@
-; Regression test for issue #1556: Sorting problem concerning amounts and -X (BZ#484)
+; Regression test for issue #1556: -S amount should sort by converted value with -X
 ; https://github.com/ledger/ledger/issues/1556
-;
-; The -S amount sort should order accounts by converted amount after -X conversion.
-; Without -X the sort works: Dining($30) < Travel($75) < Food($120).
-; With -X the sort is broken: Dining($30), Food($120), Travel($75) — not sorted.
 
 P 2015/01/01 EUR $1.20
 P 2015/01/01 GBP $1.50
@@ -23,8 +19,14 @@ P 2015/01/01 GBP $1.50
 test bal -X '$' -S amount Expenses
              $225.00  Expenses
               $30.00    Dining
-             $120.00    Food
               $75.00    Travel
+             $120.00    Food
 --------------------
              $225.00
+end test
+
+test reg -X '$' -S amount Expenses
+15-Jan-03 Payment C             Expenses:Dining              $30.00       $30.00
+15-Jan-02 Payment B             Expenses:Travel              $75.00      $105.00
+15-Jan-01 Payment A             Expenses:Food               $120.00      $225.00
 end test


### PR DESCRIPTION
## Summary

- Fix `-S amount` sorting when `-X` (exchange) is active to sort by converted value rather than raw quantity
- Move confirmation test from `test/todo/` to `test/regress/` with corrected expected output
- Add register test case alongside the balance test

Fixes #1556

## Details

When `-X <commodity>` is used with `-S amount`, postings/accounts in different commodities were sorted by their raw quantities rather than their converted values. For example, `100 EUR` and `50 GBP` would sort by 100 vs 50 instead of by their dollar equivalents ($120 vs $75).

The root cause: `-X` rewrites `display_amount_` and `display_total_` expressions to apply commodity conversion, but the `amount` sort expression evaluates the raw posting amount before conversion. The sort comparator in `compare_items<T>::operator()` cached these unconverted values.

The fix adds `convert_sort_values_for_exchange()` in `src/compare.cc` which, after sort values are evaluated and before they are cached, converts any amount/balance sort values to the exchange commodity using `value_t::exchange_commodities()`. This is called for both `post_t` and `account_t` comparisons.

## Test plan

- [x] Regression test `test/regress/1556.test` verifies correct sort order for both `bal` and `reg` with `-X '$' -S amount`
- [x] Full test suite (4180 tests) passes
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>