### PR TITLE
Enable Commodity == string comparison in Python (#759)

### DIFF
--- a/src/py_commodity.cc
+++ b/src/py_commodity.cc
@@ -350,6 +350,7 @@ void export_commodity() {
       .def("__nonzero__", &commodity_t::operator bool)
 
       .def(self == self)
+      .def(self == other<string>())
 
       .def("symbol_needs_quotes", &commodity_t::symbol_needs_quotes)
       .staticmethod("symbol_needs_quotes")

--- a/test/regress/759.py
+++ b/test/regress/759.py
@@ -1,0 +1,25 @@
+import ledger
+
+# Regression test for GitHub issue #759:
+# Allow comparing a Commodity with a string directly, e.g.
+#     if post.amount.commodity == "EUR":
+# as a convenient shortcut for
+#     if post.amount.commodity.symbol == "EUR":
+
+session = ledger.Session()
+j = session.read_journal_from_string("""
+2024-01-01 Coffee
+    Expenses:Food    10.00 EUR
+    Assets:Cash     -10.00 EUR
+
+2024-01-02 Lunch
+    Expenses:Food    $15.00
+    Assets:Cash     -$15.00
+""")
+
+for xact in j:
+    for post in xact.posts:
+        c = post.amount.commodity
+        eq_eur = c == "EUR"
+        ne_eur = c != "EUR"
+        print(f"{post.account.fullname()}: symbol={c.symbol!r} == 'EUR' -> {eq_eur}, != 'EUR' -> {ne_eur}")

--- a/test/regress/759_py.test
+++ b/test/regress/759_py.test
@@ -1,0 +1,6 @@
+test python test/regress/759.py
+Expenses:Food: symbol='EUR' == 'EUR' -> True, != 'EUR' -> False
+Assets:Cash: symbol='EUR' == 'EUR' -> True, != 'EUR' -> False
+Expenses:Food: symbol='$' == 'EUR' -> False, != 'EUR' -> True
+Assets:Cash: symbol='$' == 'EUR' -> False, != 'EUR' -> True
+end test


### PR DESCRIPTION
## Summary

- Exposes `commodity_t::operator==(const string&)` to Python so users can write `post.amount.commodity == "EUR"` instead of `post.amount.commodity.symbol == "EUR"`.
- Comparison uses `base_symbol()`, so annotated commodities (e.g. `EUR {$1.00}`) still match their plain symbol.
- `AnnotatedCommodity` inherits `__eq__` from `Commodity` via `boost::python::bases`, so no extra binding is needed there.

Fixes #759.

## Test plan

- [x] `ctest -R 759_py` passes
- [x] All 31 `_py` regression tests pass
- [x] Full `ctest` suite passes (4312 tests)
- [x] Lefthook pre-commit (cmake configure/build/ctest/doxygen/manual + nix build) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)