### PR TITLE
ci: free disk space before coverage job to prevent runner OOM

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -103,6 +103,21 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        # LLVM coverage instrumentation generates several GB of .profraw data
+        # across the full test suite; the default ubuntu-latest image has been
+        # running out of disk space mid-test, aborting the runner with
+        # "No space left on device". Remove preinstalled toolchains that
+        # this job does not need before checkout.
+        run: |
+          df -h /
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h /
+
       - uses: actions/checkout@v6
         name: Check out repository code
 


### PR DESCRIPTION
## Summary

- Prune ~20GB of preinstalled toolchains (Android SDK, .NET, GHC, CodeQL bundle, agent tools) before the coverage job runs.
- Prevents the `Run tests and generate coverage report` step from aborting mid-execution with `System.IO.IOException: No space left on device`.

## Context

The coverage job has started intermittently crashing the GitHub Actions runner itself during LLVM instrumentation of the full test suite. Two recent merge-queue runs died with identical errors at ~9m53s into the step:

- [PR #3142 run 24851525802](https://github.com/ledger/ledger/actions/runs/24851525802)
- [PR #3140 run 24853934536](https://github.com/ledger/ledger/actions/runs/24853934536/job/72761621060)

`-fprofile-instr-generate -fcoverage-mapping` writes a `.profraw` per invocation, and with 4000+ ctest cases that adds up to several GB before `llvm-profdata merge` can consolidate them. On an ubuntu-latest image that also has ~30GB of unused toolchains preinstalled, disk pressure now tips over the runner.

The `df -h /` bookend prints before/after so future disk regressions are easy to diagnose from the log.

## Test plan

- [ ] Observe CI `coverage` job run to completion on this PR
- [ ] Confirm `df -h /` output shows freed space (~20GB)
- [ ] Verify line/function coverage thresholds still pass