### PR TITLE
Allow parenthesized expression prices in P directives (#1101)

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -2243,6 +2243,20 @@ The syntax is:
 P DATE SYMBOL PRICE
 @end smallexample
 
+@code{PRICE} may also be a parenthesized expression.  If the
+expression evaluates to a single-commodity amount, that amount is
+recorded as the commodity's price on @code{DATE}.  If the expression
+evaluates to a multi-commodity balance (a ``basket''), the basket is
+attached to @code{SYMBOL} as its valuation expression, so that later
+@option{-V}/@option{-X} reports reprice the basket into whichever
+target commodity is requested (@pxref{Complete control over commodity
+pricing}).  For example, a currency basket consisting of 0.45 euros
+and 0.55 U.S. dollars can be expressed as:
+
+@smallexample
+P 2015-01-01 bicur (EUR 0.45 + $0.55)
+@end smallexample
+
 @item =
 @findex =
 @cindex automated transaction

--- a/src/commodity.cc
+++ b/src/commodity.cc
@@ -136,6 +136,21 @@ std::optional<price_point_t> commodity_t::find_price_from_expr(expr_t& expr,
     result = as_expr(result)->call(call_args, *scope_t::default_scope);
   }
 
+  // A value expression may evaluate to a multi-commodity balance -- a "basket"
+  // of different currencies (issue #1101).  Reprice each component to the
+  // requested target commodity (or the pool default when none is given) so
+  // the basket collapses to a single-commodity amount suitable for a
+  // price_point_t.
+  if (result.is_balance()) {
+    const commodity_t* target = commodity;
+    if (!target && pool().default_commodity)
+      target = &*pool().default_commodity;
+    if (target) {
+      if (auto repriced = result.as_balance().value(moment, target))
+        result = *repriced;
+    }
+  }
+
   return price_point_t(moment, result.to_amount());
 }
 

