### PR TITLE
Add regression test for Python posting flag access (#1796)

### DIFF
--- a/test/regress/1796.py
+++ b/test/regress/1796.py
@@ -1,0 +1,47 @@
+import ledger
+
+# Regression test for GitHub issue #1796:
+# Access posting flags in Python.
+#
+# Originally, reading post.flags or calling post.has_flags(ITEM_GENERATED)
+# raised Boost.Python.ArgumentError because the JournalItem binding bound
+# the flag getters/setters to supports_flags<uint_least8_t>, while item_t
+# actually inherits from supports_flags<uint_least16_t>.  The type mismatch
+# made every flags-related method unreachable from Python.
+#
+# Fixed alongside issue #2169 by binding the uint_least16_t specialisation
+# in py_item.cc.  This test exercises the exact call sites reported in the
+# issue to guard against the type mismatch returning.
+
+session = ledger.Session()
+j = session.read_journal_from_string("""
+2024/01/01 Lunch
+    Expenses:Food          $10.00
+    Assets:Cash           $-10.00
+
+2024/01/02 Virtual tracking
+    (Virtual:Envelope)     $25.00
+    Expenses:Supplies      $25.00
+    Assets:Cash           $-25.00
+""")
+
+for xact in j:
+    # Both JournalItem.flags (property) and JournalItem.has_flags (method)
+    # must be callable from Python without raising ArgumentError.
+    print("xact flags=%d has_flags(ITEM_GENERATED)=%s"
+          % (xact.flags, xact.has_flags(ledger.ITEM_GENERATED)))
+    for post in xact.posts:
+        name = post.account.fullname()
+        print("  post %s: flags=%d has_flags(ITEM_GENERATED)=%s has_flags(POST_VIRTUAL)=%s"
+              % (name, post.flags,
+                 post.has_flags(ledger.ITEM_GENERATED),
+                 post.has_flags(ledger.POST_VIRTUAL)))
+
+# Mutating methods (add_flags, drop_flags, clear_flags) must round-trip too.
+first_post = next(iter(next(iter(j)).posts))
+first_post.add_flags(ledger.ITEM_GENERATED)
+print("after add_flags: has_flags(ITEM_GENERATED)=%s"
+      % first_post.has_flags(ledger.ITEM_GENERATED))
+first_post.drop_flags(ledger.ITEM_GENERATED)
+print("after drop_flags: has_flags(ITEM_GENERATED)=%s"
+      % first_post.has_flags(ledger.ITEM_GENERATED))

--- a/test/regress/1796_py.test
+++ b/test/regress/1796_py.test
@@ -1,0 +1,11 @@
+test python test/regress/1796.py
+xact flags=0 has_flags(ITEM_GENERATED)=False
+  post Expenses:Food: flags=0 has_flags(ITEM_GENERATED)=False has_flags(POST_VIRTUAL)=False
+  post Assets:Cash: flags=0 has_flags(ITEM_GENERATED)=False has_flags(POST_VIRTUAL)=False
+xact flags=0 has_flags(ITEM_GENERATED)=False
+  post Virtual:Envelope: flags=16 has_flags(ITEM_GENERATED)=False has_flags(POST_VIRTUAL)=True
+  post Expenses:Supplies: flags=0 has_flags(ITEM_GENERATED)=False has_flags(POST_VIRTUAL)=False
+  post Assets:Cash: flags=0 has_flags(ITEM_GENERATED)=False has_flags(POST_VIRTUAL)=False
+after add_flags: has_flags(ITEM_GENERATED)=True
+after drop_flags: has_flags(ITEM_GENERATED)=False
+end test


### PR DESCRIPTION
## Summary

- Issue #1796 reported `post.flags` and `post.has_flags(ledger.ITEM_GENERATED)`
  raised `Boost.Python.ArgumentError` with a C++ signature mentioning
  `supports_flags<unsigned char, unsigned char>`.
- This was the same type-mismatch that #2169 fixed (commit 04cb83954):
  `py_item.cc` originally bound the flag accessors to
  `supports_flags<uint_least8_t>`, but `item_t` inherits from
  `supports_flags<uint_least16_t>`, so Boost.Python refused the argument.
- The underlying fix already shipped with PR #2859, so this PR only adds a
  regression test that exercises the exact call sites from the original
  bug report, to guard against the binding ever being reverted.

## Test plan

- [x] `test/regress/1796.py` reads `post.flags`, calls
      `post.has_flags(ledger.ITEM_GENERATED)` (and `POST_VIRTUAL`),
      and round-trips `add_flags` / `drop_flags`.
- [x] `ctest -j8` — 4312/4312 tests pass (includes new
      `RegressTest_1796_py`).
- [x] Existing Python regression (`RegressTest_2169_py`) still passes,
      confirming the original #2169 fix remains intact.

Fixes #1796