### PR TITLE
Add regression test for --lots-fifo / --lots-lifo (#1802)

### DIFF
--- a/test/regress/1802.test
+++ b/test/regress/1802.test
@@ -1,0 +1,54 @@
+; Regression test for issue #1802: sort lots by date with --lots.
+;
+; Reproduces the scenario from the issue: many small periodic purchases
+; at varying prices.  The reporter observed that `bal --lots` sorts the
+; lots by price (the default compare_by_commodity ordering) which makes
+; it tedious to see when each purchase was made.  `--lot-dates` orders
+; by date but strips the price annotation, so the per-lot cost basis is
+; lost.
+;
+; The `--lots-fifo` and `--lots-lifo` options (added for issue #1558)
+; display lots in date order while retaining the price annotation, which
+; is what the issue requested.
+
+2024/01/15 * Periodic buy
+    Assets:Brokerage        5 HY {$48.00} [2024/01/15]
+    Assets:Cash
+
+2024/02/15 * Periodic buy
+    Assets:Brokerage        5 HY {$52.00} [2024/02/15]
+    Assets:Cash
+
+2024/03/15 * Periodic buy
+    Assets:Brokerage        5 HY {$46.00} [2024/03/15]
+    Assets:Cash
+
+2024/04/15 * Periodic buy
+    Assets:Brokerage        5 HY {$50.00} [2024/04/15]
+    Assets:Cash
+
+; With --lots the default ordering sorts lots by price, so the January
+; purchase (the earliest) does not appear first.
+test bal --lots Assets:Brokerage
+5 HY {$46} [2024/03/15]
+5 HY {$48} [2024/01/15]
+5 HY {$50} [2024/04/15]
+5 HY {$52} [2024/02/15]  Assets:Brokerage
+end test
+
+; --lots-fifo sorts oldest-first while keeping prices and dates, which
+; is the ordering the issue asked for.
+test bal --lots-fifo Assets:Brokerage
+5 HY {$48} [2024/01/15]
+5 HY {$52} [2024/02/15]
+5 HY {$46} [2024/03/15]
+5 HY {$50} [2024/04/15]  Assets:Brokerage
+end test
+
+; --lots-lifo gives the reverse chronological order.
+test bal --lots-lifo Assets:Brokerage
+5 HY {$50} [2024/04/15]
+5 HY {$46} [2024/03/15]
+5 HY {$52} [2024/02/15]
+5 HY {$48} [2024/01/15]  Assets:Brokerage
+end test


### PR DESCRIPTION
## Summary

Issue [#1802](https://github.com/ledger/ledger/issues/1802) asked for a way to sort
the output of `balance --lots` in date order while still showing the per-lot price
annotation.  `--lots` alone sorts lots by price (the default
`compare_by_commodity` order) and `--lot-dates` drops the price information, so
neither satisfied the reporter's use case of reviewing many small periodic
purchases in chronological order.

The `--lots-fifo` and `--lots-lifo` options (added for issue #1558 in PR #2739)
already do exactly this: they imply both `--lot-prices` and `--lot-dates`, and
sort lots by acquisition date ascending (FIFO) or descending (LIFO).

This PR adds a dedicated regression test that mirrors the scenario described
in #1802 — several small periodic purchases at varying prices where price
order and date order are distinct — so the feature's effect on this use case
is exercised directly and any future regression in that ordering would be
caught here.

Closes #1802.

## Test plan

- [x] New `test/regress/1802.test` passes under `python3 test/RegressTests.py`.
- [x] Existing lot-ordering tests (`opt-lots-fifo`, `opt-lots-lifo`,
      `opt-lots`, `RegressTest_1558`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)