### PR TITLE
Recognize Windows drive-letter paths in include directive (#1670)

### DIFF
--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -292,8 +292,7 @@ void instance_t::include_directive(char* line) {
   // consult std::filesystem::path::is_absolute() which recognizes Windows
   // drive-letter paths such as `D:/ledger/main.ledger` (issue #1670).
   path include_path(line);
-  if (line[0] != '/' && line[0] != '\\' && line[0] != '~' &&
-      !include_path.is_absolute()) {
+  if (line[0] != '/' && line[0] != '\\' && line[0] != '~' && !include_path.is_absolute()) {
     DEBUG("textual.include", "received a relative path");
     DEBUG("textual.include", "parent file path: " << context.pathname);
     path parent_path = context.pathname.parent_path();

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -287,7 +287,13 @@ void instance_t::include_directive(char* line) {
 
   DEBUG("textual.include", "include: " << line);
 
-  if (line[0] != '/' && line[0] != '\\' && line[0] != '~') {
+  // Detect absolute paths so they are not joined with the parent directory.
+  // In addition to the POSIX-style leading '/', '\', and '~' checks, we
+  // consult std::filesystem::path::is_absolute() which recognizes Windows
+  // drive-letter paths such as `D:/ledger/main.ledger` (issue #1670).
+  path include_path(line);
+  if (line[0] != '/' && line[0] != '\\' && line[0] != '~' &&
+      !include_path.is_absolute()) {
     DEBUG("textual.include", "received a relative path");
     DEBUG("textual.include", "parent file path: " << context.pathname);
     path parent_path = context.pathname.parent_path();
@@ -298,7 +304,7 @@ void instance_t::include_directive(char* line) {
       DEBUG("textual.include", "normalized path: " << filename.string());
     }
   } else {
-    filename = line;
+    filename = include_path;
   }
 
   filename = resolve_path(filename);

--- a/test/regress/1670.test
+++ b/test/regress/1670.test
@@ -1,0 +1,21 @@
+; Regression test for issue #1670 (absolute paths in include directives).
+;
+; On Windows, `include d:/ledger/main.ledger` used to be misinterpreted as a
+; relative path and joined with the parent file's directory, producing a
+; bogus path such as `<parent-dir>/d:/ledger/main.ledger`.  The include
+; directive now consults std::filesystem::path::is_absolute(), which
+; correctly recognizes drive-letter-rooted Windows paths in addition to the
+; POSIX `/`, `\`, and `~` prefixes.
+;
+; This test exercises the POSIX-side of the check: a leading-'/' absolute
+; path must continue to be used verbatim (not joined with the parent
+; directory) and the error message must report that same raw path when the
+; file does not exist.
+
+include /nonexistent-1670/abs.ledger
+
+test bal -> 1
+__ERROR__
+While parsing file "$FILE", line 15:
+Error: File to include was not found: /nonexistent-1670/abs.ledger
+end test


### PR DESCRIPTION
## Summary
- `include_directive()` used to decide whether an argument was absolute by looking only at the first byte: leading `/`, `\`, or `~` were treated as absolute, everything else was joined with the parent file's directory.
- On Windows, paths like `d:/ledger/main.ledger` start with a letter, so ledger concatenated them with the parent directory and produced an unreachable path — the "cannot read journal file" error reported in #1670.
- Fall back to `std::filesystem::path::is_absolute()`, which recognizes Windows drive-letter and UNC paths. POSIX hosts are unaffected because the prefix checks short-circuit first and `is_absolute()` only returns true for paths that already start with `/`.

## Test plan
- [x] `ctest -j8` — all 4280 regression tests pass locally.
- [x] `test/regress/1670.test` (new) — pins the POSIX side of the check: an absolute `/nonexistent-1670/abs.ledger` include emits an error that reports the raw path verbatim, confirming the directive does not join it with the parent directory.
- [x] Full lefthook pre-commit suite (cmake configure/build/test, doxygen, manual, `nix build .`) run inside `nix develop`.

Fixes #1670.