### PR TITLE
Fix --sort date on balance report (#3126)

### DIFF
--- a/src/account.cc
+++ b/src/account.cc
@@ -409,6 +409,9 @@ value_t get_earliest_checkin(account_t& account) {
 value_t get_latest(account_t& account) {
   return account.self_details().latest_post;
 }
+value_t get_account_date(account_t& account) {
+  return account.family_details().latest_post;
+}
 value_t get_latest_checkout(account_t& account) {
   return (!account.self_details().latest_checkout.is_not_a_date_time()
               ? value_t(account.self_details().latest_checkout)
@@ -505,7 +508,7 @@ expr_t::ptr_op_t account_t::lookup(const symbol_t::kind_t kind, const string& fn
 
   case 'd':
     if (fn_name[1] == '\0' || fn_name == "date")
-      return WRAP_FUNCTOR(get_wrapper<&get_latest>);
+      return WRAP_FUNCTOR(get_wrapper<&get_account_date>);
     else if (fn_name == "depth")
       return WRAP_FUNCTOR(get_wrapper<&get_depth>);
     else if (fn_name == "depth_parent")

--- a/test/regress/3126.test
+++ b/test/regress/3126.test
@@ -1,0 +1,21 @@
+; Regression test for issue #3126
+; Sorting by date on balance report should work for accounts
+; that have no direct postings (parent accounts).
+
+2026/03/30 * Department Store
+    Expenses:Clothing                       $20
+    Assets:Checking
+2026/04/06 * Grocery Store
+    Expenses:Groceries:Food                  $3.58
+    Assets:Cash
+
+test bal --sort date
+             $-23.58  Assets
+             $-20.00    Checking
+              $-3.58    Cash
+              $23.58  Expenses
+              $20.00    Clothing
+               $3.58    Groceries:Food
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary
- The `date` handler added to `account_t::lookup` in edacfec used `self_details().latest_post`, which returns an invalid default date for parent accounts (e.g. `Assets`, `Expenses`) that have no direct postings
- `value_t::simplified()` converts invalid dates to integer 0, causing "Cannot compare an integer to a date" when `--sort date` compares parent and leaf accounts
- Fix: use `family_details()` instead, which aggregates the latest posting date across all descendant accounts, giving parent accounts a meaningful date and keeping the type consistent

Fixes #3126

## Test plan
- [x] Added regression test `test/regress/3126.test` with the exact reproducer from the issue
- [x] All 4223 existing tests pass (including `647D5DB9.test` which tests the `date` field for `-JV`)
- [x] Nix flake build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)