### PR TITLE
Propagate cost basis for unannotated commodity transfers

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -644,6 +644,133 @@ bool xact_base_t::finalize() {
       }
     }
 
+    // Phase 5.5: Propagate cost basis annotations for commodity transfers.
+    // When a commodity is transferred between accounts without explicit cost
+    // or lot notation, and the source account has annotated lots, propagate
+    // the lot annotations to both sides of the transfer so that -B (basis)
+    // reporting correctly shows the cost basis.
+    //
+    // Guard: Skip commodities where the user has already specified lot
+    // annotations or costs in this transaction.  If the user wrote explicit
+    // {price} or @ notation for a commodity, they are managing lots manually
+    // and we must not interfere (e.g., partial lot sales like issue #1029).
+    std::set<string> user_annotated_commodities;
+    for (const post_t* post : copy) {
+      if (post->has_flags(ITEM_GENERATED))
+        continue;
+      if (!post->amount.is_null() && post->amount.has_commodity() &&
+          (post->cost || post->amount.has_annotation())) {
+        user_annotated_commodities.insert(post->amount.commodity().base_symbol());
+      }
+    }
+
+    // Step 1: For negative unannotated postings not already handled by
+    // Phase 5, check if the source account has a single annotated lot
+    // commodity for this base symbol and annotate the posting.
+    for (post_t* post : copy) {
+      if (post->cost || post->amount.is_null() || post->amount.has_annotation() ||
+          !post->amount.has_commodity() || post->amount.sign() >= 0 ||
+          !post->amount.commodity().has_flags(COMMODITY_SAW_ANNOTATED))
+        continue;
+
+      const string& base_symbol = post->amount.commodity().base_symbol();
+
+      if (user_annotated_commodities.count(base_symbol))
+        continue;
+
+      // Verify this is a transfer: there must be a matching positive posting
+      // with the same base commodity and no explicit cost.
+      bool is_transfer = false;
+      for (const post_t* other : copy) {
+        if (other != post && !other->amount.is_null() && other->amount.has_commodity() &&
+            !other->cost && other->amount.commodity().base_symbol() == base_symbol &&
+            other->amount.sign() > 0) {
+          is_transfer = true;
+          break;
+        }
+      }
+      if (!is_transfer)
+        continue;
+
+      // Collect distinct annotated lot commodities from the source account.
+      commodity_t* sole_lot_comm = nullptr;
+      bool has_multiple_lots = false;
+      for (const post_t* prior : post->account->posts) {
+        if (prior->amount.has_commodity() && prior->amount.has_annotation() &&
+            prior->amount.commodity().base_symbol() == base_symbol) {
+          if (!sole_lot_comm)
+            sole_lot_comm = &prior->amount.commodity();
+          else if (sole_lot_comm != &prior->amount.commodity()) {
+            has_multiple_lots = true;
+            break;
+          }
+        }
+      }
+
+      if (sole_lot_comm && !has_multiple_lots)
+        post->amount.set_commodity(*sole_lot_comm);
+    }
+
+    // Step 2: For positive unannotated postings in transfers, mirror
+    // annotations from matching annotated negative postings.
+    for (std::size_t idx = 0; idx < copy.size(); ++idx) {
+      post_t* post = copy[idx];
+
+      if (post->cost || post->amount.is_null() || post->amount.has_annotation() ||
+          !post->amount.has_commodity() || post->amount.sign() <= 0)
+        continue;
+
+      const string& base_symbol = post->amount.commodity().base_symbol();
+
+      if (user_annotated_commodities.count(base_symbol))
+        continue;
+
+      // Collect matching negative annotated postings from the transaction.
+      std::vector<post_t*> sources;
+      for (post_t* other : copy) {
+        if (other != post && !other->amount.is_null() && other->amount.has_commodity() &&
+            other->amount.has_annotation() && !other->cost &&
+            other->amount.commodity().base_symbol() == base_symbol && other->amount.sign() < 0)
+          sources.push_back(other);
+      }
+
+      if (sources.empty())
+        continue;
+
+      if (sources.size() == 1) {
+        // Simple case: one source posting, mirror its annotation.
+        post->amount.set_commodity(sources[0]->amount.commodity());
+      } else {
+        // Multiple sources (e.g. Phase 5 split): split the destination
+        // posting to match each source lot.
+        amount_t remaining = post->amount;
+        bool first = true;
+
+        for (post_t* src : sources) {
+          if (remaining.is_zero())
+            break;
+
+          amount_t src_qty = src->amount.abs().strip_annotations(keep_details_t());
+          amount_t consumed = (remaining <= src_qty) ? remaining : src_qty;
+
+          if (first) {
+            post->amount = consumed;
+            post->amount.set_commodity(src->amount.commodity());
+            first = false;
+          } else {
+            post_t* split = new post_t(post->account, consumed);
+            split->amount.set_commodity(src->amount.commodity());
+            split->set_state(post->state());
+            split->add_flags(ITEM_GENERATED | POST_CALCULATED);
+            add_post(split);
+            copy.push_back(split);
+          }
+
+          remaining -= consumed;
+        }
+      }
+    }
+
     // Phase 6: Exchange amounts through the commodity pool.
     // For every posting with an explicit or computed cost, pass it
     // through commodity_pool_t::exchange().  This creates annotated

