### PR TITLE
Add --pivot-only option to replace account with pivot name (#1153)

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -973,6 +973,13 @@ Produce a balance pivot report
 .Qq around
 the given
 .Ar TAG .
+.It Fl \-pivot-only Ar TAG
+Like
+.Fl \-pivot ,
+but replaces the original account hierarchy with the pivoted name
+.Pq Sy TAG : value
+instead of prepending to it, so all postings sharing a tag value collapse
+into a single account bucket.
 .It Fl \-plopen
 Show the unrealized P/L (Profit/Loss Open) for all currently-open positions.
 For each lot, the displayed amount is

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -6596,6 +6596,13 @@ Show subtotals in the balance report as percentages.
 @item --pivot @var{TAG}
 Produce a pivot table of the @var{TAG} type specified.
 
+@item --pivot-only @var{TAG}
+Like @option{--pivot}, but replaces the original account hierarchy with the
+pivoted name instead of prepending to it.  Where @option{--pivot Member}
+produces accounts like @samp{Member:John Doe:Income:Fees},
+@option{--pivot-only Member} produces just @samp{Member:John Doe}, causing
+all postings sharing a tag value to collapse into a single account.
+
 @item --amount-data
 @itemx -j
 Show only the date and value columns to format the output for plots.
@@ -7839,6 +7846,25 @@ $ ledger bal Fuel --pivot "Car" --period "this year"
            $ 3533.95
 @end smallexample
 
+A companion option, @option{--pivot-only @var{TAG}}, replaces the original
+account hierarchy with the pivoted name instead of prepending to it.  The
+same command with @option{--pivot-only} collapses all fuel postings for a
+given car into a single bucket:
+
+@smallexample @c command:validate
+$ ledger bal Fuel --pivot-only "Car" --period "this year"
+@end smallexample
+@smallexample
+           $ 3491.26  Car
+           $ 1084.22    M3
+            $ 149.65    MG V11
+            $ 621.89    Prius
+           $ 1635.50    Sienna
+             $ 42.69  Expenses:Auto:Fuel
+--------------------
+           $ 3533.95
+@end smallexample
+
 @xref{Metadata values}.
 
 @item --plot-amount-format @var{FORMAT_STRING}
@@ -8305,6 +8331,12 @@ value expressions, see @ref{Value Expressions}.
 @item --pivot @var{TAG}
 Produce a pivot table around the @var{TAG} provided.  This requires
 meta data using valued tags.
+
+@item --pivot-only @var{TAG}
+Like @option{--pivot}, but replaces the original account hierarchy with
+the pivoted name (@samp{TAG:value}) instead of prepending to it.  Useful
+when you want the tag value to become the account itself rather than a
+prefix of the original account.
 
 @item --wide
 @itemx -w

--- a/src/chain.cc
+++ b/src/chain.cc
@@ -111,9 +111,20 @@ post_handler_ptr chain_pre_post_handlers(post_handler_ptr base_handler, report_t
   // ones.  This makes `bal --pivot Tag Value` filter by the pivoted name
   // "Tag:Value:..." instead of the original account name.  (See #1154.)
   //
-  // --account and --pivot are mutually exclusive; --account stays in
-  // chain_post_handlers because it does not interact with query filtering.
-  if (report.HANDLED(pivot_) && !report.HANDLED(account_)) {
+  // --pivot-only (issue #1153) differs from --pivot in that it replaces the
+  // original account entirely with "Tag:Value" rather than prepending.  This
+  // gives a cleaner pivot view when the original account hierarchy is not
+  // wanted (e.g. "Member:John Doe" instead of "Member:John Doe:Income:Fees").
+  //
+  // --account, --pivot, and --pivot-only are mutually exclusive; --account
+  // stays in chain_post_handlers because it does not interact with query
+  // filtering.
+  if (report.HANDLED(pivot_only_) && !report.HANDLED(account_)) {
+    string pivot = report.HANDLER(pivot_only_).str();
+    pivot = string("\"") + pivot + ":\" + tag(\"" + pivot + "\")";
+    handler = std::make_shared<transfer_details>(handler, transfer_details::SET_ACCOUNT_REPLACE,
+                                                 report.session.journal->master, pivot, report);
+  } else if (report.HANDLED(pivot_) && !report.HANDLED(account_)) {
     string pivot = report.HANDLER(pivot_).str();
     pivot = string("\"") + pivot + ":\" + tag(\"" + pivot + "\")";
     handler = std::make_shared<transfer_details>(handler, transfer_details::SET_ACCOUNT,

--- a/src/filters.cc
+++ b/src/filters.cc
@@ -1647,6 +1647,7 @@ void by_payee_posts::operator()(post_t& post) {
  * the designated element:
  * - SET_DATE: the posting's date is overridden.
  * - SET_ACCOUNT: the expression result is prepended to the account hierarchy.
+ * - SET_ACCOUNT_REPLACE: the expression result replaces the account entirely.
  * - SET_PAYEE: the transaction payee is replaced.
  */
 void transfer_details::operator()(post_t& post) {
@@ -1665,7 +1666,8 @@ void transfer_details::operator()(post_t& post) {
       temp._date = substitute.to_date();
       break;
 
-    case SET_ACCOUNT: {
+    case SET_ACCOUNT:
+    case SET_ACCOUNT_REPLACE: {
       string account_name = substitute.to_string();
 
       // When the expression result ends with ':', the tag was not found.
@@ -1691,8 +1693,13 @@ void transfer_details::operator()(post_t& post) {
         account_t* prev_account = temp.account;
         temp.account->remove_post(&temp);
 
-        account_name += ':';
-        account_name += prev_account->fullname();
+        // SET_ACCOUNT prepends the expression result to the original account
+        // hierarchy, while SET_ACCOUNT_REPLACE drops the original account
+        // entirely (for --pivot-only, issue #1153).
+        if (which_element == SET_ACCOUNT) {
+          account_name += ':';
+          account_name += prev_account->fullname();
+        }
 
         std::list<string> account_names;
         split_string(account_name, ':', account_names);

--- a/src/filters.h
+++ b/src/filters.h
@@ -151,7 +151,8 @@
  *
  * @subsection cat_transformation Transformation
  * - **transfer_details** -- Rewrites a posting's date, account, or payee based
- *   on an expression.  Used by --date, --account, --payee, and --pivot.
+ *   on an expression.  Used by --date, --account, --payee, --pivot, and
+ *   --pivot-only.
  * - **anonymize_posts** -- Replaces all identifying information (payee, account
  *   names, commodity symbols) with anonymized data.  Used by --anon.
  * - **posts_as_equity** (extends subtotal_posts) -- Converts postings into
@@ -1146,10 +1147,11 @@ public:
 /**
  * @brief Rewrites a posting's date, account, or payee based on an expression.
  *
- * Used by --date, --account, --payee, and --pivot.  For each posting, the
- * expression is evaluated and the result replaces the specified element.
- * For SET_ACCOUNT, the expression result is prepended to the existing
- * account hierarchy.
+ * Used by --date, --account, --payee, --pivot, and --pivot-only.  For each
+ * posting, the expression is evaluated and the result replaces the specified
+ * element.  For SET_ACCOUNT, the expression result is prepended to the
+ * existing account hierarchy.  For SET_ACCOUNT_REPLACE, the expression result
+ * replaces the account entirely, dropping the original account hierarchy.
  */
 class transfer_details : public item_handler<post_t> {
   account_t* master;   ///< Journal master account for resolving account paths.
@@ -1162,9 +1164,10 @@ class transfer_details : public item_handler<post_t> {
 public:
   /// Which posting element to rewrite.
   enum element_t : uint8_t {
-    SET_DATE,    ///< Rewrite the posting date.
-    SET_ACCOUNT, ///< Rewrite the account (prepending expression result).
-    SET_PAYEE    ///< Rewrite the transaction payee.
+    SET_DATE,            ///< Rewrite the posting date.
+    SET_ACCOUNT,         ///< Rewrite the account (prepending expression result).
+    SET_ACCOUNT_REPLACE, ///< Rewrite the account (replacing it entirely).
+    SET_PAYEE            ///< Rewrite the transaction payee.
   } which_element;
 
   transfer_details(post_handler_ptr handler, element_t _which_element, account_t* _master,

--- a/src/report.cc
+++ b/src/report.cc
@@ -1629,6 +1629,7 @@ option_t<report_t>* report_t::lookup_option(const char* p) {
     else OPT_(period_);
     else OPT_ALT(sort_xacts_, period_sort_);
     else OPT(pivot_);
+    else OPT(pivot_only_);
     else OPT(plopen);
     else OPT(plot_amount_format_);
     else OPT(plot_total_format_);

--- a/src/report.h
+++ b/src/report.h
@@ -437,6 +437,7 @@ public:
     HANDLER(period_).report(out);
     HANDLER(period_shift_).report(out);
     HANDLER(pivot_).report(out);
+    HANDLER(pivot_only_).report(out);
     HANDLER(plot_amount_format_).report(out);
     HANDLER(plot_total_format_).report(out);
     HANDLER(prepend_format_).report(out);
@@ -1081,6 +1082,7 @@ public:
   OPTION(report_t, period_shift_);
 
   OPTION(report_t, pivot_);
+  OPTION(report_t, pivot_only_);
 
   OPTION_(
       report_t, plopen, DO() {

--- a/test/baseline/opt-pivot-only.test
+++ b/test/baseline/opt-pivot-only.test
@@ -1,0 +1,101 @@
+
+2014-01-01 * Opening balance
+    Assets:Cash                               25.00 GBP
+    Equity:Opening balance                   -25.00 GBP
+
+2014-05-01 * Sell to customer AAA
+    ; Customer: AAA
+    ; Invoice: 101
+    Assets:Receivables                        10.00 GBP
+    Income:Sale                              -10.00 GBP
+
+2014-05-02 * Sell to customer BBB
+    ; Customer: BBB
+    ; Invoice: 102
+    Assets:Receivables                        11.00 GBP
+    Income:Sale                              -11.00 GBP
+
+2014-05-03 * Sell to customer AAA
+    ; Customer: AAA
+    ; Invoice: 103
+    Assets:Receivables                        12.00 GBP
+    Income:Sale                              -12.00 GBP
+
+2014-05-04 * Sell to customer CCC
+    ; Customer: CCC
+    ; Invoice: 104
+    Assets:Receivables                        15.00 GBP
+    Income:Sale                              -15.00 GBP
+
+2014-05-05 * Money received from customer AAA for invoice 101
+    ; Customer: AAA
+    ; Invoice: 101
+    Assets:Cash                               10.00 GBP
+    Assets:Receivables                       -10.00 GBP
+
+2014-05-05 * Sell to customer DDD
+    ; Customer: DDD
+    ; Invoice: 105
+    Assets:Receivables                        20.00 GBP
+    Income:Sale                              -20.00 GBP
+
+2014-05-07 * Money received from customer CCC for invoice 104
+    ; Customer: CCC
+    ; Invoice: 104
+    Assets:Cash                               15.00 GBP
+    Assets:Receivables                       -15.00 GBP
+
+2014-05-08 * Partial payment received from customer DDD for invoice 105
+    ; Customer: DDD
+    ; Invoice: 105
+    Assets:Cash                               15.00 GBP
+    Assets:Receivables                       -15.00 GBP
+
+test bal --pivot-only Invoice --flat --empty
+           25.00 GBP  Assets:Cash
+          -25.00 GBP  Equity:Opening balance
+            0.00 GBP  Invoice:101
+            0.00 GBP  Invoice:102
+            0.00 GBP  Invoice:103
+            0.00 GBP  Invoice:104
+            0.00 GBP  Invoice:105
+--------------------
+                   0
+end test
+
+test bal --pivot-only Invoice --empty -p "until 2014-05-05"
+           25.00 GBP  Assets:Cash
+          -25.00 GBP  Equity:Opening balance
+                   0  Invoice
+            0.00 GBP    101
+            0.00 GBP    102
+            0.00 GBP    103
+            0.00 GBP    104
+                   0    105
+--------------------
+                   0
+end test
+
+test bal --pivot-only Customer --empty
+           25.00 GBP  Assets:Cash
+                   0  Customer
+            0.00 GBP    AAA
+            0.00 GBP    BBB
+            0.00 GBP    CCC
+            0.00 GBP    DDD
+          -25.00 GBP  Equity:Opening balance
+--------------------
+                   0
+end test
+
+test bal --pivot-only Customer --empty -p "until 2014-05-05"
+           25.00 GBP  Assets:Cash
+                   0  Customer
+            0.00 GBP    AAA
+            0.00 GBP    BBB
+            0.00 GBP    CCC
+                   0    DDD
+          -25.00 GBP  Equity:Opening balance
+--------------------
+                   0
+end test

--- a/test/regress/1153.test
+++ b/test/regress/1153.test
@@ -1,0 +1,58 @@
+; Regression test for issue #1153: Pivot could use a truncate option
+; https://github.com/ledger/ledger/issues/1153
+;
+; --pivot prepends "Tag:Value" to the original account hierarchy, producing
+; names like "Member:John Doe:Income:Fees".  --pivot-only replaces the
+; original account entirely with "Tag:Value", giving a cleaner pivot view
+; (e.g. just "Member:John Doe").
+
+2024/01/01 Alpha Subscription
+    Income:Fees                              $-42.00
+        ; Member: John Doe
+    Assets:Bank
+
+2024/01/02 Beta Subscription
+    Income:Fees                              $-30.00
+        ; Member: Jane Roe
+    Assets:Bank
+
+2024/01/03 Alpha Renewal
+    Income:Fees                              $-42.00
+        ; Member: John Doe
+    Assets:Bank
+
+; --pivot retains the original account hierarchy as a suffix.
+test bal --pivot Member
+             $114.00  Assets:Bank
+            $-114.00  Member
+             $-30.00    Jane Roe:Income:Fees
+             $-84.00    John Doe:Income:Fees
+--------------------
+                   0
+end test
+
+; --pivot-only drops the original account entirely, so all Income:Fees
+; postings that share a Member tag collapse into the Member:<value> bucket.
+test bal --pivot-only Member
+             $114.00  Assets:Bank
+            $-114.00  Member
+             $-30.00    Jane Roe
+             $-84.00    John Doe
+--------------------
+                   0
+end test
+
+; Filtering by the pivoted name works with --pivot-only as well.
+test bal --pivot-only Member "Member:John Doe"
+             $-84.00  Member:John Doe
+end test
+
+; --pivot-only also works on a register report.
+test reg --pivot-only Member
+24-Jan-01 Alpha Subscription    Member:John Doe             $-42.00      $-42.00
+24-Jan-01 Alpha Subscription    Assets:Bank                  $42.00            0
+24-Jan-02 Beta Subscription     Member:Jane Roe             $-30.00      $-30.00
+24-Jan-02 Beta Subscription     Assets:Bank                  $30.00            0
+24-Jan-03 Alpha Renewal         Member:John Doe             $-42.00      $-42.00
+24-Jan-03 Alpha Renewal         Assets:Bank                  $42.00            0
+end test

--- a/test/snapshot.py
+++ b/test/snapshot.py
@@ -197,6 +197,7 @@ OPTION_MATRIX: dict[str, tuple[bool, set[str]]] = {
     # Display formatting
     "--group-by":        (True,  _BAL_REG),
     "--pivot":           (True,  _BAL_REG),
+    "--pivot-only":      (True,  _BAL_REG),
     "--color":           (False, _BAL_REG),
     "--bold-if":         (True,  _BAL_REG),
     "--average-lot-prices": (False, _BAL_REG),
@@ -219,6 +220,7 @@ OPTION_TEST_VALUES: dict[str, str] = {
     "--forecast-while": "date < [2015]",
     "--group-by": "payee",
     "--pivot": "payee",
+    "--pivot-only": "payee",
     "--bold-if": "amount > 0",
     "--date-format": "%Y-%m-%d",
 }
@@ -331,7 +333,7 @@ def generate_curated_combos() -> list[Combo]:
 VALUE_OPTIONS = frozenset({
     "-f", "--file", "--init-file", "--pager", "--columns", "--output",
     "--sort", "--head", "--tail", "--depth", "--inject", "--forecast-while",
-    "--group-by", "--pivot", "--bold-if", "--date-format", "--format",
+    "--group-by", "--pivot", "--pivot-only", "--bold-if", "--date-format", "--format",
     "--balance-format", "--register-format", "--csv-format", "--plot-format",
     "--pricedb-format", "--prices-format", "--limit", "--only", "--display",
     "--amount", "--total", "--account", "--payee", "--begin", "--end",


### PR DESCRIPTION
## Summary

- New option `--pivot-only TAG` that replaces the account entirely with `TAG:value` instead of prepending to it (the existing `--pivot` behaviour).
- Shares `transfer_details` with `--pivot` via a new `SET_ACCOUNT_REPLACE` element; tag lookup and the built-in property fallback (from #1048) are reused.
- Regression test (`test/regress/1153.test`), baseline test (`test/baseline/opt-pivot-only.test`), and documentation updates in `doc/ledger3.texi` and `doc/ledger.1`.

## Motivation

The reporter wanted `--pivot Member` on a posting tagged `Member: John Doe` to produce `Member:John Doe` rather than `Member:John Doe:Income:Fees`. `--pivot-only` gives that view — useful when the tag value is the bucket and the original account hierarchy is incidental.

Closes #1153.

## Test plan

- [x] New regression test `test/regress/1153.test` exercises `--pivot` (prepend), `--pivot-only` (replace), filtering by pivoted name, and register output.
- [x] New baseline `test/baseline/opt-pivot-only.test` parallels `opt-pivot.test`.
- [x] Full `ctest -j8` run: 4313/4313 passing.
- [x] Existing pivot tests still pass (1048, 1154, 1693, coverage-filters-pivot, cov2-groupby-pivot, cov6-filters-transfer, cov9-pivot-account, coverage-report-new-4).