### PR TITLE
Fix CSV mark in description when code present

### DIFF
--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -1002,6 +1002,25 @@ xact_t* instance_t::parse_xact(char* line, std::streamsize len, account_t* accou
       }
     }
 
+    // Phase 3b: Check for a state flag after the code.
+    // Ledger accepts the state flag either before or after the code,
+    // e.g., both "2020/01/01 * (CODE) Payee" and "2020/01/01 (CODE) * Payee".
+
+    if (next && xact->_state == item_t::UNCLEARED) {
+      switch (*next) {
+      case '*':
+        xact->_state = item_t::CLEARED;
+        next = skip_ws(++next);
+        break;
+      case '!':
+        xact->_state = item_t::PENDING;
+        next = skip_ws(++next);
+        break;
+      default:
+        break;
+      }
+    }
+
     // Phase 4: Parse the payee/description text.
     // The payee ends at the first inline note separator (two+ spaces or a
     // tab followed by ';').  The payee is validated/rewritten through the

--- a/test/regress/3115.test
+++ b/test/regress/3115.test
@@ -1,0 +1,46 @@
+; Regression test for #3115: CSV output embeds mark in description when
+; both code and mark are present.
+;
+; When a transaction has both a code and a clearing mark, the CSV output
+; should place the mark in the mark column (column 7), not embed it in
+; the description column (column 3).
+
+2020/01/01 (CODE) * Payee
+    Assets:A  -1 USD
+    Expenses:B  1 USD
+
+2020/01/02 (CODE) ! Pending Payee
+    Assets:A  -1 USD
+    Expenses:B  1 USD
+
+2020/01/03 * (CODE) Cleared Before Code
+    Assets:A  -1 USD
+    Expenses:B  1 USD
+
+2020/01/04 (CODE) No Mark
+    Assets:A  -1 USD
+    Expenses:B  1 USD
+
+; === Test: code + cleared mark should separate mark from description ===
+test csv -d "date==[2020-01-01]"
+"2020/01/01","CODE","Payee","Assets:A","USD","-1","*",""
+"2020/01/01","CODE","Payee","Expenses:B","USD","1","*",""
+end test
+
+; === Test: code + pending mark ===
+test csv -d "date==[2020-01-02]"
+"2020/01/02","CODE","Pending Payee","Assets:A","USD","-1","!",""
+"2020/01/02","CODE","Pending Payee","Expenses:B","USD","1","!",""
+end test
+
+; === Test: mark before code (existing behavior should remain correct) ===
+test csv -d "date==[2020-01-03]"
+"2020/01/03","CODE","Cleared Before Code","Assets:A","USD","-1","*",""
+"2020/01/03","CODE","Cleared Before Code","Expenses:B","USD","1","*",""
+end test
+
+; === Test: code without mark ===
+test csv -d "date==[2020-01-04]"
+"2020/01/04","CODE","No Mark","Assets:A","USD","-1","",""
+"2020/01/04","CODE","No Mark","Expenses:B","USD","1","",""
+end test


### PR DESCRIPTION
## Summary
- When a transaction has both a code and a clearing mark in the order `DATE (CODE) * Payee`, the parser only checked for the state flag before the code, causing the mark to be embedded in the payee text
- Added a second state-flag check after parsing the transaction code so both orderings (`* (CODE) Payee` and `(CODE) * Payee`) are handled correctly
- Added regression test covering cleared, pending, mark-before-code, and no-mark cases

Fixes #3115

## Test plan
- [x] Verified CSV output correctly separates mark from description with code+cleared
- [x] Verified CSV output works with code+pending (`!`)
- [x] Verified existing mark-before-code order still works
- [x] Verified code-without-mark still works
- [x] Verified `register` and `print` output not affected
- [x] All existing regression and baseline tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)