### PR TITLE
Fix --invert option with equity command (#1645)

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1548,11 +1548,15 @@ void posts_as_equity::report_subtotal() {
   xact.payee = _("Opening Balances");
   xact._date = finish;
 
+  const bool invert = report.HANDLED(invert);
+
   value_t total = 0L;
   for (values_map::value_type& pair : values) {
     value_t value(pair.second.value.strip_annotations(report.what_to_keep()));
     if (unround)
       value.in_place_unround();
+    if (invert)
+      value.in_place_negate();
     if (!value.is_zero()) {
       if (value.is_balance()) {
         value.as_balance_lval().map_sorted_amounts([&](const amount_t& amt) {

--- a/test/regress/1645.test
+++ b/test/regress/1645.test
@@ -1,0 +1,44 @@
+; Regression test for issue #1645: `ledger equity` should honour `--invert`,
+; producing an inverting transaction that would zero out the source balances.
+
+D 1000.00 GBP
+
+2011-03-04 Buy shares
+    Assets:Broker           2 AAA @ 0.90 GBP
+    Assets:Bank
+
+2011-03-05 Buy shares
+    Assets:Broker           2 AAA @ 1.00 GBP
+    Assets:Bank
+
+test equity
+2011/03/05 Opening Balances
+    Assets:Bank                            -3.80 GBP
+    Assets:Broker                              4 AAA
+    Equity:Opening Balances                   -4 AAA
+    Equity:Opening Balances                 3.80 GBP
+end test
+
+test equity --invert
+2011/03/05 Opening Balances
+    Assets:Bank                             3.80 GBP
+    Assets:Broker                             -4 AAA
+    Equity:Opening Balances                    4 AAA
+    Equity:Opening Balances                -3.80 GBP
+end test
+
+test equity --invert assets:bank
+2011/03/05 Opening Balances
+    Assets:Bank                             3.80 GBP
+    Equity:Opening Balances
+end test
+
+test equity --invert --lots --date-format %Y/%m/%d
+2011/03/05 Opening Balances
+    Assets:Bank                             3.80 GBP
+    Assets:Broker                       -2 AAA {0.90 GBP} [2011/03/04]
+    Assets:Broker                       -2 AAA {1.00 GBP} [2011/03/05]
+    Equity:Opening Balances             2 AAA {0.90 GBP} [2011/03/04]
+    Equity:Opening Balances             2 AAA {1.00 GBP} [2011/03/05]
+    Equity:Opening Balances                -3.80 GBP
+end test


### PR DESCRIPTION
## Summary

`ledger equity --invert` was a no-op: the output was identical to plain
`ledger equity`.  `--invert` works everywhere else (balance, register,
…) because the global handler rewrites `display_amount` /
`display_total`, and those expressions drive every other report.
`posts_as_equity::report_subtotal`, however, emits fresh `post_t`
objects and `print_xacts` renders `post.amount` directly, bypassing
`display_amount` entirely.

Fix: negate each accumulated value in `posts_as_equity::report_subtotal`
when `--invert` is active, before emitting the posting and adding it to
the running total.  The balancing Equity:Opening Balances posting (which
is the negated total) comes out with the opposite sign too, so the
resulting transaction, when appended to the source journal, zeroes out
the original account balances -- which is exactly what the issue
reporter wanted.

## Test plan

- [x] New regression test `test/regress/1645.test` covering bare
  `equity --invert`, `equity --invert assets:bank` (narrowed account),
  and `equity --invert --lots --date-format …` (with lot annotations).
- [x] Full test suite (`ctest`) passes: 4281/4281.
- [x] Manual round-trip: applying the inverted equity transaction back
  to the source journal zeroes out `Assets:*` and `Equity:Opening
  Balances`.

Fixes #1645.