### PR TITLE
Fix --sort date crash with bucket accounts (#3128)

### DIFF
--- a/src/account.cc
+++ b/src/account.cc
@@ -426,7 +426,8 @@ value_t get_latest(account_t& account) {
   return account.self_details().latest_post;
 }
 value_t get_account_date(account_t& account) {
-  return account.family_details().latest_post;
+  date_t date = account.family_details().latest_post;
+  return is_valid(date) ? value_t(date) : NULL_VALUE;
 }
 value_t get_latest_checkout(account_t& account) {
   return (!account.self_details().latest_checkout.is_not_a_date_time()

--- a/src/compare.cc
+++ b/src/compare.cc
@@ -70,10 +70,11 @@ void push_sort_value(std::list<sort_value_t>& sort_values, expr_t::ptr_op_t node
 
     sort_values.push_back(sort_value_t());
     sort_values.back().inverted = inverted;
-    sort_values.back().value = expr_t(node).calc(scope).simplified();
 
-    if (sort_values.back().value.is_null())
-      throw_(calc_error, _("Could not determine sorting value based an expression"));
+    value_t result = expr_t(node).calc(scope);
+    if (!result.is_null())
+      result.in_place_simplify();
+    sort_values.back().value = result;
   }
 }
 

--- a/src/value.cc
+++ b/src/value.cc
@@ -395,6 +395,9 @@ void value_t::in_place_simplify() {
   LOGGER("value.simplify");
 #endif
 
+  if (is_null())
+    return;
+
   if (is_realzero()) {
     DEBUG_("Zeroing type " << static_cast<int>(type()));
     set_long(0L);
@@ -1120,9 +1123,12 @@ bool value_t::is_equal_to(const value_t& val) const {
 /// BALANCE comparison against scalars checks whether ALL component amounts
 /// are less than the scalar.  SEQUENCE comparison is lexicographic.
 bool value_t::is_less_than(const value_t& val) const {
+  if (val.is_null())
+    return false; // nothing is less than null (null sorts first)
+
   switch (type()) {
   case VOID:
-    return !val.is_null(); // null is less than any non-null value
+    return true; // null is less than any non-null value
 
   case BOOLEAN:
     if (val.is_boolean()) {
@@ -1266,6 +1272,9 @@ bool value_t::is_less_than(const value_t& val) const {
 /// never greater than anything.  BALANCE > scalar requires ALL components
 /// to be greater.
 bool value_t::is_greater_than(const value_t& val) const {
+  if (val.is_null())
+    return !is_null(); // non-null is greater than null
+
   switch (type()) {
   case VOID:
     return false; // null is not greater than anything

--- a/test/regress/3128.test
+++ b/test/regress/3128.test
@@ -1,0 +1,17 @@
+; Regression test for #3128: --sort date broken with bucket accounts
+; The bucket directive creates accounts in the hierarchy that may have
+; no postings, causing date lookups to return null values that must be
+; handled gracefully during sorting.
+
+bucket Assets:Checking
+
+2026/04/01 * Grocery Store
+    Expenses:Groceries:Food                          $1.23
+    Liabilities:Credit
+
+test bal --sort date
+               $1.23  Expenses:Groceries:Food
+              $-1.23  Liabilities:Credit
+--------------------
+                   0
+end test

--- a/test/regress/cov9-compare-null-sort.test
+++ b/test/regress/cov9-compare-null-sort.test
@@ -1,11 +1,12 @@
-; Coverage for compare.cc null sort value error
+; Coverage for compare.cc null sort value handling
+; Null sort values should be treated as VOID and sort first,
+; not crash with an error.
 
 2024/01/01 Test
     Expenses:Food    $10.00
     Assets:Cash
 
-test reg --sort "null" -> 1
-__ERROR__
-While applying is_realzero to :
-Error: Cannot determine if an uninitialized value is really zero
+test reg --sort "null"
+24-Jan-01 Test                  Expenses:Food                $10.00       $10.00
+                                Assets:Cash                 $-10.00            0
 end test

--- a/test/regress/coverage-compare-sort-null-value.test
+++ b/test/regress/coverage-compare-sort-null-value.test
@@ -1,11 +1,12 @@
-; Coverage for compare.cc null sort value error
+; Coverage for compare.cc null sort value handling
+; Sorting by a nonexistent tag should treat null values as VOID
+; and sort normally, not crash with an error.
 
 2024/01/01 Test
     Expenses:Food    $10.00
     Assets:Cash
 
-test reg --sort "tag('nonexistent')" -> 1
-__ERROR__
-While applying is_realzero to :
-Error: Cannot determine if an uninitialized value is really zero
+test reg --sort "tag('nonexistent')"
+24-Jan-01 Test                  Expenses:Food                $10.00       $10.00
+                                Assets:Cash                 $-10.00            0
 end test

--- a/test/unit/t_expr.cc
+++ b/test/unit/t_expr.cc
@@ -4449,10 +4449,10 @@ BOOST_AUTO_TEST_CASE(testLambdaCallW8)
 }
 
 // =======================================================================
-// W8 Coverage: compare.cc - push_sort_value null throw (line 62)
+// W8 Coverage: compare.cc - push_sort_value null handling (line 62)
 // =======================================================================
 
-BOOST_AUTO_TEST_CASE(testPushSortValueNullThrowsW8)
+BOOST_AUTO_TEST_CASE(testPushSortValueNullHandledW8)
 {
   // Create an expression that evaluates to null
   // A PLUG node is typically null-like
@@ -4460,7 +4460,9 @@ BOOST_AUTO_TEST_CASE(testPushSortValueNullThrowsW8)
   expr_t::ptr_op_t node = expr_t::op_t::new_node(expr_t::op_t::PLUG);
 
   symbol_scope_t scope(*scope_t::empty_scope);
-  BOOST_CHECK_THROW(ledger::push_sort_value(sort_values, node, scope), std::exception);
+  ledger::push_sort_value(sort_values, node, scope);
+  BOOST_CHECK_EQUAL(sort_values.size(), 1U);
+  BOOST_CHECK(sort_values.back().value.is_null());
 }
 
 // =======================================================================


### PR DESCRIPTION
## Summary

- Fix crash "Cannot compare a date to an integer" when using `--sort date` with the `bucket` directive
- The `bucket` directive creates intermediate accounts with no postings, so their dates are invalid. `get_account_date()` now returns `NULL_VALUE` for invalid dates, and the comparison and simplification paths handle null values gracefully instead of crashing.
- Null/VOID values sort first, establishing a consistent total order

## Changes

1. **`src/account.cc`** — `get_account_date()` validates the date before returning, returns `NULL_VALUE` for invalid dates
2. **`src/value.cc`** — `in_place_simplify()` returns early for null values; `is_less_than()`/`is_greater_than()` handle null right-hand operands
3. **`src/compare.cc`** — `push_sort_value()` allows null sort values instead of throwing
4. **Updated tests** — Three existing tests updated to expect graceful handling instead of errors
5. **`test/regress/3128.test`** — New regression test for the exact bug scenario

## Test plan

- [x] All 4232 tests pass (including new regression test)
- [x] `ledger bal --sort date` with `bucket` directive produces correct sorted output
- [x] Sorting by null expression (`--sort "null"`) works gracefully
- [x] Sorting by nonexistent tag (`--sort "tag('nonexistent')"`) works gracefully

Fixes #3128

🤖 Generated with [Claude Code](https://claude.com/claude-code)