### PR TITLE
Support date expressions in xact command (#647)

### DIFF
--- a/src/draft.cc
+++ b/src/draft.cc
@@ -166,6 +166,61 @@ void draft_t::parse_args(const value_t& args) {
         tmpl->date = date;
         check_for_date = false;
       } else {
+        if (check_for_date &&
+            arg.find_first_of("abcdefghijklmnopqrstuvwxyz"
+                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ") != string::npos) {
+          // Try parsing as a date expression (e.g. "yesterday", "today",
+          // "tomorrow", "last month").  Only attempt this when the token
+          // contains letters — pure numbers are handled as amounts.
+          string date_expr = arg;
+          auto saved = begin;
+          optional<date_t> best_date;
+          auto best_begin = begin;
+
+          // Try single token first
+          try {
+            date_interval_t interval(date_expr);
+            optional<date_t> d = interval.begin();
+            if (d) {
+              best_date = *d;
+              best_begin = begin;
+            }
+          } catch (...) {
+          }
+
+          // Try accumulating more tokens for multi-word expressions
+          while (std::next(begin) != end) {
+            string next_arg = (*std::next(begin)).to_string();
+            if (next_arg == "at" || next_arg == "to" || next_arg == "from" ||
+                next_arg == "on" || next_arg == "code" || next_arg == "note" ||
+                next_arg == "rest" || next_arg == "@" || next_arg == "@@")
+              break;
+            amount_t test_amt;
+            if (test_amt.parse(next_arg, PARSE_SOFT_FAIL | PARSE_NO_MIGRATE))
+              break;
+            date_expr += " ";
+            date_expr += next_arg;
+            ++begin;
+            try {
+              date_interval_t interval(date_expr);
+              optional<date_t> d = interval.begin();
+              if (d) {
+                best_date = *d;
+                best_begin = begin;
+              }
+            } catch (...) {
+              break;
+            }
+          }
+
+          if (best_date) {
+            tmpl->date = *best_date;
+            check_for_date = false;
+            begin = best_begin;
+            continue;
+          }
+          begin = saved;
+        }
         // NOLINTBEGIN(bugprone-branch-clone)
 
         // Handle preposition-based argument syntax
@@ -372,7 +427,19 @@ xact_t* draft_t::insert(journal_t& journal) {
     bool has_year = slash_count >= 2 || (date_str.find_first_of("0123456789") != string::npos &&
                                          date_str.length() > 5); // Rough check for year presence
 
-    added->_date = parse_date(date_str);
+    try {
+      added->_date = parse_date(date_str);
+    } catch (date_error&) {
+      // If parse_date failed, try parsing as a date expression
+      // (e.g. "yesterday", "today", "last month")
+      try {
+        date_interval_t interval(*tmpl->date_string);
+        optional<date_t> d = interval.begin();
+        if (d)
+          added->_date = *d;
+      } catch (...) {
+      }
+    }
 
     // If no explicit year in the date and we have a year directive,
     // ensure we use the year directive's year

--- a/src/draft.cc
+++ b/src/draft.cc
@@ -166,9 +166,8 @@ void draft_t::parse_args(const value_t& args) {
         tmpl->date = date;
         check_for_date = false;
       } else {
-        if (check_for_date &&
-            arg.find_first_of("abcdefghijklmnopqrstuvwxyz"
-                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ") != string::npos) {
+        if (check_for_date && arg.find_first_of("abcdefghijklmnopqrstuvwxyz"
+                                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ") != string::npos) {
           // Try parsing as a date expression (e.g. "yesterday", "today",
           // "tomorrow", "last month").  Only attempt this when the token
           // contains letters — pure numbers are handled as amounts.
@@ -185,15 +184,14 @@ void draft_t::parse_args(const value_t& args) {
               best_date = *d;
               best_begin = begin;
             }
-          } catch (...) {
-          }
+          } catch (...) {} // NOLINT(bugprone-empty-catch)
 
           // Try accumulating more tokens for multi-word expressions
           while (std::next(begin) != end) {
             string next_arg = (*std::next(begin)).to_string();
-            if (next_arg == "at" || next_arg == "to" || next_arg == "from" ||
-                next_arg == "on" || next_arg == "code" || next_arg == "note" ||
-                next_arg == "rest" || next_arg == "@" || next_arg == "@@")
+            if (next_arg == "at" || next_arg == "to" || next_arg == "from" || next_arg == "on" ||
+                next_arg == "code" || next_arg == "note" || next_arg == "rest" || next_arg == "@" ||
+                next_arg == "@@")
               break;
             amount_t test_amt;
             if (test_amt.parse(next_arg, PARSE_SOFT_FAIL | PARSE_NO_MIGRATE))
@@ -437,8 +435,7 @@ xact_t* draft_t::insert(journal_t& journal) {
         optional<date_t> d = interval.begin();
         if (d)
           added->_date = *d;
-      } catch (...) {
-      }
+      } catch (...) {} // NOLINT(bugprone-empty-catch)
     }
 
     // If no explicit year in the date and we have a year directive,

--- a/test/regress/647.test
+++ b/test/regress/647.test
@@ -1,0 +1,36 @@
+; Regression test for issue #647: date expressions in xact command
+;
+; The xact command should accept date expressions like "yesterday",
+; "today", "tomorrow", "last month", etc. in addition to numeric dates.
+
+2024/01/15 Grocery Store
+    Expenses:Food    $50.00
+    Assets:Checking
+
+; Test "yesterday" as a positional date argument
+test xact --now 2024/03/15 yesterday Grocery
+2024/03/14 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+; Test "today" as a positional date argument
+test xact --now 2024/03/15 today Grocery
+2024/03/15 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+; Test "tomorrow" as a positional date argument
+test xact --now 2024/03/15 tomorrow Grocery
+2024/03/16 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+; Test "on yesterday" using the "on" preposition
+test xact --now 2024/03/15 Grocery on yesterday
+2024/03/14 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test


### PR DESCRIPTION
## Summary
- The `xact` command now accepts date expressions like "yesterday", "today", "tomorrow", "last month" in addition to numeric dates and weekday names
- Works as a positional first argument (`xact yesterday Grocery`) and with the `on` preposition (`xact Grocery on yesterday`)
- Uses the existing `date_interval_t` parser via progressive longest-match for multi-word expressions

## Implementation
1. In `parse_args()`: after the existing weekday check, letter-containing tokens are tried as date expressions via `date_interval_t`, with progressive accumulation for multi-word expressions like "last month"
2. In `insert()`: when `parse_date()` throws on a stored `date_string` (from the "on" preposition), falls back to `date_interval_t` parsing

## Test plan
- [x] All 4180 existing tests pass
- [x] New regression test `test/regress/647.test` covers: yesterday, today, tomorrow (positional), and "on yesterday" (preposition)
- [ ] CI pipeline passes

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)