--- a/test/regress/1554.test
+++ b/test/regress/1554.test
@@ -2,10 +2,12 @@
 ; https://github.com/ledger/ledger/issues/1554
 ;
 ; When transferring a commodity between accounts without explicit lot notation,
-; the cost basis does NOT follow the commodity to the new account.
-; Using {price} lot notation on both postings correctly transfers the cost basis.
+; the cost basis should follow the commodity to the new account.
+; Previously, only explicit {price} lot notation on both postings correctly
+; transferred the cost basis. Now, unannotated transfers also propagate
+; the cost basis from the source account's lot annotations.
 
-; Scenario 1 (broken): Transfer without lot notation - cost basis does not follow commodity
+; Scenario 1: Transfer without lot notation - cost basis now follows commodity
 2015/01/01 Buy AAPL
     Assets:Brokerage:Stocks   10 AAPL @ $100.00
     Assets:Brokerage:Cash
@@ -14,7 +16,7 @@
     Assets:IRA:Stocks         10 AAPL
     Assets:Brokerage:Stocks  -10 AAPL
 
-; Scenario 2 (workaround): Transfer with explicit lot notation - cost basis transfers correctly
+; Scenario 2: Transfer with explicit lot notation - cost basis transfers correctly
 2015/01/01 Buy MSFT
     Assets:Brokerage:Stocks   10 MSFT @ $100.00
     Assets:Brokerage:Cash
@@ -23,10 +25,7 @@
     Assets:IRA:Stocks         10 MSFT {$100.00}
     Assets:Brokerage:Stocks  -10 MSFT {$100.00}
 
-; Without lot notation on transfer, AAPL appears in IRA with no cost basis (only commodity units)
-; while MSFT with lot notation correctly shows $1000 cost basis.
-; The combined output shows the discrepancy.
+; Both AAPL and MSFT should show $1000 cost basis each = $2000 total
 test balance -B Assets:IRA:Stocks
-               $1000
-             10 AAPL  Assets:IRA:Stocks
+               $2000  Assets:IRA:Stocks
 end test


### PR DESCRIPTION
## Summary
- Adds Phase 5.5 to `finalize()` that propagates lot annotations when commodities are transferred between accounts without explicit `{price}` or `@` notation, so `-B` (cost basis) reporting correctly tracks the original purchase price.
- Safely skips commodities where the user has already written explicit lot or cost annotations in the transaction, preserving existing behavior for partial lot sales (e.g., #1029).
- Supports FIFO/LIFO lot-matching integration: when `--lot-matching=fifo|lifo` splits source postings across lots, the destination side is automatically split to match.

Fixes #1554

## Test plan
- [x] Regression test `test/regress/1554.test` passes (moved from `test/todo/`)
- [x] Existing regression test `test/regress/1029.test` still passes (partial lot sale scenario)
- [x] Full test suite (4179 tests) passes with zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)