### PR TITLE
Fix #531: install Python module with executable permissions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -257,8 +257,11 @@ if(USE_PYTHON)
       TARGET libledger POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
       $<TARGET_FILE:libledger> "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}")
+    # Use PROGRAMS (not FILES) so the installed Python extension module has
+    # executable permissions (mode 755).  Fedora and other distributions
+    # require dynamic libraries to be installed with the executable bit set.
     install(
-      FILES "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}"
+      PROGRAMS "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}"
       DESTINATION "${LEDGER_PYTHON_INSTALL_DIR}")
   else()
     message(WARNING "Python_SITEARCH not set. Will not install python module.")


### PR DESCRIPTION
## Summary

Fixes #531. The `ledger.so` Python extension module was being installed via `install(FILES ...)` in `src/CMakeLists.txt`, which defaults to mode 644 (no executable bits). Fedora and other Linux distributions require dynamic libraries to be installed with the executable bit set (mode 755), so Fedora's packaging has had to `chmod +x` the module after install ([`ledger.spec`](https://src.fedoraproject.org/rpms/ledger/blob/master/f/ledger.spec#_120)).

## Change

Switch `install(FILES ...)` to `install(PROGRAMS ...)` for the Python module copy. `PROGRAMS` is the canonical CMake form for files that need to be executable: it adds `OWNER_EXECUTE`, `GROUP_EXECUTE`, and `WORLD_EXECUTE` to the default permissions (so mode 755 instead of 644), matching what `install(TARGETS ...)` already uses for other shared libraries in this project.

## Verification

With this change, a staged install of the Python module reports the correct permissions:

```
-rwxr-xr-x 1 johnw wheel 10024064 Apr 24 00:05 ledger.so
```

The generated `cmake_install.cmake` now emits `TYPE PROGRAM` (previously `TYPE FILE`) for this file.

## Test plan

- [x] cmake configure + build + ctest pass (verified via lefthook pre-commit hook)
- [x] cmake configure + install to staging dir produces `ledger.so` with mode 755
- [x] nix build passes

No runtime regression test is added because this is a build-system-only change that takes effect at install time; the install behavior is not exercised by ledger's CTest suite.