### PR TITLE
Fix bad pricedb info under --anon (#756)

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -260,19 +260,23 @@ account_t* create_temp_account_from_path(std::list<string>& account_names, tempo
  *
  * The mapping is stable: the same original commodity always maps to the same
  * label within a single anonymization pass.  Commodity flags and precision
- * are preserved from the original.
+ * are preserved from the original.  Annotated commodities (e.g.
+ * AAA{1.00 EUR} and AAA{2.00 EUR}) share the same label as their base
+ * commodity (AAA), since the index key is the referent (base) rather than
+ * the per-annotation pointer.  (#756)
  */
 void anonymize_posts::render_commodity(amount_t& amt) {
   commodity_t& comm(amt.commodity());
+  commodity_t* base = &comm.referent();
 
   std::size_t id;
   bool newly_added = false;
 
-  commodity_index_map::iterator i = comms.find(&comm);
+  commodity_index_map::iterator i = comms.find(base);
   if (i == comms.end()) {
     id = next_comm_id++;
     newly_added = true;
-    comms.insert(commodity_index_map::value_type(&comm, id));
+    comms.insert(commodity_index_map::value_type(base, id));
   } else {
     id = (*i).second;
   }

--- a/test/regress/2CE7DADB.test
+++ b/test/regress/2CE7DADB.test
@@ -11,3 +11,14 @@ test --anon pricedb --format "%(date) %(amount)\n"
 2012/02/01 2.00 A
 end test
 
+; Verify that the same base commodity always anonymizes to the same label,
+; even when it appears with different price annotations.  Before the fix
+; for #756, AAA{1.00 EUR} and AAA{2.00 EUR} would map to different labels
+; (e.g. A and C) because the commodity index keyed on the per-annotation
+; pointer rather than the base referent.
+test --anon reg --format "%(date) %(commodity)\n"
+2012/01/01 A
+2012/01/01 B
+2012/02/01 A
+2012/02/01 B
+end test

--- a/test/regress/756.test
+++ b/test/regress/756.test
@@ -1,0 +1,39 @@
+; Regression test for issue #756: --anon must give the same anonymized
+; label to a commodity regardless of which price/lot annotation is attached
+; to it.  Previously, AAA appeared as different labels (A, C, ...) across
+; transactions because annotated commodities have distinct pointers from
+; their base, and anonymize_posts indexed commodities by pointer instead
+; of by referent.  After the fix, the base commodity (AAA) maps to a
+; single label and the annotated forms inherit it.
+
+2012-01-01 * Buy AAA
+    A         1 AAA @ 1.00 EUR
+    B                -1.00 EUR
+
+2012-02-01 * Buy AAA
+    A         1 AAA @ 2.00 EUR
+    B                -2.00 EUR
+
+2012-03-01 * Buy AAA
+    A         1 AAA @ 3.00 EUR
+    B                -3.00 EUR
+
+; All AAA postings use the same anonymized commodity ("A"), regardless
+; of the differing price annotations.  All EUR postings use a single
+; commodity ("B") as well.
+test --anon reg --format "%(date) %(commodity)\n"
+2012/01/01 A
+2012/01/01 B
+2012/02/01 A
+2012/02/01 B
+2012/03/01 A
+2012/03/01 B
+end test
+
+; The pricedb output must use a single label for the priced currency
+; across all price entries.
+test --anon pricedb --format "%(date) %(amount)\n"
+2012/01/01 1.00 A
+2012/02/01 2.00 A
+2012/03/01 3.00 A
+end test


### PR DESCRIPTION
## Summary

- Fixes [#756](https://github.com/ledger/ledger/issues/756): under `--anon`, the same base commodity could be assigned multiple anonymized labels when it appeared with different price annotations (e.g. `AAA{1.00 EUR}` and `AAA{2.00 EUR}` ended up as `A` and `C`).
- Indexes the commodity map in `anonymize_posts::render_commodity` by `commodity_t::referent()` instead of the per-annotation pointer, so all annotated forms of a base commodity collapse onto a single label. The same base commodity now consistently maps to one label, in both `--anon print`/`reg` and `--anon pricedb` outputs.
- Updates the existing `test/regress/2CE7DADB.test` (which sidestepped the bug by formatting only date and amount) and adds `test/regress/756.test` covering both `reg` and `pricedb` formats across three price points.

## Background

Previously, postings like:

```
2012/01/01 * Buy AAA
    A         1 AAA @ 1.00 EUR
    B                -1.00 EUR

2012/02/01 * Buy AAA
    A         1 AAA @ 2.00 EUR
    B                -2.00 EUR
```

produced under `--anon print`:

```
    ... 1 A    <- AAA{1.00 EUR}
    ... -1.00 B
    ... 1 C    <- AAA{2.00 EUR}, BUG (should be A)
    ... -2.00 B
```

because `AAA{1.00 EUR}` and `AAA{2.00 EUR}` are distinct annotated commodity pointers. After the fix, both annotated forms map to the same base commodity (`AAA`) and receive the same label.

## Test plan

- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/2CE7DADB.test` — passes (was passing before due to weak format, now also asserts the consistent labeling)
- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/756.test` — passes
- [x] Verified that both new test assertions FAIL on the unfixed code (the second AAA prints as `C`/`D` instead of `A`)
- [x] Full `ctest` run: 4267 / 4267 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)