--- a/src/pool.cc
+++ b/src/pool.cc
@@ -501,8 +501,8 @@ commodity_pool_t::parse_price_directive(char* line, bool do_not_add_price, bool 
   char* price_ptr = skip_ws(symbol_and_price);
   if (price_ptr && *price_ptr == '(') {
     expr_t value_expr{string(price_ptr)};
-    value_t result(value_expr.calc(scope_t::default_scope ? *scope_t::default_scope
-                                                          : *scope_t::empty_scope));
+    value_t result(
+        value_expr.calc(scope_t::default_scope ? *scope_t::default_scope : *scope_t::empty_scope));
     if (result.is_balance() && result.as_balance().amounts.size() > 1) {
       // Store the literal balance as the commodity's value expression so
       // that find_price_from_expr can reprice it to whatever target

--- a/src/pool.cc
+++ b/src/pool.cc
@@ -55,6 +55,8 @@
 #include "pool.h"
 #include "history.h"
 #include "quotes.h"
+#include "expr.h"
+#include "scope.h"
 
 namespace ledger {
 
@@ -486,7 +488,46 @@ commodity_pool_t::parse_price_directive(char* line, bool do_not_add_price, bool 
 
   price_point_t point;
   point.when = datetime;
-  (void)point.price.parse(symbol_and_price, PARSE_NO_MIGRATE);
+
+  // A parenthesized price expression (issue #1101) allows the price to be
+  // computed from an expression which may reference multiple commodities,
+  // e.g. "P 2015-01-01 bicur (€0.45 + $0.55)".  The enclosing parentheses
+  // signal that the remaining text should be parsed as a value expression
+  // rather than as a plain amount.  If the expression evaluates to a
+  // multi-commodity balance (a "basket"), the result is attached as a
+  // value_expr on the commodity so that later valuations can reprice the
+  // basket into whatever target commodity is requested.  Otherwise the
+  // collapsed amount is recorded as a normal price history entry.
+  char* price_ptr = skip_ws(symbol_and_price);
+  if (price_ptr && *price_ptr == '(') {
+    expr_t value_expr{string(price_ptr)};
+    value_t result(value_expr.calc(scope_t::default_scope ? *scope_t::default_scope
+                                                          : *scope_t::empty_scope));
+    if (result.is_balance() && result.as_balance().amounts.size() > 1) {
+      // Store the literal balance as the commodity's value expression so
+      // that find_price_from_expr can reprice it to whatever target
+      // commodity is requested at query time.
+      std::ostringstream expr_text;
+      expr_text << '(';
+      bool first = true;
+      for (const auto& pair : result.as_balance().amounts) {
+        if (!first)
+          expr_text << " + ";
+        pair.second.print(expr_text);
+        first = false;
+      }
+      expr_text << ')';
+      if (commodity_t* commodity = find_or_create(symbol)) {
+        commodity->set_value_expr(expr_t(expr_text.str()));
+        commodity->add_flags(COMMODITY_KNOWN);
+        return std::pair<commodity_t*, price_point_t>(commodity, point);
+      }
+      return std::nullopt;
+    }
+    point.price = result.to_amount();
+  } else {
+    (void)point.price.parse(symbol_and_price, PARSE_NO_MIGRATE);
+  }
   VERIFY(point.price.valid());
 
   // Update the price commodity's precision based on the parsed amount.

--- a/test/regress/1101.test
+++ b/test/regress/1101.test
@@ -1,0 +1,39 @@
+; Regression test for issue #1101: parenthesized price expressions.
+;
+; A price directive may enclose its amount in parentheses to request
+; expression evaluation.  When the expression yields a single-commodity
+; amount it is stored as an ordinary price; when it yields a
+; multi-commodity balance ("basket"), the balance becomes the
+; commodity's value expression so that later valuations can reprice
+; the basket into any requested target commodity.
+
+P 2015-01-01 A  (EUR 0.50 + EUR 0.50)
+P 2015-01-01 B  (EUR 1.00)
+P 2015-01-01 C  (100 * EUR 0.01)
+P 2015-01-01 bicur (EUR 0.45 + USD 0.55)
+P 2015-01-01 EUR USD 1.10
+
+2015/01/01 Plain price tests
+    Assets:A         1 A
+    Assets:B         1 B
+    Assets:C         1 C
+    Equity
+
+2015/01/01 Basket test
+    Assets:Basket    1 bicur
+    Equity
+
+test prices
+2015/01/01 A            EUR 1.00
+2015/01/01 B            EUR 1.00
+2015/01/01 C            EUR 1.00
+2015/01/01 EUR          USD 1.10
+end test
+
+test bal -X USD Assets:Basket
+            USD 1.04  Assets:Basket
+end test
+
+test bal -X EUR Assets:Basket
+            EUR 0.95  Assets:Basket
+end test


### PR DESCRIPTION
## Summary

Teach the `P` price directive to accept a parenthesized value expression in place of a bare amount, so that a commodity can be defined in terms of multiple other commodities -- for example, a currency basket consisting of 0.45 EUR plus 0.55 USD:

```
P 2015-01-01 bicur (EUR 0.45 + USD 0.55)
```

Single-commodity expression results (e.g. `(EUR 0.50 + EUR 0.50)`) are recorded as ordinary price history entries.  Multi-commodity balance results are stored as the commodity's `value_expr`, so that subsequent `-V` / `-X` reports evaluate the basket and reprice it into whichever target commodity is requested.

Closes #1101.

## Implementation

- `src/pool.cc`: when `parse_price_directive` encounters a `(`-prefixed price payload, parse the remainder as an `expr_t` and branch on the result type.
- `src/commodity.cc`: `find_price_from_expr` now collapses a multi-commodity balance to a single-commodity amount by calling `balance_t::value` against the requested target (or the pool default when none is given).  This is what lets a basket be revalued under `-V` / `-X` without hitting the "Cannot convert a balance with multiple commodities to an amount" error from `to_amount()`.
- `doc/ledger3.texi`: document the extended syntax next to the existing `P DATE SYMBOL PRICE` description.
- `test/regress/1101.test`: regression test covering single-commodity, multi-commodity, and arithmetic expression prices, plus `-V`/`-X` revaluation into EUR and USD.

## Test plan

- [x] `ctest -R RegressTest_1101` passes.
- [x] Full `ctest` run (4280 tests) passes via the lefthook pre-commit hook on each of the three commits.
- [x] 474 price/commodity/value-related tests pass under parallel ctest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)