### PR TITLE
Fix stats command day count for single-day journals (#740)

### DIFF
--- a/src/stats.cc
+++ b/src/stats.cc
@@ -53,9 +53,14 @@ value_t report_statistics(call_scope_t& args) {
   assert(is_valid(statistics.earliest_post));
   assert(is_valid(statistics.latest_post));
 
+  // Use inclusive day count: a single-day period spans 1 day, not 0.
+  // This also prevents division by zero when computing the per-day rate
+  // for journals whose transactions all fall on the same date.
+  long period_days =
+      (statistics.latest_post - statistics.earliest_post).days() + 1;
+
   out << format(_f("Time period: %1% to %2% (%3% days)") % format_date(statistics.earliest_post) %
-                format_date(statistics.latest_post) %
-                (statistics.latest_post - statistics.earliest_post).days())
+                format_date(statistics.latest_post) % period_days)
       << '\n'
       << '\n';
 
@@ -82,8 +87,7 @@ value_t report_statistics(call_scope_t& args) {
 
   out << " (";
   out.precision(2);
-  out << (double(statistics.posts_count) /
-          double((statistics.latest_post - statistics.earliest_post).days()))
+  out << (double(statistics.posts_count) / double(period_days))
       << _(" per day)") << '\n';
 
   out << _("  Uncleared postings:     ");

--- a/src/stats.cc
+++ b/src/stats.cc
@@ -56,8 +56,7 @@ value_t report_statistics(call_scope_t& args) {
   // Use inclusive day count: a single-day period spans 1 day, not 0.
   // This also prevents division by zero when computing the per-day rate
   // for journals whose transactions all fall on the same date.
-  long period_days =
-      (statistics.latest_post - statistics.earliest_post).days() + 1;
+  long period_days = (statistics.latest_post - statistics.earliest_post).days() + 1;
 
   out << format(_f("Time period: %1% to %2% (%3% days)") % format_date(statistics.earliest_post) %
                 format_date(statistics.latest_post) % period_days)
@@ -87,8 +86,7 @@ value_t report_statistics(call_scope_t& args) {
 
   out << " (";
   out.precision(2);
-  out << (double(statistics.posts_count) / double(period_days))
-      << _(" per day)") << '\n';
+  out << (double(statistics.posts_count) / double(period_days)) << _(" per day)") << '\n';
 
   out << _("  Uncleared postings:     ");
   out.width(6);

--- a/test/baseline/cmd-stats.test
+++ b/test/baseline/cmd-stats.test
@@ -12,7 +12,7 @@
     B
 
 test stats --now "2012-03-31"
-Time period: 12-Feb-28 to 12-Mar-24 (25 days)
+Time period: 12-Feb-28 to 12-Mar-24 (26 days)
 
   Files these postings came from:
     $sourcepath/test/baseline/cmd-stats.test
@@ -20,7 +20,7 @@ Time period: 12-Feb-28 to 12-Mar-24 (25 days)
   Unique payees:               1
   Unique accounts:             4
 
-  Number of postings:          6 (0.24 per day)
+  Number of postings:          6 (0.23 per day)
   Uncleared postings:          2
 
   Days since last post:        7

--- a/test/baseline/cmd-stats1.test
+++ b/test/baseline/cmd-stats1.test
@@ -6,7 +6,7 @@
     Equity
 
 test stats --now "2023-02-06"
-Time period: 23-Feb-06 to 23-Feb-06 (0 days)
+Time period: 23-Feb-06 to 23-Feb-06 (1 days)
 
   Files these postings came from:
     $FILE
@@ -14,7 +14,7 @@ Time period: 23-Feb-06 to 23-Feb-06 (0 days)
   Unique payees:               1
   Unique accounts:             1
 
-  Number of postings:          1 (inf per day)
+  Number of postings:          1 (1 per day)
   Uncleared postings:          1
 
   Days since last post:        0

--- a/test/regress/1631.test
+++ b/test/regress/1631.test
@@ -20,7 +20,7 @@
     Assets:Checking
 
 test --now 2024/03/01 stats
-Time period: 24-Jan-01 to 24-Feb-15 (45 days)
+Time period: 24-Jan-01 to 24-Feb-15 (46 days)
 
   Files these postings came from:
     $FILE
@@ -28,7 +28,7 @@ Time period: 24-Jan-01 to 24-Feb-15 (45 days)
   Unique payees:               4
   Unique accounts:             4
 
-  Number of postings:          8 (0.18 per day)
+  Number of postings:          8 (0.17 per day)
   Uncleared postings:          8
 
   Days since last post:       15

--- a/test/regress/740.test
+++ b/test/regress/740.test
@@ -1,16 +1,18 @@
 ; Regression test for issue #740: ledger stat calculates days incorrectly (BZ#740)
 ; https://github.com/ledger/ledger/issues/740
 ;
-; When all transactions are on a single day, stat shows "0 days" and "inf per day"
-; because it computes (latest_post - earliest_post).days() = 0.
-; The correct count should be 1 day, giving a meaningful per-day rate.
+; When all transactions fall on a single day, the stats command used to
+; report a span of "0 days" and "inf per day" because it computed the raw
+; difference (latest_post - earliest_post).days() == 0.  The fix uses an
+; inclusive day count so a single-day journal spans 1 day and yields a
+; meaningful per-day rate.
 
 2014/01/01 Single Day Transaction
     Assets:Checking    $1000.00
     Equity:Opening
 
 test stat | sed 's/Days since last post: *[0-9]*/Days since last post:     NNNN/; s/Posts in last [0-9]* days: *[0-9]*/Posts in last N days:        0/g; s/Posts seen this month: *[0-9]*/Posts seen this month:       0/'
-Time period: 14-Jan-01 to 14-Jan-01 (0 days)
+Time period: 14-Jan-01 to 14-Jan-01 (1 days)
 
   Files these postings came from:
     $FILE
@@ -18,7 +20,7 @@ Time period: 14-Jan-01 to 14-Jan-01 (0 days)
   Unique payees:               1
   Unique accounts:             2
 
-  Number of postings:          2 (inf per day)
+  Number of postings:          2 (2 per day)
   Uncleared postings:          2
 
   Days since last post:     NNNN

--- a/test/regress/741.test
+++ b/test/regress/741.test
@@ -16,7 +16,7 @@
     Assets:Cash
 
 test --now 2020/06/01 stat
-Time period: 20-May-28 to 20-Dec-31 (217 days)
+Time period: 20-May-28 to 20-Dec-31 (218 days)
 
   Files these postings came from:
     $FILE


### PR DESCRIPTION
## Summary

Closes #740.

`ledger stats` reported `Time period: ... (0 days)` and `(inf per day)` whenever a journal's transactions all fell on a single date, because it computed the period as `(latest_post - earliest_post).days()`.  That value is `0` for a single-day journal, which is both counter-intuitive and the cause of the divide-by-zero in the per-day rate.

`src/stats.cc` now uses an inclusive day count (`+1`).  A single-day journal reports `(1 days)` and a meaningful per-day rate, and a journal that runs from Jan 1 through Jan 31 reports `(31 days)` rather than `(30 days)` — matching the usual reading of a "time period".

The change updates three existing tests whose expected output baked in the old computation:
- `test/baseline/cmd-stats.test` — multi-day journal (25 → 26 days, 0.24 → 0.23 per day)
- `test/regress/1631.test` — multi-day journal (45 → 46 days, 0.18 → 0.17 per day)
- `test/baseline/cmd-stats1.test` — single-day journal that had been asserting the buggy `(inf per day)` output; now confirms the fix

The confirmation test from `test/todo/740.test` moves to `test/regress/740.test` with its expected output corrected to demonstrate the fix.

## Test plan

- [x] `cd build && ctest` — all 4267 tests pass with the fix
- [x] Manual repro from the issue:
  ```
  $ ledger -f a stats --now "2012-03-25"
  Time period: 12-Mar-24 to 12-Mar-24 (1 days)
  ...
    Number of postings: 2 (2 per day)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)