### PR TITLE
Exclude future-dated postings from recency statistics (#741)

### DIFF
--- a/src/account.cc
+++ b/src/account.cc
@@ -673,6 +673,9 @@ account_t::xdata_t::details_t& account_t::xdata_t::details_t::operator+=(const d
   if (!is_valid(latest_cleared_post) ||
       (is_valid(other.latest_cleared_post) && other.latest_cleared_post > latest_cleared_post))
     latest_cleared_post = other.latest_cleared_post;
+  if (!is_valid(latest_past_post) ||
+      (is_valid(other.latest_past_post) && other.latest_past_post > latest_past_post))
+    latest_past_post = other.latest_past_post;
 
   filenames.insert(other.filenames.begin(), other.filenames.end());
   accounts_referenced.insert(other.accounts_referenced.begin(), other.accounts_referenced.end());
@@ -860,14 +863,23 @@ void account_t::xdata_t::details_t::update(post_t& post, bool gather_all) {
     filenames.insert(post.pos->pathname);
 
   date_t date = post.date();
+  date_t today = CURRENT_DATE();
 
-  if (date.year() == CURRENT_DATE().year() && date.month() == CURRENT_DATE().month())
-    posts_this_month_count++;
+  // Recency counters should only include postings that have actually
+  // occurred on or before today; future-dated postings must not inflate
+  // the "in last N days" or "this month" tallies (issue #741).
+  if (date <= today) {
+    if (date.year() == today.year() && date.month() == today.month())
+      posts_this_month_count++;
 
-  if ((CURRENT_DATE() - date).days() <= 30)
-    posts_last_30_count++;
-  if ((CURRENT_DATE() - date).days() <= 7)
-    posts_last_7_count++;
+    if ((today - date).days() <= 30)
+      posts_last_30_count++;
+    if ((today - date).days() <= 7)
+      posts_last_7_count++;
+
+    if (!is_valid(latest_past_post) || date > latest_past_post)
+      latest_past_post = date;
+  }
 
   if (!is_valid(earliest_post) || post.date() < earliest_post)
     earliest_post = post.date();

--- a/src/account.h
+++ b/src/account.h
@@ -296,6 +296,7 @@ public:
       date_t earliest_cleared_post; ///< Date of the earliest cleared posting.
       date_t latest_post;           ///< Date of the most recent posting.
       date_t latest_cleared_post;   ///< Date of the most recent cleared posting.
+      date_t latest_past_post;      ///< Most recent posting whose date is not in the future.
 
       datetime_t earliest_checkin;  ///< Earliest timeclock check-in timestamp.
       datetime_t latest_checkout;   ///< Latest timeclock check-out timestamp.

--- a/src/py_account.cc
+++ b/src/py_account.cc
@@ -155,6 +155,7 @@ void export_account() {
       .def_readonly("earliest_cleared_post", &account_t::xdata_t::details_t::earliest_cleared_post)
       .def_readonly("latest_post", &account_t::xdata_t::details_t::latest_post)
       .def_readonly("latest_cleared_post", &account_t::xdata_t::details_t::latest_cleared_post)
+      .def_readonly("latest_past_post", &account_t::xdata_t::details_t::latest_past_post)
 
       .def_readonly("filenames", &account_t::xdata_t::details_t::filenames)
       .def_readonly("accounts_referenced", &account_t::xdata_t::details_t::accounts_referenced)

--- a/src/stats.cc
+++ b/src/stats.cc
@@ -92,9 +92,15 @@ value_t report_statistics(call_scope_t& args) {
 
   out << '\n';
 
+  // Use latest_past_post (most recent non-future posting) so that
+  // future-dated transactions don't yield negative "days since" values.
+  // Fall back to latest_post only if every posting is in the future.
   out << _("  Days since last post:   ");
   out.width(6);
-  out << (CURRENT_DATE() - statistics.latest_post).days() << '\n';
+  out << (CURRENT_DATE() - (is_valid(statistics.latest_past_post) ? statistics.latest_past_post
+                                                                  : statistics.latest_post))
+             .days()
+      << '\n';
 
   out << _("  Posts in last 7 days:   ");
   out.width(6);

--- a/test/regress/741.test
+++ b/test/regress/741.test
@@ -1,13 +1,11 @@
 ; Regression test for issue #741: ledger stat doesn't handle future transactions well (BZ#741)
 ; https://github.com/ledger/ledger/issues/741
 ;
-; When future-dated transactions are present, the stat command incorrectly uses
-; the future transaction date as the reference point for "Days since last post",
-; "Posts in last 7 days", and "Posts in last 30 days" instead of using today's date.
-; With --now 2020/06/01:
-;   - "Days since last post" should be 4 (days since 2020/05/28), not -213
-;   - "Posts in last 7 days" should be 2 (from 2020/05/28), not 4 (which wrongly includes future postings)
-;   - "Posts in last 30 days" should be 2, not 4
+; When future-dated transactions are present, the stat command used to
+; include them in "Days since last post", "Posts in last 7 days",
+; "Posts in last 30 days", and "Posts seen this month".  Those recency
+; statistics should be computed relative to today, ignoring postings
+; whose dates are still in the future.
 
 2020/05/28 Past transaction
     Expenses:Food    $10.00
@@ -29,8 +27,8 @@ Time period: 20-May-28 to 20-Dec-31 (217 days)
   Number of postings:          4 (0.018 per day)
   Uncleared postings:          4
 
-  Days since last post:     -213
-  Posts in last 7 days:        4
-  Posts in last 30 days:       4
+  Days since last post:        4
+  Posts in last 7 days:        2
+  Posts in last 30 days:       2
   Posts seen this month:       0
 end test


### PR DESCRIPTION
## Summary

- Fix [#741](https://github.com/ledger/ledger/issues/741): `ledger stat` counted future-dated postings when computing *Days since last post*, *Posts in last 7 days*, *Posts in last 30 days*, and *Posts seen this month*, so a journal containing a transaction dated 2020/12/31 with `--now 2020/06/01` reported nonsensical values like `Days since last post: -213` and inflated last-7/last-30-day counts that swept in the future posting.
- Gate the recency counters in `details_t::update()` on `date <= today` and track a new `latest_past_post` field that records the most recent non-future posting date; use it in `stats.cc` for the "Days since last post" calculation, falling back to `latest_post` only when every posting is in the future.
- Move the confirmation test from `test/todo/741.test` to `test/regress/741.test` with the corrected expected output.

## Test plan

- [x] `cd build && ctest -R '^RegressTest_741$'` passes
- [x] `cd build && ctest -R stats` — all four stats tests pass (`cmd-stats`, `cmd-stats1`, `coverage-stats-command`, `coverage-stats-empty`)
- [x] Full suite `cd build && ctest` — 4267/4267 tests pass
- [x] Manual verification of Martin's original BZ#741 example (`2012-02-29` + `2012-03-24` with `--now "2012-02-29"`) now reports `Posts in last 7 days: 2` and `Days since last post: 0` instead of `4` and `-24`

🤖 Generated with [Claude Code](https://claude.com/claude-code)