### PR TITLE
Fix alias expansion duplicating fully-qualified paths (#3132)

### DIFF
--- a/src/journal.cc
+++ b/src/journal.cc
@@ -224,12 +224,21 @@ account_t* journal_t::register_account(string_view name, post_t* post, account_t
  * @brief Recursively expand account aliases with cycle detection.
  *
  * Checks the account_aliases map for a full-name match first (e.g.,
- * "Foo:Bar" -> some account), then tries matching each colon-separated
- * component of the name (e.g., "Foo", "Bar", "Baz" in "Foo:Bar:Baz").
- * The first matching component is expanded.  When recursive_aliases is
- * true, the loop repeats until no alias matches.  An already_seen set
- * tracks which names have been expanded to detect and prevent infinite
- * alias loops.
+ * "Foo:Bar" -> some account), then tries matching the first
+ * colon-separated component of the name (e.g., "Foo" in "Foo:Bar:Baz").
+ * When recursive_aliases is true the loop repeats until no alias
+ * matches, and each non-first component of the name is also considered
+ * for expansion so that e.g. "alias Food=Healthy:Food" rewrites
+ * "Expenses:Food:Groceries" to "Expenses:Healthy:Food:Groceries"
+ * (#836).  An already_seen set tracks which names have been expanded
+ * to detect and prevent infinite alias loops.
+ *
+ * To avoid the duplication bug reported in #3132 -- where
+ * "alias Dining=Expenses:Dining" would cause a user-written
+ * "Expenses:Dining:Coffee" to become
+ * "Expenses:Expenses:Dining:Coffee" -- a component is skipped when
+ * the portion of the name up to and including that component already
+ * equals the alias target on a colon-aligned boundary.
  *
  * @return The resolved account, or nullptr if no alias matched.
  */
@@ -259,33 +268,55 @@ account_t* journal_t::expand_aliases(string name) {
         result = (*i).second;
         name = result->fullname();
       } else {
-        // Check each account name component for alias expansion (#836).
-        // For "A:B:C", try "A", then "B", then "C" — expand the first
-        // component that matches an alias.
+        // Walk colon-separated components looking for an alias match.
+        // In the default (non-recursive) mode only the first component
+        // is considered; with --recursive-aliases every component is
+        // eligible (#836).  The first match is expanded.
         size_t pos = 0;
         bool found = false;
         while (pos < name.size()) {
           size_t colon = name.find(':', pos);
-          string component =
-              (colon != string::npos) ? name.substr(pos, colon - pos) : name.substr(pos);
+          size_t component_end = (colon != string::npos) ? colon : name.size();
+          string component = name.substr(pos, component_end - pos);
 
           if (auto j = account_aliases.find(component);
               j != account_aliases.end() && already_seen.count(component) == 0) {
-            already_seen.insert(component);
+            // Skip the expansion when the name already contains the
+            // alias target as a colon-aligned prefix ending at this
+            // component.  This prevents #3132's duplication:
+            // "Expenses:Dining:Coffee" must not be rewritten using
+            // "alias Dining=Expenses:Dining" just because its middle
+            // component matches.
+            const string& target = (*j).second->fullname();
+            bool already_there = false;
+            if (component_end >= target.size()) {
+              size_t start = component_end - target.size();
+              if ((start == 0 || name[start - 1] == ':') &&
+                  name.compare(start, target.size(), target) == 0) {
+                already_there = true;
+              }
+            }
 
-            string new_name;
-            if (pos > 0)
-              new_name = name.substr(0, pos); // prefix including trailing ':'
-            new_name += (*j).second->fullname();
-            if (colon != string::npos)
-              new_name += name.substr(colon); // suffix including leading ':'
-            result = find_account(new_name);
-            name = result->fullname();
-            found = true;
-            break;
+            if (!already_there) {
+              already_seen.insert(component);
+
+              string new_name;
+              if (pos > 0)
+                new_name = name.substr(0, pos); // prefix including trailing ':'
+              new_name += target;
+              if (colon != string::npos)
+                new_name += name.substr(colon); // suffix including leading ':'
+              result = find_account(new_name);
+              name = result->fullname();
+              found = true;
+              break;
+            }
           }
 
-          if (colon == string::npos)
+          // Only walk past the first component when recursive alias
+          // expansion is enabled; otherwise stop here to preserve the
+          // pre-#836 default behavior.
+          if (!recursive_aliases || colon == string::npos)
             break;
           pos = colon + 1;
         }

--- a/test/regress/3132.test
+++ b/test/regress/3132.test
@@ -1,0 +1,45 @@
+; Regression test for issue #3132: alias expansion must not rewrite
+; fully-qualified account names that happen to contain an alias key as
+; a non-leading component.
+;
+; Previously the change introduced for #836 caused
+; "Expenses:Dining:Coffee" to be expanded to
+; "Expenses:Expenses:Dining:Coffee" because the middle component
+; "Dining" matched the `Dining=Expenses:Dining` alias.  By default the
+; expansion should only apply to the full account name or its first
+; component, preserving the pre-#836 behavior.
+
+alias Coffee=Expenses:Dining:Coffee
+alias Dining=Expenses:Dining
+alias Gas=Expenses:Auto:Gas
+alias Food=Expenses:Groceries:Food
+
+commodity $
+    format  $1,000.00
+    alias   USD
+    default
+
+bucket Liabilities:Credit:Visa
+
+2023/01/31 * Coffee Shop
+    Expenses:Dining:Coffee      $5
+2023/01/31 * Coffee Shop
+    Coffee                      $5
+
+test bal
+              $10.00  Expenses:Dining:Coffee
+             $-10.00  Liabilities:Credit:Visa
+--------------------
+                   0
+end test
+
+; Even with --recursive-aliases, a fully-qualified name that already
+; contains the alias target as a boundary-aligned prefix must not be
+; expanded again.  Both postings should still resolve to
+; Expenses:Dining:Coffee.
+test bal --recursive-aliases
+              $10.00  Expenses:Dining:Coffee
+             $-10.00  Liabilities:Credit:Visa
+--------------------
+                   0
+end test

--- a/test/regress/836.test
+++ b/test/regress/836.test
@@ -1,8 +1,10 @@
 ; Regression test for issue #836: Account aliases should match account name components
 ; https://github.com/ledger/ledger/issues/836
 ;
-; Account aliases should expand when they match ANY component of an account
-; name, not just the first component.
+; With --recursive-aliases, account aliases expand when they match ANY
+; component of an account name, not just the first component.  Without
+; --recursive-aliases, only the first component (or full name) is
+; considered, which is the historical default (see #3132).
 
 alias Food=Healthy:Food
 
@@ -14,9 +16,20 @@ alias Food=Healthy:Food
     Expenses:Food:Groceries    $100.00
     Assets:Cash
 
-test bal
+test bal --recursive-aliases
             $-150.00  Assets:Cash
              $100.00  Expenses:Healthy:Food:Groceries
+              $50.00  Healthy:Food:Groceries
+--------------------
+                   0
+end test
+
+; Default (non-recursive) mode leaves non-leading components alone so
+; that explicit account paths like "Expenses:Food:Groceries" are not
+; rewritten unexpectedly.
+test bal
+            $-150.00  Assets:Cash
+             $100.00  Expenses:Food:Groceries
               $50.00  Healthy:Food:Groceries
 --------------------
                    0


### PR DESCRIPTION
## Summary

- Restore the pre-#836 default alias-expansion semantics so that a
  fully-qualified account name whose non-leading components happen to
  match an alias key is no longer silently rewritten
- Gate the any-component expansion behavior introduced by #836 behind
  `--recursive-aliases`, per the resolution in #3132
- Add a colon-aligned "already there" guard inside the recursive path
  so even users who opt into `--recursive-aliases` are protected from
  the Expenses:Expenses:Dining:Coffee duplication

## Test plan

- [x] `test/regress/3132.test` exercises both the default and
      `--recursive-aliases` modes with the exact scenario from the issue
- [x] `test/regress/836.test` is split to cover the historical default
      (first component only) and the broader component-wise expansion
      under `--recursive-aliases`
- [x] Full ctest suite (4259 tests) passes locally

Closes #3132.