### PR TITLE
Accept relative date expressions in xact command (#647)

### DIFF
--- a/src/draft.cc
+++ b/src/draft.cc
@@ -139,6 +139,7 @@ void draft_t::parse_args(const value_t& args) {
   tmpl = xact_template_t();
 
   optional<date_time::weekdays> weekday;
+  optional<date_t> rel_date;
   xact_template_t::post_template_t* post = nullptr;
   value_t::sequence_t::const_iterator begin = args.begin();
   value_t::sequence_t::const_iterator end = args.end();
@@ -148,6 +149,13 @@ void draft_t::parse_args(const value_t& args) {
 
     if (check_for_date && regex_match(arg, what, date_mask)) {
       tmpl->date_string = what[0];
+      check_for_date = false;
+    } else if (check_for_date && (rel_date = string_to_relative_date(arg))) {
+      // "today", "yesterday", "tomorrow" (and the short forms "tday",
+      // "yday", "tmrw") as a positional first argument.  Multi-word
+      // expressions such as "last month" must be passed with the `on`
+      // preposition so they can be supplied as a single argument.
+      tmpl->date = *rel_date;
       check_for_date = false;
     } else {
       weekday = string_to_day_of_week(arg);
@@ -360,14 +368,17 @@ xact_t* draft_t::insert(journal_t& journal) {
     added->_date = tmpl->date;
     DEBUG("draft.xact", "Setting date to template date: " << *tmpl->date);
   } else if (tmpl->date_string) {
-    // Convert separators to slashes for consistent parsing
+    // Convert separators to slashes for consistent parsing.  parse_date_expr
+    // first tries the registered date formats and falls back to the full
+    // period-expression grammar (yesterday, last month, 3 days ago, etc.)
+    // so the `on` preposition accepts the same date vocabulary as --period.
     string date_str = *tmpl->date_string;
     for (char& c : date_str) {
       if (c == '-' || c == '.')
         c = '/';
     }
 
-    added->_date = parse_date(date_str);
+    added->_date = parse_date_expr(date_str);
     DEBUG("draft.xact",
           "Setting date to parsed date string: " << *tmpl->date_string << " -> " << added->_date);
   }

--- a/src/times.cc
+++ b/src/times.cc
@@ -458,7 +458,7 @@ date_t parse_date(const char* str) {
 date_t parse_date_expr(const std::string& str) {
   try {
     return parse_date(str);
-  } catch (const date_error&) {
+  } catch (const date_error&) { // NOLINT(bugprone-empty-catch)
     // Fall through to the richer period-expression grammar.
   }
 

--- a/src/times.cc
+++ b/src/times.cc
@@ -390,6 +390,25 @@ optional<date_time::months_of_year> string_to_month_of_year(const std::string& s
     return none;
 }
 
+/**
+ * @brief Resolve a single-word relative-date keyword to a concrete date.
+ *
+ * Recognizes the common shorthand the `xact` command accepts in place of
+ * an explicit date: "today"/"tday", "yesterday"/"yday", "tomorrow"/"tmrw".
+ * The anchor is `epoch->date()` when --now is in effect, otherwise
+ * CURRENT_DATE(), matching the conventions used elsewhere by
+ * date_interval_t::determine_when().
+ */
+optional<date_t> string_to_relative_date(const std::string& str) {
+  if (str == _("today") || str == _("tday"))
+    return epoch ? epoch->date() : CURRENT_DATE();
+  if (str == _("yesterday") || str == _("yday"))
+    return (epoch ? epoch->date() : CURRENT_DATE()) - gregorian::days(1);
+  if (str == _("tomorrow") || str == _("tmrw"))
+    return (epoch ? epoch->date() : CURRENT_DATE()) + gregorian::days(1);
+  return none;
+}
+
 /*--- Top-Level Parse Functions ---*/
 
 /**
@@ -423,6 +442,32 @@ datetime_t parse_datetime(const char* str) {
 /// @brief Parse a date string using the registered format cascade.
 date_t parse_date(const char* str) {
   return parse_date_mask(str);
+}
+
+/**
+ * @brief Parse a date string that may be a formatted date or a relative
+ *        date expression.
+ *
+ * First delegates to parse_date() (which tries each registered date format).
+ * If that fails, the string is handed to date_interval_t, which supports the
+ * full period-expression grammar: `today`/`yesterday`/`tomorrow`, `this`/
+ * `next`/`last <unit>`, `<N> <unit> ago/hence`, and so on.  Only the interval's
+ * begin date is returned; callers interested in ranges should use
+ * date_interval_t directly.
+ */
+date_t parse_date_expr(const std::string& str) {
+  try {
+    return parse_date(str);
+  } catch (const date_error&) {
+    // Fall through to the richer period-expression grammar.
+  }
+
+  date_interval_t interval(str);
+  if (optional<date_t> when = interval.begin())
+    return *when;
+
+  throw_(date_error, _f("Invalid date: %1%") % str);
+  return date_t();
 }
 
 /*--- Date Specifier Resolution ---*/

--- a/src/times.h
+++ b/src/times.h
@@ -157,6 +157,15 @@ optional<date_time::weekdays> string_to_day_of_week(const std::string& str);
 /// @return The month, or none if the string is not recognized.
 optional<date_time::months_of_year> string_to_month_of_year(const std::string& str);
 
+/// @brief Resolve a single-word relative-date keyword ("today", "yesterday", "tomorrow",
+/// or the short forms "tday", "yday", "tmrw") to a concrete date.
+///
+/// The anchor is `epoch->date()` if --now was used, otherwise CURRENT_DATE().
+/// Intended for command-line contexts (like the xact command) that accept a
+/// relative date as a positional argument.
+/// @return The resolved date, or none if the string is not a recognized keyword.
+optional<date_t> string_to_relative_date(const std::string& str);
+
 /**
  * @brief Parse a datetime string in "YYYY/MM/DD HH:MM:SS" or "MM/DD/YYYY HH:MM:SS" format.
  *
@@ -195,6 +204,21 @@ date_t parse_date(const char* str);
 inline date_t parse_date(const std::string& str) {
   return parse_date(str.c_str());
 }
+
+/**
+ * @brief Parse a date string that may be either a standard date format or a
+ *        relative date expression (e.g. "yesterday", "last month", "3 days ago").
+ *
+ * First attempts `parse_date()` using the registered format readers.  If that
+ * fails, the string is handed to the `date_interval_t` parser, which recognizes
+ * the full period-expression grammar (today/yesterday/tomorrow, this/next/last
+ * <unit>, <N> <unit> ago/hence, and explicit dates).
+ *
+ * @param str  The date expression.
+ * @return     The resolved date.
+ * @throws date_error if neither parser accepts the string.
+ */
+date_t parse_date_expr(const std::string& str);
 
 /**
  * @brief Selects which format to use when rendering dates or datetimes.

--- a/test/regress/647.test
+++ b/test/regress/647.test
@@ -1,0 +1,86 @@
+; Regression test for issue #647: Add ability to pass offset dates to xact command
+; https://github.com/ledger/ledger/issues/647
+;
+; The xact command should accept relative date expressions ("today",
+; "yesterday", "tomorrow") as a positional first argument, and the full
+; period-expression grammar ("last month", "3 days ago", ...) via the
+; `on` preposition.  Previously only formatted dates or weekday names
+; were recognized.
+
+2024/01/15 Grocery Store
+    Expenses:Food    $50.00
+    Assets:Checking
+
+; Positional relative-date keywords
+
+test --now 2024/03/15 xact today Grocery
+2024/03/15 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+test --now 2024/03/15 xact yesterday Grocery
+2024/03/14 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+test --now 2024/03/15 xact tomorrow Grocery
+2024/03/16 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+; Positional short forms
+
+test --now 2024/03/15 xact tday Grocery
+2024/03/15 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+test --now 2024/03/15 xact yday Grocery
+2024/03/14 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+test --now 2024/03/15 xact tmrw Grocery
+2024/03/16 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+; The `on` preposition accepts the full period-expression grammar
+
+test --now 2024/03/15 xact Grocery on yesterday
+2024/03/14 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+test --now 2024/03/15 xact Grocery on "last month"
+2024/02/01 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+test --now 2024/03/15 xact Grocery on "3 days ago"
+2024/03/12 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+; Existing date syntaxes must continue to work
+
+test --now 2024/03/15 xact 2024/03/10 Grocery
+2024/03/10 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test
+
+test --now 2024/03/15 xact monday Grocery
+2024/03/11 Grocery Store
+    Expenses:Food                             $50.00
+    Assets:Checking
+end test


### PR DESCRIPTION
## Summary

The `xact` command previously only recognized formatted dates or weekday names when drafting a new transaction. This PR adds relative-date support, resolving the long-standing feature request in issue #647.

## Approach

Rather than trying to guess multi-word date phrases in the positional parser (the approach in the earlier PR #3112, which became hacky due to exception-based control flow and token accumulation), this change introduces two small, focused helpers and wires them in cleanly:

- **`string_to_relative_date()`** — in `src/times.cc`, next to `string_to_day_of_week()` / `string_to_month_of_year()`. Resolves `today`/`tday`, `yesterday`/`yday`, `tomorrow`/`tmrw` against `epoch`/`CURRENT_DATE()`. Single-word, unambiguous.

- **`parse_date_expr()`** — delegates to `parse_date()` first (existing format cascade) and falls back to `date_interval_t` only if that fails. No exception-based branching scattered through the call site.

In `src/draft.cc`:
- Positional first argument: a quick `string_to_relative_date()` check sits beside the existing numeric-date and weekday checks.
- `on <date>` preposition: the captured `date_string` now flows through `parse_date_expr`, so it accepts the full period-expression grammar (\`on yesterday\`, \`on \"last month\"\`, \`on \"3 days ago\"\`, etc.).

Multi-word expressions are handled only via the \`on\` preposition — the positional parser never has to guess where a date ends and a payee begins.

## Test plan
- [x] \`test/regress/647.test\` covers positional \`today\`/\`yesterday\`/\`tomorrow\` and their short forms, the three \`on\` forms above, and the existing numeric-date and weekday paths.
- [x] Full local suite: 4297/4297 regression tests, 305/305 baseline tests pass.
- [x] \`clang-format\` clean on \`draft.cc\`, \`times.cc\`, \`times.h\`.
- [x] \`nix build .\` green.

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)