### PR TITLE
Support nested account declarations (issue #877)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,10 @@
 
 - Add yday shortcut for "yesterday"
 
+- Allow nested `account` sub-directives inside an `account` block so a
+  parent account can declare its children without repeating the full
+  colon-separated path (issue #877)
+
 ### File Handling
 
 - Skip files with invalid UTF-8 names in include directive (bug #2421)

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -2357,6 +2357,30 @@ The @code{default} directive specifies that this account should be
 used as the ``balancing account'' for any future transactions that
 contain only a single posting.
 
+The @code{account} sub-directive declares a child account under the
+enclosing account, so the full colon-separated path need not be
+repeated for every descendant.  Nested @code{account} sub-directives
+can themselves contain further sub-directives (including more nested
+accounts); indentation determines nesting, so sub-directives that
+sit at the same indentation as a nested @code{account} keyword
+continue to attach to the enclosing account.
+
+@smallexample @c input:validate
+account Income
+    note Top-level income category
+    account Salary
+        note Regular monthly salary
+        alias salary
+    account Apps
+        account Android
+        account iPhone
+    account Rent
+@end smallexample
+
+The example above declares @samp{Income}, @samp{Income:Salary},
+@samp{Income:Apps}, @samp{Income:Apps:Android},
+@samp{Income:Apps:iPhone}, and @samp{Income:Rent}.
+
 @item apply account
 @findex apply account
 @c instance_t::master_account_directive

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -232,6 +232,35 @@ std::streamsize instance_t::read_line(char*& line) {
   return len;
 }
 
+std::size_t instance_t::peek_line_indent() {
+  if (!in.good() || in.eof())
+    return 0;
+
+  int first = in.peek();
+  if (in.eof() || (first != ' ' && first != '\t'))
+    return 0;
+
+  std::streampos saved_pos = in.tellg();
+  if (saved_pos == std::streampos(-1)) {
+    // Non-seekable stream: fall back to reporting a single unit of indent
+    // so callers still treat the line as a continuation.
+    return 1;
+  }
+
+  std::size_t count = 0;
+  while (in.good()) {
+    int c = in.peek();
+    if (c != ' ' && c != '\t')
+      break;
+    in.get();
+    count++;
+  }
+
+  in.clear();
+  in.seekg(saved_pos);
+  return count;
+}
+
 /*--- Line Dispatch ---*/
 
 xact_t* instance_t::read_next_directive(bool& error_flag, xact_t* previous_xact) {

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -538,15 +538,24 @@ void instance_t::end_apply_directive(char* kind) {
 /*--- Account Directives ---*/
 
 void instance_t::account_directive(char* line) {
+  account_directive_body(line, top_account(), 0);
+}
+
+void instance_t::account_directive_body(char* line, account_t* parent,
+                                        std::size_t outer_indent) {
   std::istream::pos_type beg_pos = context.line_beg_pos;
   std::size_t beg_linenum = context.linenum;
 
   char* p = skip_ws(line);
-  account_t* account = context.journal->register_account(p, nullptr, top_account());
+  account_t* account = context.journal->register_account(p, nullptr, parent);
   account->add_flags(ACCOUNT_KNOWN);
   unique_ptr<auto_xact_t> ae;
 
-  while (peek_whitespace_line()) {
+  while (true) {
+    std::size_t next_indent = peek_line_indent();
+    if (next_indent == 0 || next_indent <= outer_indent)
+      break;
+
     read_line(line);
     char* q = skip_ws(line);
     if (!*q)
@@ -566,6 +575,11 @@ void instance_t::account_directive(char* line) {
       account_value_directive(account, b);
     } else if (keyword == "default") {
       account_default_directive(account);
+    } else if (keyword == "account") {
+      // Nested account declaration (issue #877): register a child account
+      // using the enclosing account as its parent, avoiding the need to
+      // repeat the full colon-separated path.
+      account_directive_body(b, account, next_indent);
     } else if (keyword == "assert" || keyword == "check") {
       keep_details_t keeper(true, true, true);
       string safe_name = account->fullname();

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -541,8 +541,7 @@ void instance_t::account_directive(char* line) {
   account_directive_body(line, top_account(), 0);
 }
 
-void instance_t::account_directive_body(char* line, account_t* parent,
-                                        std::size_t outer_indent) {
+void instance_t::account_directive_body(char* line, account_t* parent, std::size_t outer_indent) {
   std::istream::pos_type beg_pos = context.line_beg_pos;
   std::size_t beg_linenum = context.linenum;
 

--- a/src/textual_internal.h
+++ b/src/textual_internal.h
@@ -198,6 +198,13 @@ public:
   bool peek_whitespace_line() {
     return (in.good() && !in.eof() && (in.peek() == ' ' || in.peek() == '\t'));
   }
+
+  /// @brief Count leading spaces/tabs on the next line without consuming it.
+  /// @return Number of leading whitespace characters, or 0 if the next line
+  ///         is not indented (or the stream is at EOF).  Treats one tab and
+  ///         one space as equal; callers requiring consistent indentation
+  ///         must enforce it themselves.
+  std::size_t peek_line_indent();
 #if HAVE_BOOST_PYTHON
   bool peek_blank_line() {
     return (in.good() && !in.eof() && (in.peek() == '\n' || in.peek() == '\r'));
@@ -226,8 +233,17 @@ public:
   /*--- Account Directives ---*/
 
   /// @brief Handle the `account` directive and its indented sub-directives (alias, payee, value,
-  /// default, assert, check, note).
+  /// default, assert, check, note, account).
   void account_directive(char* line);
+
+  /// @brief Shared body for `account` parsing that also supports nested
+  ///        `account` sub-directives (issue #877).
+  /// @param line          The remainder of the "account NAME" line (just NAME, leading ws OK).
+  /// @param parent        Root account under which NAME is registered.
+  /// @param outer_indent  Indentation column of the "account NAME" line itself;
+  ///                      only sub-directives with strictly greater indentation
+  ///                      are consumed by this call.
+  void account_directive_body(char* line, account_t* parent, std::size_t outer_indent);
   void account_alias_directive(account_t* account,
                                string alias); ///< Register an alias name that maps to this account
   void account_payee_directive(

--- a/test/regress/877.test
+++ b/test/regress/877.test
@@ -1,0 +1,88 @@
+; Regression test for issue #877.
+;
+; Allow nested `account` declarations under an enclosing `account`
+; directive, so the full colon-separated path need not be repeated
+; for every descendant account.
+;
+;   account Income
+;       account Salary            ; creates "Income:Salary"
+;       account Apps              ; creates "Income:Apps"
+;           account Android       ; creates "Income:Apps:Android"
+;           account iPhone        ; creates "Income:Apps:iPhone"
+;       account Rent              ; creates "Income:Rent"
+;
+; Sub-directives (note, alias, default, etc.) still apply to the
+; enclosing account as long as they sit at the same indentation as
+; the nested `account` keyword; deeper indentation attaches them to
+; the nested account instead.
+
+commodity $
+
+account Income
+    note Top-level income category
+    account Salary
+        note Regular monthly salary
+        alias salary
+    account Apps
+        note Mobile app revenue
+        account Android
+            alias android
+        account iPhone
+            alias iphone
+    account Rent
+        note Rental income
+    alias inc
+
+account Assets
+    account Cash
+        alias cash
+
+2024/01/15 Paycheck
+    salary                  $-1000
+    cash
+
+2024/02/01 App sale (Android)
+    android                    $5
+    cash
+
+2024/02/02 App sale (iPhone)
+    iphone                     $3
+    cash
+
+2024/03/01 Rent collected
+    Income:Rent             $-500
+    cash
+
+2024/04/01 Deposit
+    inc                      $-20
+    cash
+
+test --strict -f $FILE accounts
+Assets
+Assets:Cash
+Income
+Income:Apps
+Income:Apps:Android
+Income:Apps:iPhone
+Income:Rent
+Income:Salary
+end test
+
+test --strict -f $FILE reg Income
+24-Jan-15 Paycheck              Income:Salary                $-1000       $-1000
+24-Feb-01 App sale (Android)    Income:Apps:Android              $5        $-995
+24-Feb-02 App sale (iPhone)     Income:Apps:iPhone               $3        $-992
+24-Mar-01 Rent collected        Income:Rent                   $-500       $-1492
+24-Apr-01 Deposit               Income                         $-20       $-1512
+end test
+
+test --strict -f $FILE bal Income
+              $-1512  Income
+                  $8    Apps
+                  $5      Android
+                  $3      iPhone
+               $-500    Rent
+              $-1000    Salary
+--------------------
+              $-1512
+end test


### PR DESCRIPTION
Fixes #877.

Allows an `account NAME` directive to contain indented `account CHILD`
sub-directives, so a parent account can declare its children without
repeating the full colon-separated path.

```ledger
account Income
    note Top-level income category
    account Salary
        note Regular monthly salary
        alias salary
    account Apps
        account Android
        account iPhone
    account Rent
```

The example above registers `Income`, `Income:Salary`, `Income:Apps`,
`Income:Apps:Android`, `Income:Apps:iPhone`, and `Income:Rent`.

### Design

Indentation determines nesting, matching the style already used for
existing `account` sub-directives (`note`, `alias`, `default`, `assert`,
etc.). A new `peek_line_indent()` helper in `src/textual.cc` reports the
column of the next line without consuming it; `account_directive_body()`
then recursively consumes sub-directives that are more deeply indented
than the enclosing `account` keyword and dispatches nested `account`
lines as children.

Sub-directives at the same indent as a nested `account` continue to
attach to the enclosing account; only deeper indentation attaches them
to the nested account. Existing flat `account FOO:BAR` declarations are
unchanged.

### Tests

- `test/regress/877.test` covers the new syntax end to end: strict-mode
  account recognition, alias/note propagation to the correct account,
  and the resulting hierarchical balance and register output.
- Full `ctest` suite passes (4311 tests), including all `apply account`,
  account-directive, and coverage tests.

### Docs

- `doc/ledger3.texi` documents the new sub-directive with a worked
  example.
- `NEWS.md` has a release-note entry.