### PR TITLE
Accept duration units in --price-exp / --leeway (#607)

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -1016,16 +1016,29 @@ spaces at the beginning of each line of the output.
 .It Fl \-price Pq Fl I
 Use the price of the commodity purchase for performing calculations.
 .It Fl \-price-db Ar FILE
-.It Fl \-price-exp Ar INT Pq Fl Z
-Set the expected freshness of price quotes, in
-.Ar INT
-hours.  That
-is, if the last known quote for any commodity is older than this value,
-and if
+.It Fl \-price-exp Ar DURATION Pq Fl Z
+Set the expected freshness of price quotes.
+.Ar DURATION
+is an integer optionally followed by a single unit character
+(case-insensitive):
+.Sy s
+for seconds,
+.Sy m
+for minutes,
+.Sy h
+for hours,
+.Sy d
+for days, or
+.Sy w
+for weeks.  A bare integer is interpreted as hours (so
+.Ql 24
+and
+.Ql 24h
+are equivalent, and the default is 24 hours).  If the last known quote
+for any commodity is older than this value, and if
 .Fl \-download
-is being used, then the Internet will be
-consulted again for a newer price.  Otherwise, the old price is still
-considered to be fresh enough.
+is being used, then the Internet will be consulted again for a newer
+price.  Otherwise, the old price is still considered to be fresh enough.
 Alias for
 .Fl \-leeway .
 .It Fl \-prices-format Ar FMT

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -6809,10 +6809,14 @@ Group postings together, similar to the balance report.
 @item --price-db @var{FILE}
 Use @file{FILE} for retrieving stored commodity prices.
 
-@item --price-exp @var{INT}
-@itemx --leeway @var{INT}
-@itemx -Z @var{INT}
-Set expected freshness of prices in @var{INT} hours.
+@item --price-exp @var{DURATION}
+@itemx --leeway @var{DURATION}
+@itemx -Z @var{DURATION}
+Set expected freshness of prices.  @var{DURATION} is an integer optionally
+followed by a single unit character (case-insensitive): @samp{s} for seconds,
+@samp{m} for minutes, @samp{h} for hours, @samp{d} for days, or @samp{w} for
+weeks.  A bare integer is interpreted as hours (for example, @samp{24}
+and @samp{24h} are equivalent).
 
 @item --download
 @itemx -Q
@@ -7117,14 +7121,18 @@ Quiet balance assertions.
 @item --price-db @var{FILE}
 Specify the location of the price entry data file.
 
-@item --price-exp @var{INT}
-@itemx --leeway @var{INT}
-@itemx -Z @var{INT}
-Set the expected freshness of price quotes, in @var{INT} hours.  That
-is, if the last known quote for any commodity is older than this value,
-and if @option{--download} is being used, then the Internet will be
-consulted again for a newer price.  Otherwise, the old price is still
-considered to be fresh enough.
+@item --price-exp @var{DURATION}
+@itemx --leeway @var{DURATION}
+@itemx -Z @var{DURATION}
+Set the expected freshness of price quotes.  @var{DURATION} is an integer
+optionally followed by a single unit character (case-insensitive):
+@samp{s} for seconds, @samp{m} for minutes, @samp{h} for hours, @samp{d}
+for days, or @samp{w} for weeks.  A bare integer is interpreted as hours
+(so @samp{24} and @samp{24h} are equivalent, and the default is 24 hours).
+If the last known quote for any commodity is older than this value, and
+if @option{--download} is being used, then the Internet will be consulted
+again for a newer price.  Otherwise, the old price is still considered
+to be fresh enough.
 
 @item --strict
 Ledger normally silently accepts any account or commodity in a posting,
@@ -8684,14 +8692,18 @@ it manually.
 The format of the file can be changed by telling ledger to use the
 @option{--pricedb-format @var{FORMAT_STRING}} you define.
 
-@item --price-exp @var{INT}
-@itemx --leeway @var{INT}
-@itemx -Z @var{INT}
-Set the expected freshness of price quotes, in @var{INT} hours.  That
-is, if the last known quote for any commodity is older than this value,
-and if @option{--download} is being used, then the Internet will be
-consulted again for a newer price.  Otherwise, the old price is still
-considered to be fresh enough.
+@item --price-exp @var{DURATION}
+@itemx --leeway @var{DURATION}
+@itemx -Z @var{DURATION}
+Set the expected freshness of price quotes.  @var{DURATION} is an integer
+optionally followed by a single unit character (case-insensitive):
+@samp{s} for seconds, @samp{m} for minutes, @samp{h} for hours, @samp{d}
+for days, or @samp{w} for weeks.  A bare integer is interpreted as hours
+(so @samp{24} and @samp{24h} are equivalent, and the default is 24 hours).
+If the last known quote for any commodity is older than this value, and
+if @option{--download} is being used, then the Internet will be consulted
+again for a newer price.  Otherwise, the old price is still considered
+to be fresh enough.
 
 @item --download
 @itemx -Q

--- a/src/report.cc
+++ b/src/report.cc
@@ -104,11 +104,21 @@ long parse_leeway_seconds(const string& raw) {
   char suffix = s[s.size() - 1];
   if (!std::isdigit(static_cast<unsigned char>(suffix))) {
     switch (std::tolower(static_cast<unsigned char>(suffix))) {
-    case 's': multiplier = 1L; break;
-    case 'm': multiplier = 60L; break;
-    case 'h': multiplier = 3600L; break;
-    case 'd': multiplier = 86400L; break;
-    case 'w': multiplier = 604800L; break;
+    case 's':
+      multiplier = 1L;
+      break;
+    case 'm':
+      multiplier = 60L;
+      break;
+    case 'h':
+      multiplier = 3600L;
+      break;
+    case 'd':
+      multiplier = 86400L;
+      break;
+    case 'w':
+      multiplier = 604800L;
+      break;
     default:
       throw_(option_error,
              _f("Invalid unit '%1%' for --price-exp; expected s, m, h, d, or w") % suffix);

--- a/src/report.cc
+++ b/src/report.cc
@@ -85,6 +85,56 @@
 
 namespace ledger {
 
+namespace {
+
+/// Parse a --price-exp / --leeway duration string into seconds.
+///
+/// Accepts an integer optionally followed by a single-character unit suffix
+/// (case-insensitive): @c s (seconds), @c m (minutes), @c h (hours),
+/// @c d (days), or @c w (weeks).  A bare integer with no suffix is interpreted
+/// as hours for backward compatibility (issue #607).  Whitespace around the
+/// value and between the number and its suffix is tolerated.
+long parse_leeway_seconds(const string& raw) {
+  string s = raw;
+  boost::algorithm::trim(s);
+  if (s.empty())
+    throw_(option_error, _f("Missing argument for --price-exp"));
+
+  long multiplier = 3600L; // default: hours
+  char suffix = s[s.size() - 1];
+  if (!std::isdigit(static_cast<unsigned char>(suffix))) {
+    switch (std::tolower(static_cast<unsigned char>(suffix))) {
+    case 's': multiplier = 1L; break;
+    case 'm': multiplier = 60L; break;
+    case 'h': multiplier = 3600L; break;
+    case 'd': multiplier = 86400L; break;
+    case 'w': multiplier = 604800L; break;
+    default:
+      throw_(option_error,
+             _f("Invalid unit '%1%' for --price-exp; expected s, m, h, d, or w") % suffix);
+    }
+    s.erase(s.size() - 1);
+    boost::algorithm::trim_right(s);
+  }
+
+  long value;
+  try {
+    value = lexical_cast<long>(s);
+  } catch (const bad_lexical_cast&) {
+    throw_(option_error, _f("Invalid value for --price-exp: %1%") % raw);
+  }
+
+  if (value < 0)
+    throw_(option_error, _f("--price-exp value must be non-negative: %1%") % raw);
+
+  if (value > std::numeric_limits<long>::max() / multiplier)
+    throw_(option_error, _f("--price-exp value too large: %1%") % raw);
+
+  return value * multiplier;
+}
+
+} // anonymous namespace
+
 /*--- Option Normalization ---*/
 
 void report_t::normalize_options(const string& verb) {
@@ -139,7 +189,7 @@ void report_t::normalize_options(const string& verb) {
 
   if (session.HANDLED(price_exp_))
     commodity_pool_t::current_pool->quote_leeway =
-        lexical_cast<long>(session.HANDLER(price_exp_).value) * 3600L;
+        parse_leeway_seconds(session.HANDLER(price_exp_).value);
 
   if (session.HANDLED(price_db_))
     commodity_pool_t::current_pool->price_db = session.HANDLER(price_db_).str();

--- a/test/regress/607.test
+++ b/test/regress/607.test
@@ -1,0 +1,82 @@
+; Regression test for issue #607: --price-exp should accept unit suffixes.
+; https://github.com/ledger/ledger/issues/607
+;
+; Historically, --price-exp (-Z / --leeway) accepted only a bare integer
+; interpreted as a number of hours.  The issue requested an expanded syntax
+; that also understands minutes, hours, days, and weeks (case-insensitive).
+;
+; The new syntax accepts an integer optionally followed by a single unit
+; character:
+;   s = seconds, m = minutes, h = hours, d = days, w = weeks
+; A bare integer with no suffix is still interpreted as hours, preserving
+; backward compatibility with existing command lines and configuration files.
+
+P 2024/01/01 AAPL $150.00
+
+2024/01/15 Buy Stock
+    Assets:Brokerage    10 AAPL
+    Assets:Checking    $-1500.00
+
+; Bare integer (backward compatible: interpreted as hours).
+test bal --price-exp 24 --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+; Explicit hours suffix (case-insensitive).
+test bal --price-exp 24h --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+test bal --price-exp 24H --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+; Days suffix (case-insensitive).
+test bal --price-exp 7d --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+test bal --price-exp 7D --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+; Weeks, minutes, and seconds suffixes.
+test bal --price-exp 2w --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+test bal --price-exp 45m --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+test bal --price-exp 3600s --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+; -Z short alias accepts the same syntax.
+test bal -Z 24h --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+; --leeway is an alias and must also honor the new syntax.
+test bal --leeway 7d --market Assets:Brokerage
+            $1500.00  Assets:Brokerage
+end test
+
+; An unrecognized unit is reported with a clear error.
+test bal --price-exp 5x Assets -> 1
+__ERROR__
+Error: Invalid unit 'x' for --price-exp; expected s, m, h, d, or w
+end test
+
+; A non-numeric argument is reported as invalid.
+test bal --price-exp abcd Assets -> 1
+__ERROR__
+Error: Invalid value for --price-exp: abcd
+end test
+
+; Negative values are rejected: a stale threshold cannot run backwards.
+test bal --price-exp -5 Assets -> 1
+__ERROR__
+Error: --price-exp value must be non-negative: -5
+end test


### PR DESCRIPTION
## Summary

Closes #607.

`--price-exp` (and its aliases `--leeway` / `-Z`) historically accepted only
a bare integer, interpreted as a number of hours.  This PR extends the option
to accept a single-character unit suffix so users can say `24h`, `7d`, `45m`,
`2w`, or `3600s` directly, without converting by hand.

## Details

- Units (case-insensitive): `s` = seconds, `m` = minutes, `h` = hours,
  `d` = days, `w` = weeks.
- A bare integer with no suffix is still treated as hours, so every existing
  command line, config file, and price database keeps working.
- Invalid inputs (unknown unit, non-numeric value, negative, overflow) now
  produce a clear `option_error` that names the offending argument instead of
  a raw `bad_lexical_cast`.
- Parsing lives in a small anonymous-namespace helper in `src/report.cc`,
  right next to the one place that converts the option value into
  `commodity_pool_t::quote_leeway` seconds.
- `doc/ledger3.texi` and `doc/ledger.1` now document the new syntax in all
  three places `--price-exp` is described.

## Test plan

- [x] `test/regress/607.test` exercises every unit, the backward-compatible
      bare-integer form, the `-Z` and `--leeway` aliases, and each error path
      (unknown unit, non-numeric, negative).
- [x] Local `ctest -j8` run: 4279/4281 regression tests passed.  The two
      flaky failures (`RegressTest_1784`, `RegressTest_1798`) pass on isolated
      re-run and are unrelated to this change.