### PR TITLE
Allow ledger to load as a Python extension module (#513)

### DIFF
--- a/src/pyinterp.cc
+++ b/src/pyinterp.cc
@@ -131,35 +131,50 @@ void python_interpreter_t::initialize() {
   try {
     DEBUG("python.interp", "Initializing Python");
 
-    // PyImport_AppendInittab docs: "This should be called before Py_Initialize()".
-    PyImport_AppendInittab((const char*)"ledger", PyInit_ledger);
+    // If Python is already running (for example, because ledger was loaded
+    // as a Python extension module via `import ledger` from an external
+    // interpreter), skip the inittab registration and Py_Initialize.
+    // Calling PyImport_AppendInittab after Py_Initialize is a fatal error
+    // in Python 3.12+, and re-running Py_Initialize on an embedding
+    // interpreter would clobber its state.  In that scenario the ledger
+    // module has already been loaded via PyInit_ledger, so every Boost
+    // converter is already registered and no further setup is required.
+    if (!Py_IsInitialized()) {
+      // PyImport_AppendInittab docs: "This should be called before Py_Initialize()".
+      PyImport_AppendInittab((const char*)"ledger", PyInit_ledger);
 
-    // Unbuffer stdio to avoid python output getting stuck in buffer when
-    // stdout is not a TTY. Normally buffers are flushed by Py_Finalize but
-    // Boost has a long-standing issue preventing proper shutdown of the
-    // interpreter with Py_Finalize when embedded.
+      // Unbuffer stdio to avoid python output getting stuck in buffer when
+      // stdout is not a TTY. Normally buffers are flushed by Py_Finalize but
+      // Boost has a long-standing issue preventing proper shutdown of the
+      // interpreter with Py_Finalize when embedded.
 #if PY_MINOR_VERSION < 12
-    Py_UnbufferedStdioFlag = 1;
-    Py_Initialize();
+      Py_UnbufferedStdioFlag = 1;
+      Py_Initialize();
 #else
-    PyStatus status;
-    PyConfig config;
-    PyConfig_InitPythonConfig(&config);
-    config.buffered_stdio = 0;
-    status = Py_InitializeFromConfig(&config);
-    if (PyStatus_Exception(status)) {
+      PyStatus status;
+      PyConfig config;
+      PyConfig_InitPythonConfig(&config);
+      config.buffered_stdio = 0;
+      status = Py_InitializeFromConfig(&config);
+      if (PyStatus_Exception(status)) {
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+        return;
+      }
       PyConfig_Clear(&config);
-      Py_ExitStatusException(status);
-      return;
-    }
-    PyConfig_Clear(&config);
 #endif
+
+      we_started_python = true;
+    }
 
     assert(Py_IsInitialized());
 
     hack_system_paths();
 
     main_module = import_module("__main__");
+    // PyImport_ImportModule returns the cached module if "ledger" is
+    // already in sys.modules, so this does not re-run PyInit_ledger and
+    // will not cause duplicate converter registration.
     PyImport_ImportModule("ledger");
 
     is_initialized = true;

--- a/src/pyinterp.h
+++ b/src/pyinterp.h
@@ -72,6 +72,7 @@ typedef std::map<PyObject*, std::shared_ptr<python_module_t>> python_module_map_
 class python_interpreter_t : public session_t {
 public:
   bool is_initialized;
+  bool we_started_python;
 
   std::shared_ptr<python_module_t> main_module;
   python_module_map_t modules_map;
@@ -83,12 +84,15 @@ public:
     return mod;
   }
 
-  python_interpreter_t() : session_t(), is_initialized(false) {
+  python_interpreter_t() : session_t(), is_initialized(false), we_started_python(false) {
     TRACE_CTOR(python_interpreter_t, "");
   }
   virtual ~python_interpreter_t() {
     TRACE_DTOR(python_interpreter_t);
-    if (is_initialized)
+    // Only shut down Python if we started it.  When ledger is loaded as a
+    // Python extension module (via `import ledger`), the embedding
+    // interpreter owns the runtime and will finalize it itself.
+    if (is_initialized && we_started_python)
       Py_Finalize();
   }
 

--- a/src/pyledger.cc
+++ b/src/pyledger.cc
@@ -40,6 +40,22 @@ namespace ledger {
 extern void initialize_for_python();
 }
 
+namespace {
+
+/// Callback registered with Python's `atexit` module to drop the global
+/// python_session while the interpreter is still fully alive.  When ledger
+/// is loaded as a Python extension module, the shared_ptr would otherwise
+/// be destroyed by C++ static destructors after Py_Finalize has already
+/// released the GIL, causing boost::python::object destructors to crash
+/// while decrementing refcounts on torn-down Python objects.
+///
+/// This function is exposed to Python as `ledger._release_session`.
+void release_python_session() {
+  ledger::python_session.reset();
+}
+
+} // namespace
+
 BOOST_PYTHON_MODULE(ledger) {
   using namespace ledger;
 
@@ -78,4 +94,19 @@ BOOST_PYTHON_MODULE(ledger) {
   }
 
   initialize_for_python();
+
+  // Register release_python_session with Python's `atexit` module so the
+  // shared_ptr is dropped before Py_Finalize runs.  Py_AtExit callbacks
+  // fire during finalization when the GIL has already been released, so
+  // destroying boost::python objects there is unsafe; atexit callbacks run
+  // earlier, while the interpreter is fully alive.  Without this, static
+  // C++ destructors tear down python_session after Python is gone,
+  // crashing in boost::python object destructors (GitHub issue #513).
+  object release_fn = make_function(&release_python_session);
+  scope().attr("_release_session") = release_fn;
+  try {
+    import("atexit").attr("register")(release_fn);
+  } catch (const error_already_set&) {
+    PyErr_Clear();
+  }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,20 @@ if(Python_EXECUTABLE)
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     set_tests_properties(demo
       PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE};PYTHONPATH=.")
+
+    # Regression test for GitHub issue #513: loading the ledger module from
+    # an external Python interpreter must not re-initialize Python, and
+    # reading a journal with a `python` directive must not emit any
+    # RuntimeWarnings (or, on Python 3.12+, abort with a fatal error from
+    # PyImport_AppendInittab).  This test must run via the external Python
+    # interpreter -- not the in-tree test harness, which executes python
+    # blocks under ledger's embedded interpreter where the bug does not
+    # manifest.
+    add_test(NAME RegressPyTest_513
+      COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/regress/513.py
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    set_tests_properties(RegressPyTest_513
+      PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE};PYTHONPATH=.")
   endif()
 endif()
 

--- a/test/regress/513.py
+++ b/test/regress/513.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Regression test for GitHub issue #513:
+# Reading a journal containing Python snippets from an *external* Python
+# interpreter yielded dozens of
+#   RuntimeWarning: to-Python converter for <type> already registered
+# messages on Python <=3.11, and a fatal PyImport_AppendInittab abort on
+# Python >=3.12, because python_interpreter_t::initialize() attempted to
+# start a second Python runtime when one was already running.
+#
+# This test must be run via the external Python interpreter (not the
+# `ledger python` command), because the bug only manifests when ledger
+# is loaded as a Python extension module with Py_Initialize already done
+# by the embedding interpreter.
+
+import warnings
+
+# Elevate every RuntimeWarning to a hard error.  Under the bug, importing
+# ledger and parsing a journal with a `python` directive produces a
+# cascade of "to-Python converter ... already registered" warnings, which
+# this converts into a failing test.
+warnings.simplefilter("error", RuntimeWarning)
+
+import ledger
+
+journal = ledger.read_journal_from_string("""
+python
+    print("Hello from python block")
+
+2017-01-01 Payee
+    Expenses:Food      $1.00
+    Assets:Cash
+""")
+
+# Sanity-check that the bindings still work end-to-end after the
+# journal-embedded python block has run.
+for xact in journal.xacts:
+    for post in xact.posts:
+        print("%s %s" % (post.amount, post.account))
+
+print("OK")


### PR DESCRIPTION
## Summary
- Skip `PyImport_AppendInittab`/`Py_Initialize` when the embedding Python interpreter is already running — fixes the fatal abort on Python 3.12+ and the cascade of "already registered" `RuntimeWarning`s on earlier versions.
- Gate `Py_Finalize` on a new `we_started_python` flag so we only shut down an interpreter we actually started.
- Drop the static `python_session` via `atexit.register` so `boost::python` object destructors run while the interpreter is still alive.

## Test plan
- [x] Added `test/regress/513.py` that imports `ledger`, reads a journal containing a `python` directive, and escalates `RuntimeWarning` to an error. Wired up as `RegressPyTest_513` in `test/CMakeLists.txt`.
- [x] `ctest` passes (4312 tests); test fails without the fix (`Subprocess aborted`, `PyImport_AppendInittab()...` fatal error), passes with it.
- [x] `python3 -c 'import ledger'` and `python3 -c 'import ledger; ledger.read_journal("…")'` both exit cleanly.
- [x] Lefthook pre-commit (cmake configure/build/test + doxygen + manual + nix flake build) all green.

Fixes #513.