### PR TITLE
Preserve push-command positional query args in REPL (#528)

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -182,11 +182,20 @@ public:
 
   /// REPL pre-command: push a copy of the current report onto the stack
   /// at position 2 (below the active report whose output stream is open).
-  value_t push_command(call_scope_t&) {
+  /// Options set on the push command line (e.g. --period) were applied to
+  /// the active report during argument processing and are preserved via the
+  /// copy; positional query terms (e.g. account names) are applied here so
+  /// that they too persist until the matching pop.  Fixes #528.
+  value_t push_command(call_scope_t& args) {
     // Make a copy at position 2, because the topmost report object has an
     // open output stream at this point.  We want it to get popped off as
     // soon as this command terminate so that the stream is closed cleanly.
-    report_stack.insert(++report_stack.begin(), new report_t(report_stack.front()));
+    report_t* saved_report = new report_t(report_stack.front());
+    report_stack.insert(++report_stack.begin(), saved_report);
+
+    if (args.size() > 0)
+      saved_report->parse_query_args(args.value(), "#push");
+
     return true;
   }
 

--- a/test/regress/528.dat
+++ b/test/regress/528.dat
@@ -1,0 +1,16 @@
+--no-pager --columns=80 b
+--no-pager --columns=80 b Groceries
+--no-pager --columns=80 push Groceries
+--no-pager --columns=80 b
+--no-pager --columns=80 pop
+--no-pager --columns=80 b
+--no-pager --columns=80 push -p "2018/01"
+--no-pager --columns=80 b
+--no-pager --columns=80 pop
+--no-pager --columns=80 push Fuel
+--no-pager --columns=80 push -p "2018/03"
+--no-pager --columns=80 b
+--no-pager --columns=80 pop
+--no-pager --columns=80 b
+--no-pager --columns=80 pop
+--no-pager --columns=80 b

--- a/test/regress/528.test
+++ b/test/regress/528.test
@@ -1,0 +1,54 @@
+; Regression test for issue #528: push/pop REPL commands
+; https://github.com/ledger/ledger/issues/528
+;
+; The `push` pre-command should preserve both options (e.g. -p) and
+; positional query arguments (e.g. "Groceries") across subsequent
+; commands until the matching `pop`.
+;
+; Before the fix, positional query args passed to `push` were silently
+; dropped: the push_command handler ignored its argument list, so only
+; options preserved via the report_t copy constructor survived.  After
+; the fix, push_command forwards its positional arguments to
+; parse_query_args() on the preserved report so that query terms behave
+; the same as --period and other --option flags.
+
+2018-01-01 Walmart
+    Expenses:Groceries                                   50.00 USD
+    Assets:Bank:Checking
+
+2018-02-01 Walmart
+    Expenses:Groceries                                   50.00 USD
+    Assets:Bank:Checking
+
+2018-03-01 Fuel Station
+    Expenses:Fuel                                        30.00 USD
+    Assets:Bank:Checking
+
+test --now "2018-02-15" --script test/regress/528.dat
+         -130.00 USD  Assets:Bank:Checking
+          130.00 USD  Expenses
+           30.00 USD    Fuel
+          100.00 USD    Groceries
+--------------------
+                   0
+          100.00 USD  Expenses:Groceries
+          100.00 USD  Expenses:Groceries
+         -130.00 USD  Assets:Bank:Checking
+          130.00 USD  Expenses
+           30.00 USD    Fuel
+          100.00 USD    Groceries
+--------------------
+                   0
+          -50.00 USD  Assets:Bank:Checking
+           50.00 USD  Expenses:Groceries
+--------------------
+                   0
+           30.00 USD  Expenses:Fuel
+           30.00 USD  Expenses:Fuel
+         -130.00 USD  Assets:Bank:Checking
+          130.00 USD  Expenses
+           30.00 USD    Fuel
+          100.00 USD    Groceries
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Forward the `push` pre-command's positional arguments to
  `parse_query_args()` on the preserved report so positional filters
  (account names, payee masks, etc.) persist until the matching `pop`,
  matching how options like `--period` already behave.
- Add regression test `528.test` that drives `push`/`pop` through
  `--script` mode with a mix of positional filters, options, and
  nested pushes, so a regression in either path shows up as a visible
  balance diff.

Fixes #528.

## Test plan
- [x] `ctest -R RegressTest_528` passes
- [x] Related REPL tests (`1980`, `2131_repl_gain`,
      `coverage-global-push-precommand`) still pass
- [x] Confirmed `528.test` fails against the pre-fix binary and passes
      after the patch