### PR TITLE
Support metadata tags on account directives (#1681)

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -2395,6 +2395,23 @@ The example above declares @samp{Income}, @samp{Income:Salary},
 @samp{Income:Apps}, @samp{Income:Apps:Android},
 @samp{Income:Apps:iPhone}, and @samp{Income:Rent}.
 
+Comment lines that follow an @code{account} directive may also declare
+metadata tags for the account, using the same @samp{Key: value} and
+@samp{:tag:} syntaxes accepted inside transactions:
+
+@smallexample @c input:validate
+account Assets:Budget:Food
+    ; Contribution: 50 EUR
+    ; Target: 100 EUR
+    ; :Important:
+@end smallexample
+
+These tags are reachable from any account-context expression -- most
+usefully from a @command{balance} format string -- through the
+@code{tag}, @code{meta}, @code{has_tag}, and @code{has_meta} functions.
+Tag lookups walk up the account hierarchy, so a tag declared on a
+parent account is inherited by its children unless they redeclare it.
+
 @item apply account
 @findex apply account
 @c instance_t::master_account_directive

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LEDGER_SOURCES
   xact.cc
   post.cc
   item.cc
+  metadata.cc
   format.cc
   query.cc
   scope.cc
@@ -108,6 +109,7 @@ set(LEDGER_INCLUDES
   journal.h
   lookup.h
   mask.h
+  metadata.h
   op.h
   option.h
   output.h

--- a/src/account.cc
+++ b/src/account.cc
@@ -295,6 +295,162 @@ std::ostream& operator<<(std::ostream& out, const account_t& account) {
   return out;
 }
 
+/*--- Metadata Operations ---*/
+
+namespace {
+/**
+ * @brief Case-insensitive ordering used when lazily creating an account
+ *        metadata map.  Mirrors the comparator in item.cc so account
+ *        tags use the same name-matching semantics as item tags.
+ */
+struct AccountKeyCompare {
+  bool operator()(const string& s1, const string& s2) const {
+    return boost::algorithm::ilexicographical_compare(s1, s2);
+  }
+};
+} // namespace
+
+bool account_t::has_tag(const string& tag, bool inherit) const {
+  if (metadata && metadata->find(tag) != metadata->end())
+    return true;
+  if (inherit && parent && parent->parent)
+    return parent->has_tag(tag, inherit);
+  return false;
+}
+
+bool account_t::has_tag(const mask_t& tag_mask, const std::optional<mask_t>& value_mask,
+                        bool inherit) const {
+  if (metadata) {
+    for (const item_t::string_map::value_type& data : *metadata) {
+      if (tag_mask.match(data.first)) {
+        if (!value_mask)
+          return true;
+        else if (data.second.first)
+          return value_mask->match(data.second.first->to_string());
+      }
+    }
+  }
+  if (inherit && parent && parent->parent)
+    return parent->has_tag(tag_mask, value_mask, inherit);
+  return false;
+}
+
+std::optional<value_t> account_t::get_tag(const string& tag, bool inherit) const {
+  if (metadata) {
+    item_t::string_map::const_iterator i = metadata->find(tag);
+    if (i != metadata->end())
+      return i->second.first;
+  }
+  if (inherit && parent && parent->parent)
+    return parent->get_tag(tag, inherit);
+  return std::nullopt;
+}
+
+std::optional<value_t> account_t::get_tag(const mask_t& tag_mask,
+                                          const std::optional<mask_t>& value_mask,
+                                          bool inherit) const {
+  if (metadata) {
+    for (const item_t::string_map::value_type& data : *metadata) {
+      if (tag_mask.match(data.first) &&
+          (!value_mask ||
+           (data.second.first && value_mask->match(data.second.first->to_string())))) {
+        return data.second.first;
+      }
+    }
+  }
+  if (inherit && parent && parent->parent)
+    return parent->get_tag(tag_mask, value_mask, inherit);
+  return std::nullopt;
+}
+
+item_t::string_map::iterator account_t::set_tag(const string& tag,
+                                                const std::optional<value_t>& value,
+                                                bool overwrite_existing) {
+  assert(!tag.empty());
+
+  if (!metadata)
+    metadata = item_t::string_map(AccountKeyCompare());
+
+  std::optional<value_t> data = value;
+  if (data && (data->is_null() || (data->is_string() && data->as_string().empty())))
+    data = std::nullopt;
+
+  item_t::string_map::iterator i = metadata->find(tag);
+  if (i == metadata->end()) {
+    auto [iter, inserted] =
+        metadata->insert(item_t::string_map::value_type(tag, item_t::tag_data_t(data, false)));
+    assert(inserted);
+    return iter;
+  }
+  if (overwrite_existing)
+    i->second = item_t::tag_data_t(data, false);
+  return i;
+}
+
+void account_t::parse_tags(const char* p, scope_t& scope, bool overwrite_existing) {
+  // Unlike item_t::parse_tags, accounts have no dates, so `[date]` brackets
+  // are ignored here -- we only scan for `:tag1:tag2:` bare tags and the
+  // `Key: value` / `Key:: expr` metadata forms.
+  if (!std::strchr(p, ':'))
+    return;
+
+  string str(p);
+  string::size_type pos = 0;
+
+  string tag;
+  bool by_value = false;
+  bool first = true;
+
+  while (pos < str.length()) {
+    pos = str.find_first_not_of(" \t", pos);
+    if (pos == string::npos)
+      break;
+
+    string::size_type end = str.find_first_of(" \t", pos);
+    if (end == string::npos)
+      end = str.length();
+
+    string token = str.substr(pos, end - pos);
+    if (token.length() < 2) {
+      pos = end;
+      continue;
+    }
+
+    if (token[0] == ':' && token[token.length() - 1] == ':') { // a series of tags
+      string tag_str(token, 1, token.length() - 2);
+      std::vector<string> tag_names;
+      boost::split(tag_names, tag_str, boost::is_any_of(":"));
+      for (const string& tag_name : tag_names) {
+        if (!tag_name.empty()) {
+          item_t::string_map::iterator i = set_tag(tag_name, std::nullopt, overwrite_existing);
+          i->second.second = true;
+        }
+      }
+    } else if (first && token[token.length() - 1] == ':') { // a metadata setting
+      std::size_t index = 1;
+      if (token[token.length() - 2] == ':') {
+        by_value = true;
+        index = 2;
+      }
+      tag = token.substr(0, token.length() - index);
+
+      item_t::string_map::iterator i;
+      string field(p + end);
+      trim(field);
+      if (by_value) {
+        bind_scope_t bound_scope(scope, *this);
+        i = set_tag(tag, expr_t(field).calc(bound_scope), overwrite_existing);
+      } else {
+        i = set_tag(tag, string_value(field), overwrite_existing);
+      }
+      i->second.second = true;
+      break;
+    }
+    first = false;
+    pos = end;
+  }
+}
+
 /*--- Expression Bindings ---*/
 
 namespace {
@@ -364,6 +520,60 @@ value_t get_depth(account_t& account) {
 
 value_t get_note(account_t& account) {
   return account.note ? string_value(*account.note) : NULL_VALUE;
+}
+
+value_t has_tag(call_scope_t& args) {
+  account_t& account(args.context<account_t>());
+
+  if (args.size() == 1) {
+    if (args[0].is_string())
+      return account.has_tag(args.get<string>(0));
+    else if (args[0].is_mask())
+      return account.has_tag(args.get<mask_t>(0));
+    else
+      throw_(std::runtime_error,
+             _f("Expected string or mask for argument 1, but received %1%") % args[0].label());
+  } else if (args.size() == 2) {
+    if (args[0].is_mask() && args[1].is_mask())
+      return account.has_tag(args.get<mask_t>(0), args.get<mask_t>(1));
+    else
+      throw_(std::runtime_error,
+             _f("Expected masks for arguments 1 and 2, but received %1% and %2%") %
+                 args[0].label() % args[1].label());
+  } else if (args.size() == 0) {
+    throw_(std::runtime_error, _("Too few arguments to function"));
+  } else {
+    throw_(std::runtime_error, _("Too many arguments to function"));
+  }
+  return false;
+}
+
+value_t get_tag(call_scope_t& args) {
+  account_t& account(args.context<account_t>());
+  std::optional<value_t> val;
+
+  if (args.size() == 1) {
+    if (args[0].is_string())
+      val = account.get_tag(args.get<string>(0));
+    else if (args[0].is_mask())
+      val = account.get_tag(args.get<mask_t>(0));
+    else
+      throw_(std::runtime_error,
+             _f("Expected string or mask for argument 1, but received %1%") % args[0].label());
+  } else if (args.size() == 2) {
+    if (args[0].is_mask() && args[1].is_mask())
+      val = account.get_tag(args.get<mask_t>(0), args.get<mask_t>(1));
+    else
+      throw_(std::runtime_error,
+             _f("Expected masks for arguments 1 and 2, but received %1% and %2%") %
+                 args[0].label() % args[1].label());
+  } else if (args.size() == 0) {
+    throw_(std::runtime_error, _("Too few arguments to function"));
+  } else {
+    throw_(std::runtime_error, _("Too many arguments to function"));
+  }
+
+  return val ? *val : NULL_VALUE;
 }
 
 value_t ignore(account_t&) {
@@ -546,6 +756,13 @@ expr_t::ptr_op_t account_t::lookup(const symbol_t::kind_t kind, const string& fn
   case 'h':
     if (fn_name == "has_children_to_display")
       return WRAP_FUNCTOR(get_wrapper<&get_has_children_to_display>);
+    else if (fn_name == "has_tag" || fn_name == "has_meta")
+      return WRAP_FUNCTOR(ledger::has_tag);
+    break;
+
+  case 'm':
+    if (fn_name == "meta")
+      return WRAP_FUNCTOR(ledger::get_tag);
     break;
 
   case 'i':
@@ -588,7 +805,9 @@ expr_t::ptr_op_t account_t::lookup(const symbol_t::kind_t kind, const string& fn
     break;
 
   case 't':
-    if (fn_name == "total")
+    if (fn_name == "tag")
+      return WRAP_FUNCTOR(ledger::get_tag);
+    else if (fn_name == "total")
       return WRAP_FUNCTOR(get_wrapper<&get_total>);
     break;
 

--- a/src/account.cc
+++ b/src/account.cc
@@ -295,23 +295,10 @@ std::ostream& operator<<(std::ostream& out, const account_t& account) {
   return out;
 }
 
-/*--- Metadata Operations ---*/
-
-namespace {
-/**
- * @brief Case-insensitive ordering used when lazily creating an account
- *        metadata map.  Mirrors the comparator in item.cc so account
- *        tags use the same name-matching semantics as item tags.
- */
-struct AccountKeyCompare {
-  bool operator()(const string& s1, const string& s2) const {
-    return boost::algorithm::ilexicographical_compare(s1, s2);
-  }
-};
-} // namespace
+/*--- Metadata Operations (parent-walking inheritance) ---*/
 
 bool account_t::has_tag(const string& tag, bool inherit) const {
-  if (metadata && metadata->find(tag) != metadata->end())
+  if (metadata_t::has_tag(tag))
     return true;
   if (inherit && parent && parent->parent)
     return parent->has_tag(tag, inherit);
@@ -320,27 +307,16 @@ bool account_t::has_tag(const string& tag, bool inherit) const {
 
 bool account_t::has_tag(const mask_t& tag_mask, const std::optional<mask_t>& value_mask,
                         bool inherit) const {
-  if (metadata) {
-    for (const item_t::string_map::value_type& data : *metadata) {
-      if (tag_mask.match(data.first)) {
-        if (!value_mask)
-          return true;
-        else if (data.second.first)
-          return value_mask->match(data.second.first->to_string());
-      }
-    }
-  }
+  if (metadata_t::has_tag(tag_mask, value_mask))
+    return true;
   if (inherit && parent && parent->parent)
     return parent->has_tag(tag_mask, value_mask, inherit);
   return false;
 }
 
 std::optional<value_t> account_t::get_tag(const string& tag, bool inherit) const {
-  if (metadata) {
-    item_t::string_map::const_iterator i = metadata->find(tag);
-    if (i != metadata->end())
-      return i->second.first;
-  }
+  if (std::optional<value_t> v = metadata_t::get_tag(tag))
+    return v;
   if (inherit && parent && parent->parent)
     return parent->get_tag(tag, inherit);
   return std::nullopt;
@@ -349,106 +325,11 @@ std::optional<value_t> account_t::get_tag(const string& tag, bool inherit) const
 std::optional<value_t> account_t::get_tag(const mask_t& tag_mask,
                                           const std::optional<mask_t>& value_mask,
                                           bool inherit) const {
-  if (metadata) {
-    for (const item_t::string_map::value_type& data : *metadata) {
-      if (tag_mask.match(data.first) &&
-          (!value_mask ||
-           (data.second.first && value_mask->match(data.second.first->to_string())))) {
-        return data.second.first;
-      }
-    }
-  }
+  if (std::optional<value_t> v = metadata_t::get_tag(tag_mask, value_mask))
+    return v;
   if (inherit && parent && parent->parent)
     return parent->get_tag(tag_mask, value_mask, inherit);
   return std::nullopt;
-}
-
-item_t::string_map::iterator account_t::set_tag(const string& tag,
-                                                const std::optional<value_t>& value,
-                                                bool overwrite_existing) {
-  assert(!tag.empty());
-
-  if (!metadata)
-    metadata = item_t::string_map(AccountKeyCompare());
-
-  std::optional<value_t> data = value;
-  if (data && (data->is_null() || (data->is_string() && data->as_string().empty())))
-    data = std::nullopt;
-
-  item_t::string_map::iterator i = metadata->find(tag);
-  if (i == metadata->end()) {
-    auto [iter, inserted] =
-        metadata->insert(item_t::string_map::value_type(tag, item_t::tag_data_t(data, false)));
-    assert(inserted);
-    return iter;
-  }
-  if (overwrite_existing)
-    i->second = item_t::tag_data_t(data, false);
-  return i;
-}
-
-void account_t::parse_tags(const char* p, scope_t& scope, bool overwrite_existing) {
-  // Unlike item_t::parse_tags, accounts have no dates, so `[date]` brackets
-  // are ignored here -- we only scan for `:tag1:tag2:` bare tags and the
-  // `Key: value` / `Key:: expr` metadata forms.
-  if (!std::strchr(p, ':'))
-    return;
-
-  string str(p);
-  string::size_type pos = 0;
-
-  string tag;
-  bool by_value = false;
-  bool first = true;
-
-  while (pos < str.length()) {
-    pos = str.find_first_not_of(" \t", pos);
-    if (pos == string::npos)
-      break;
-
-    string::size_type end = str.find_first_of(" \t", pos);
-    if (end == string::npos)
-      end = str.length();
-
-    string token = str.substr(pos, end - pos);
-    if (token.length() < 2) {
-      pos = end;
-      continue;
-    }
-
-    if (token[0] == ':' && token[token.length() - 1] == ':') { // a series of tags
-      string tag_str(token, 1, token.length() - 2);
-      std::vector<string> tag_names;
-      boost::split(tag_names, tag_str, boost::is_any_of(":"));
-      for (const string& tag_name : tag_names) {
-        if (!tag_name.empty()) {
-          item_t::string_map::iterator i = set_tag(tag_name, std::nullopt, overwrite_existing);
-          i->second.second = true;
-        }
-      }
-    } else if (first && token[token.length() - 1] == ':') { // a metadata setting
-      std::size_t index = 1;
-      if (token[token.length() - 2] == ':') {
-        by_value = true;
-        index = 2;
-      }
-      tag = token.substr(0, token.length() - index);
-
-      item_t::string_map::iterator i;
-      string field(p + end);
-      trim(field);
-      if (by_value) {
-        bind_scope_t bound_scope(scope, *this);
-        i = set_tag(tag, expr_t(field).calc(bound_scope), overwrite_existing);
-      } else {
-        i = set_tag(tag, string_value(field), overwrite_existing);
-      }
-      i->second.second = true;
-      break;
-    }
-    first = false;
-    pos = end;
-  }
 }
 
 /*--- Expression Bindings ---*/
@@ -522,58 +403,12 @@ value_t get_note(account_t& account) {
   return account.note ? string_value(*account.note) : NULL_VALUE;
 }
 
-value_t has_tag(call_scope_t& args) {
-  account_t& account(args.context<account_t>());
-
-  if (args.size() == 1) {
-    if (args[0].is_string())
-      return account.has_tag(args.get<string>(0));
-    else if (args[0].is_mask())
-      return account.has_tag(args.get<mask_t>(0));
-    else
-      throw_(std::runtime_error,
-             _f("Expected string or mask for argument 1, but received %1%") % args[0].label());
-  } else if (args.size() == 2) {
-    if (args[0].is_mask() && args[1].is_mask())
-      return account.has_tag(args.get<mask_t>(0), args.get<mask_t>(1));
-    else
-      throw_(std::runtime_error,
-             _f("Expected masks for arguments 1 and 2, but received %1% and %2%") %
-                 args[0].label() % args[1].label());
-  } else if (args.size() == 0) {
-    throw_(std::runtime_error, _("Too few arguments to function"));
-  } else {
-    throw_(std::runtime_error, _("Too many arguments to function"));
-  }
-  return false;
+value_t account_has_tag(call_scope_t& args) {
+  return metadata_has_tag(args.context<account_t>(), args);
 }
 
-value_t get_tag(call_scope_t& args) {
-  account_t& account(args.context<account_t>());
-  std::optional<value_t> val;
-
-  if (args.size() == 1) {
-    if (args[0].is_string())
-      val = account.get_tag(args.get<string>(0));
-    else if (args[0].is_mask())
-      val = account.get_tag(args.get<mask_t>(0));
-    else
-      throw_(std::runtime_error,
-             _f("Expected string or mask for argument 1, but received %1%") % args[0].label());
-  } else if (args.size() == 2) {
-    if (args[0].is_mask() && args[1].is_mask())
-      val = account.get_tag(args.get<mask_t>(0), args.get<mask_t>(1));
-    else
-      throw_(std::runtime_error,
-             _f("Expected masks for arguments 1 and 2, but received %1% and %2%") %
-                 args[0].label() % args[1].label());
-  } else if (args.size() == 0) {
-    throw_(std::runtime_error, _("Too few arguments to function"));
-  } else {
-    throw_(std::runtime_error, _("Too many arguments to function"));
-  }
-
-  return val ? *val : NULL_VALUE;
+value_t account_get_tag(call_scope_t& args) {
+  return metadata_get_tag(args.context<account_t>(), args);
 }
 
 value_t ignore(account_t&) {
@@ -757,12 +592,12 @@ expr_t::ptr_op_t account_t::lookup(const symbol_t::kind_t kind, const string& fn
     if (fn_name == "has_children_to_display")
       return WRAP_FUNCTOR(get_wrapper<&get_has_children_to_display>);
     else if (fn_name == "has_tag" || fn_name == "has_meta")
-      return WRAP_FUNCTOR(ledger::has_tag);
+      return WRAP_FUNCTOR(account_has_tag);
     break;
 
   case 'm':
     if (fn_name == "meta")
-      return WRAP_FUNCTOR(ledger::get_tag);
+      return WRAP_FUNCTOR(account_get_tag);
     break;
 
   case 'i':
@@ -806,7 +641,7 @@ expr_t::ptr_op_t account_t::lookup(const symbol_t::kind_t kind, const string& fn
 
   case 't':
     if (fn_name == "tag")
-      return WRAP_FUNCTOR(ledger::get_tag);
+      return WRAP_FUNCTOR(account_get_tag);
     else if (fn_name == "total")
       return WRAP_FUNCTOR(get_wrapper<&get_total>);
     break;

--- a/src/account.h
+++ b/src/account.h
@@ -130,8 +130,7 @@ public:
   // has an independent (empty) posting history.
   account_t(const account_t& other)
       : supports_flags<>(other.flags()), scope_t(), parent(other.parent), name(other.name),
-        note(other.note), depth(other.depth), accounts(other.accounts),
-        metadata(other.metadata) {
+        note(other.note), depth(other.depth), accounts(other.accounts), metadata(other.metadata) {
     TRACE_CTOR(account_t, "copy");
   }
   account_t& operator=(const account_t&) = default;
@@ -278,8 +277,7 @@ public:
    * @param value              Optional value to associate with the tag.
    * @param overwrite_existing If false, an existing tag is left untouched.
    */
-  item_t::string_map::iterator set_tag(const string& tag,
-                                       const std::optional<value_t>& value = {},
+  item_t::string_map::iterator set_tag(const string& tag, const std::optional<value_t>& value = {},
                                        bool overwrite_existing = true);
 
   /**

--- a/src/account.h
+++ b/src/account.h
@@ -61,6 +61,7 @@
 
 #include <limits>
 
+#include "item.h"
 #include "scope.h"
 #include "types.h"
 
@@ -108,6 +109,12 @@ public:
   std::optional<expr_t>
       value_expr; ///< Custom valuation expression overriding commodity-level valuation.
 
+  /// Structured metadata tags parsed from `;`-prefixed comment lines that
+  /// follow an `account` directive.  Shares item_t's case-insensitive
+  /// string_map type so account tags interoperate with the same tag/meta
+  /// expressions already used for transactions and postings (issue #1681).
+  optional<item_t::string_map> metadata;
+
   mutable string _fullname; ///< Cached colon-joined full name, computed lazily by fullname().
 
   account_t(account_t* _parent = nullptr, const string& _name = "",
@@ -123,7 +130,8 @@ public:
   // has an independent (empty) posting history.
   account_t(const account_t& other)
       : supports_flags<>(other.flags()), scope_t(), parent(other.parent), name(other.name),
-        note(other.note), depth(other.depth), accounts(other.accounts) {
+        note(other.note), depth(other.depth), accounts(other.accounts),
+        metadata(other.metadata) {
     TRACE_CTOR(account_t, "copy");
   }
   account_t& operator=(const account_t&) = default;
@@ -229,6 +237,60 @@ public:
 
   posts_list::iterator posts_begin() { return posts.begin(); }
   posts_list::iterator posts_end() { return posts.end(); }
+
+  /**
+   * @brief Test whether a metadata tag is set on this account.
+   * @param tag      Tag name to look up (case-insensitive).
+   * @param inherit  If true, also search ancestor accounts.
+   */
+  bool has_tag(const string& tag, bool inherit = true) const;
+
+  /**
+   * @brief Test whether any tag matching a regex pattern exists on this account.
+   * @param tag_mask    Regex to match against tag names.
+   * @param value_mask  Optional regex to additionally match the tag's value.
+   * @param inherit     If true, also search ancestor accounts.
+   */
+  bool has_tag(const mask_t& tag_mask, const std::optional<mask_t>& value_mask = {},
+               bool inherit = true) const;
+
+  /**
+   * @brief Retrieve the value of a metadata tag.
+   * @param tag      Tag name to look up (case-insensitive).
+   * @param inherit  If true, and the tag is not set here, search ancestor accounts.
+   * @return The tag's value, or nullopt if the tag is not found.
+   */
+  std::optional<value_t> get_tag(const string& tag, bool inherit = true) const;
+
+  /**
+   * @brief Retrieve the first tag value matching a regex pattern.
+   * @param tag_mask    Regex to match against tag names.
+   * @param value_mask  Optional regex to additionally match the tag's value.
+   * @param inherit     If true, also search ancestor accounts.
+   */
+  std::optional<value_t> get_tag(const mask_t& tag_mask,
+                                 const std::optional<mask_t>& value_mask = {},
+                                 bool inherit = true) const;
+
+  /**
+   * @brief Set or overwrite a metadata tag on this account, creating the map if needed.
+   * @param tag                Tag name (case-insensitive key).
+   * @param value              Optional value to associate with the tag.
+   * @param overwrite_existing If false, an existing tag is left untouched.
+   */
+  item_t::string_map::iterator set_tag(const string& tag,
+                                       const std::optional<value_t>& value = {},
+                                       bool overwrite_existing = true);
+
+  /**
+   * @brief Parse metadata tags from a comment line.
+   *
+   * Recognizes the same `:tag1:tag2:` and `Key: value` / `Key:: expr`
+   * syntaxes that `item_t::parse_tags` handles, but without the
+   * bracketed-date support since accounts are not dated.  The scope is
+   * bound through this account when evaluating `Key:: expr` forms.
+   */
+  void parse_tags(const char* p, scope_t& scope, bool overwrite_existing = true);
 
   /**
    * @brief Dispatch table for expression function lookups.

--- a/src/account.h
+++ b/src/account.h
@@ -61,7 +61,7 @@
 
 #include <limits>
 
-#include "item.h"
+#include "metadata.h"
 #include "scope.h"
 #include "types.h"
 
@@ -89,7 +89,7 @@ using deferred_posts_map_t = std::map<string, posts_list>;
  * as the evaluation context, giving expressions access to the account's
  * name, depth, totals, and statistics through the lookup() dispatch table.
  */
-class account_t : public flags::supports_flags<>, public scope_t {
+class account_t : public flags::supports_flags<>, public metadata_t, public scope_t {
 #define ACCOUNT_NORMAL 0x00 ///< No special flags; an ordinary user-defined account.
 #define ACCOUNT_KNOWN                                                                              \
   0x01 ///< Account was declared with the `account` directive (for --strict/--pedantic validation).
@@ -109,17 +109,11 @@ public:
   std::optional<expr_t>
       value_expr; ///< Custom valuation expression overriding commodity-level valuation.
 
-  /// Structured metadata tags parsed from `;`-prefixed comment lines that
-  /// follow an `account` directive.  Shares item_t's case-insensitive
-  /// string_map type so account tags interoperate with the same tag/meta
-  /// expressions already used for transactions and postings (issue #1681).
-  optional<item_t::string_map> metadata;
-
   mutable string _fullname; ///< Cached colon-joined full name, computed lazily by fullname().
 
   account_t(account_t* _parent = nullptr, const string& _name = "",
             const optional<string>& _note = none)
-      : supports_flags<>(), scope_t(), parent(_parent), name(_name), note(_note),
+      : supports_flags<>(), metadata_t(), scope_t(), parent(_parent), name(_name), note(_note),
         depth(static_cast<unsigned short>(parent ? parent->depth + 1 : 0)) {
     if (parent && parent->depth == std::numeric_limits<unsigned short>::max())
       throw std::runtime_error("Account hierarchy too deep");
@@ -127,10 +121,11 @@ public:
   }
   // Note: copy is intentionally shallow — posts and deferred_posts are
   // NOT copied. The copy shares the same parent and children map but
-  // has an independent (empty) posting history.
+  // has an independent (empty) posting history.  Metadata is copied via
+  // the metadata_t copy constructor.
   account_t(const account_t& other)
-      : supports_flags<>(other.flags()), scope_t(), parent(other.parent), name(other.name),
-        note(other.note), depth(other.depth), accounts(other.accounts), metadata(other.metadata) {
+      : supports_flags<>(other.flags()), metadata_t(other), scope_t(), parent(other.parent),
+        name(other.name), note(other.note), depth(other.depth), accounts(other.accounts) {
     TRACE_CTOR(account_t, "copy");
   }
   account_t& operator=(const account_t&) = default;
@@ -238,57 +233,33 @@ public:
   posts_list::iterator posts_end() { return posts.end(); }
 
   /**
-   * @brief Test whether a metadata tag is set on this account.
-   * @param tag      Tag name to look up (case-insensitive).
-   * @param inherit  If true, also search ancestor accounts.
+   * @brief Tag lookup with parent-account inheritance.
+   *
+   * Overrides metadata_t::has_tag / metadata_t::get_tag so that, when
+   * the tag is not present on this account and @p inherit is true, the
+   * search walks up the parent chain.  The walk stops one level above
+   * the root (an account whose grandparent is null is the master
+   * account, which never carries directive-supplied metadata).
    */
-  bool has_tag(const string& tag, bool inherit = true) const;
-
-  /**
-   * @brief Test whether any tag matching a regex pattern exists on this account.
-   * @param tag_mask    Regex to match against tag names.
-   * @param value_mask  Optional regex to additionally match the tag's value.
-   * @param inherit     If true, also search ancestor accounts.
-   */
+  bool has_tag(const string& tag, bool inherit = true) const override;
   bool has_tag(const mask_t& tag_mask, const std::optional<mask_t>& value_mask = {},
-               bool inherit = true) const;
+               bool inherit = true) const override;
 
-  /**
-   * @brief Retrieve the value of a metadata tag.
-   * @param tag      Tag name to look up (case-insensitive).
-   * @param inherit  If true, and the tag is not set here, search ancestor accounts.
-   * @return The tag's value, or nullopt if the tag is not found.
-   */
-  std::optional<value_t> get_tag(const string& tag, bool inherit = true) const;
-
-  /**
-   * @brief Retrieve the first tag value matching a regex pattern.
-   * @param tag_mask    Regex to match against tag names.
-   * @param value_mask  Optional regex to additionally match the tag's value.
-   * @param inherit     If true, also search ancestor accounts.
-   */
+  std::optional<value_t> get_tag(const string& tag, bool inherit = true) const override;
   std::optional<value_t> get_tag(const mask_t& tag_mask,
                                  const std::optional<mask_t>& value_mask = {},
-                                 bool inherit = true) const;
+                                 bool inherit = true) const override;
 
   /**
-   * @brief Set or overwrite a metadata tag on this account, creating the map if needed.
-   * @param tag                Tag name (case-insensitive key).
-   * @param value              Optional value to associate with the tag.
-   * @param overwrite_existing If false, an existing tag is left untouched.
-   */
-  item_t::string_map::iterator set_tag(const string& tag, const std::optional<value_t>& value = {},
-                                       bool overwrite_existing = true);
-
-  /**
-   * @brief Parse metadata tags from a comment line.
+   * @brief Parse `:tag:` and `Key:` metadata from an account-directive comment.
    *
-   * Recognizes the same `:tag1:tag2:` and `Key: value` / `Key:: expr`
-   * syntaxes that `item_t::parse_tags` handles, but without the
-   * bracketed-date support since accounts are not dated.  The scope is
-   * bound through this account when evaluating `Key:: expr` forms.
+   * Accounts have no dates, so this is a thin wrapper around
+   * metadata_t::parse_metadata_tags binding @c *this as the
+   * `Key:: expr` evaluation target.
    */
-  void parse_tags(const char* p, scope_t& scope, bool overwrite_existing = true);
+  void parse_tags(const char* p, scope_t& scope, bool overwrite_existing = true) {
+    parse_metadata_tags(p, scope, *this, overwrite_existing);
+  }
 
   /**
    * @brief Dispatch table for expression function lookups.

--- a/src/item.cc
+++ b/src/item.cc
@@ -37,8 +37,9 @@
  *
  * @brief  Implementation of item_t -- the base class for all journal items.
  *
- * This file implements the metadata system (has_tag, get_tag, set_tag,
- * parse_tags), the expression-engine bindings (lookup), and utility
+ * The metadata storage, lookups, and `:tag:` / `Key:` parser live in
+ * metadata.cc.  This file implements the date-aware parse_tags
+ * extension, the expression-engine bindings (lookup), and utility
  * functions for printing and serializing journal items.
  */
 
@@ -55,179 +56,22 @@ namespace ledger {
 bool item_t::use_aux_date = false;
 
 /*----------------------------------------------------------------------*/
-/*  Metadata Operations                                                 */
+/*  Tag Parsing (date extension)                                        */
 /*                                                                      */
-/*  The metadata map uses a case-insensitive comparator so that tags    */
-/*  like "Payee", "payee", and "PAYEE" all resolve to the same entry.   */
-/*  Lookups by exact string use the map's find(); lookups by regex      */
-/*  iterate over all entries.                                           */
+/*  Items extend the base parser with a leading bracketed-date form     */
+/*  `[date]` or `[date=auxdate]`.  Everything else is delegated to      */
+/*  metadata_t::parse_metadata_tags.                                    */
 /*----------------------------------------------------------------------*/
 
-bool item_t::has_tag(const string& tag, bool) const {
-  DEBUG("item.meta", "Checking if item has tag: " << tag);
-  if (!metadata) {
-    DEBUG("item.meta", "Item has no metadata at all");
-    return false;
-  }
-  string_map::const_iterator i = metadata->find(tag);
-#if DEBUG_ON
-  if (SHOW_DEBUG("item.meta")) {
-    if (i == metadata->end())
-      DEBUG("item.meta", "Item does not have this tag");
-    else
-      DEBUG("item.meta", "Item has the tag!");
-  }
-#endif
-  return i != metadata->end();
-}
-
-bool item_t::has_tag(const mask_t& tag_mask, const std::optional<mask_t>& value_mask, bool) const {
-  if (metadata) {
-    for (const string_map::value_type& data : *metadata) {
-      if (tag_mask.match(data.first)) {
-        if (!value_mask)
-          return true;
-        else if (data.second.first)
-          return value_mask->match(data.second.first->to_string());
-      }
-    }
-  }
-  return false;
-}
-
-std::optional<value_t> item_t::get_tag(const string& tag, bool) const {
-  DEBUG("item.meta", "Getting item tag: " << tag);
-  if (metadata) {
-    DEBUG("item.meta", "Item has metadata");
-    string_map::const_iterator i = metadata->find(tag);
-    if (i != metadata->end()) {
-      DEBUG("item.meta", "Found the item!");
-      return (*i).second.first;
-    }
-  }
-  return std::nullopt;
-}
-
-std::optional<value_t> item_t::get_tag(const mask_t& tag_mask,
-                                       const std::optional<mask_t>& value_mask, bool) const {
-  if (metadata) {
-    for (const string_map::value_type& data : *metadata) {
-      if (tag_mask.match(data.first) &&
-          (!value_mask ||
-           (data.second.first && value_mask->match(data.second.first->to_string())))) {
-        return data.second.first;
-      }
-    }
-  }
-  return std::nullopt;
-}
-
-namespace {
-/**
- * @brief Case-insensitive ordering for metadata tag names.
- *
- * Used as the comparator for item_t::string_map so that metadata
- * lookups are case-insensitive.  For example, a tag set as "Payee"
- * can be retrieved via has_tag("payee") or get_tag("PAYEE").
- * Delegates to Boost's ilexicographical_compare for locale-aware
- * case-folded ordering.
- */
-struct CaseInsensitiveKeyCompare
-#if __cplusplus < 201103L
-    : public std::binary_function<string, string, bool>
-#endif
-{
-  bool operator()(const string& s1, const string& s2) const {
-    return boost::algorithm::ilexicographical_compare(s1, s2);
-  }
-};
-} // namespace
-
-/**
- * @brief Set or overwrite a metadata tag, creating the map if needed.
- *
- * When the metadata map does not yet exist, it is initialized with a
- * CaseInsensitiveKeyCompare comparator.  Null or empty-string values
- * are normalized to std::nullopt (stored as a valueless tag).
- */
-item_t::string_map::iterator item_t::set_tag(const string& tag, const std::optional<value_t>& value,
-                                             const bool overwrite_existing) {
-  assert(!tag.empty());
-
-  if (!metadata)
-    metadata = string_map(CaseInsensitiveKeyCompare());
-
-  DEBUG("item.meta", "Setting tag '" << tag << "' to value '"
-                                     << (value ? *value : string_value("<none>")) << "'");
-
-  std::optional<value_t> data = value;
-  if (data && (data->is_null() || (data->is_string() && data->as_string().empty())))
-    data = std::nullopt;
-
-  string_map::iterator i = metadata->find(tag);
-  if (i == metadata->end()) {
-    DEBUG("item.meta", "Setting new metadata value");
-    auto [iter, inserted] = metadata->insert(string_map::value_type(tag, tag_data_t(data, false)));
-    assert(inserted);
-    return iter;
-  } else {
-    DEBUG("item.meta", "Found old metadata value");
-    if (overwrite_existing) {
-      DEBUG("item.meta", "Overwriting old metadata value");
-      (*i).second = tag_data_t(data, false);
-    }
-    return i;
-  }
-}
-
-/*----------------------------------------------------------------------*/
-/*  Tag Parsing                                                         */
-/*                                                                      */
-/*  Comment lines (`;`-prefixed) are scanned for structured metadata.   */
-/*  Three syntaxes are recognized:                                      */
-/*    1. [date=auxdate] -- bracketed date override                      */
-/*    2. :tag1:tag2:    -- colon-delimited bare tags                    */
-/*    3. Key: value     -- key/value metadata (first token with `:`)    */
-/*    4. Key:: expr     -- like Key: but value is an evaluated expr     */
-/*----------------------------------------------------------------------*/
-
-/**
- * @brief Parse metadata tags from a single comment line.
- *
- * This function extracts structured metadata from comment text.  It
- * handles three distinct syntaxes:
- *
- * **Bracketed dates** `[date]` or `[date=auxdate]`:
- *   If the text contains `[` followed by a digit or `=`, the content
- *   between brackets is parsed as a date override.  The part before
- *   `=` sets the primary date; the part after `=` sets the auxiliary
- *   (effective) date.  This allows postings to carry dates different
- *   from their parent transaction.
- *
- * **Colon-delimited tags** `:tag1:tag2:tag3:`:
- *   A token beginning and ending with `:` is split on `:` to produce
- *   multiple bare (valueless) tags in one comment line.
- *
- * **Key/value metadata** `Key: value` or `Key:: expr`:
- *   The first whitespace-delimited token ending with `:` names the key.
- *   Everything after it is the value.  With a single colon the value
- *   is stored as a string; with a double colon (`::`) the value is
- *   parsed and evaluated as an expression in the current scope.
- *
- * Only the first key/value pair per line is parsed (the function
- * breaks after finding it).  Multiple bare tags on the same line
- * are all recorded.
- */
 void item_t::parse_tags(const char* p, scope_t& scope, bool overwrite_existing) {
-  // Skip any additional leading `;` characters (with interleaved whitespace).
-  // The first `;` has already been consumed by the caller in textual_xacts.cc,
-  // but comments written as `;;Key: value` or `;  ;Key: value` would otherwise
-  // see the extra semicolon glom onto the tag name (fixes #1786).  Treat a run
-  // of leading semicolons as an extended comment prefix.
-  while (*p == ' ' || *p == '\t' || *p == ';')
-    ++p;
+  // Skip any additional leading `;` characters (with interleaved whitespace)
+  // before scanning for `[date]`.  `parse_metadata_tags` repeats this skip
+  // so the colon parser sees the same starting position.
+  const char* d = p;
+  while (*d == ' ' || *d == '\t' || *d == ';')
+    ++d;
 
-  if (const char* b = std::strchr(p, '[')) {
+  if (const char* b = std::strchr(d, '[')) {
     if (*(b + 1) != '\0' &&
         (std::isdigit(static_cast<unsigned char>(*(b + 1))) || *(b + 1) == '=')) {
       if (const char* e = std::strchr(b, ']')) {
@@ -245,64 +89,7 @@ void item_t::parse_tags(const char* p, scope_t& scope, bool overwrite_existing) 
     }
   }
 
-  if (!std::strchr(p, ':'))
-    return;
-
-  string str(p);
-  string::size_type pos = 0;
-
-  string tag;
-  bool by_value = false;
-  bool first = true;
-
-  while (pos < str.length()) {
-    pos = str.find_first_not_of(" \t", pos);
-    if (pos == string::npos)
-      break;
-
-    string::size_type end = str.find_first_of(" \t", pos);
-    if (end == string::npos)
-      end = str.length();
-
-    string token = str.substr(pos, end - pos);
-    if (token.length() < 2) {
-      pos = end;
-      continue;
-    }
-
-    if (token[0] == ':' && token[token.length() - 1] == ':') { // a series of tags
-      string tag_str(token, 1, token.length() - 2);
-      std::vector<string> tag_names;
-      boost::split(tag_names, tag_str, boost::is_any_of(":"));
-      for (const string& tag_name : tag_names) {
-        if (!tag_name.empty()) {
-          string_map::iterator i = set_tag(tag_name, std::nullopt, overwrite_existing);
-          (*i).second.second = true;
-        }
-      }
-    } else if (first && token[token.length() - 1] == ':') { // a metadata setting
-      std::size_t index = 1;
-      if (token[token.length() - 2] == ':') {
-        by_value = true;
-        index = 2;
-      }
-      tag = token.substr(0, token.length() - index);
-
-      string_map::iterator i;
-      string field(p + end); // NOLINT(bugprone-unused-local-non-trivial-variable)
-      trim(field);
-      if (by_value) {
-        bind_scope_t bound_scope(scope, *this);
-        i = set_tag(tag, expr_t(field).calc(bound_scope), overwrite_existing);
-      } else {
-        i = set_tag(tag, string_value(field), overwrite_existing);
-      }
-      (*i).second.second = true;
-      break;
-    }
-    first = false;
-    pos = end;
-  }
+  parse_metadata_tags(p, scope, *this, overwrite_existing);
 }
 
 void item_t::append_note(const char* p, scope_t& scope, bool overwrite_existing) {
@@ -359,58 +146,12 @@ value_t get_note(item_t& item) {
   return item.note ? string_value(*item.note) : NULL_VALUE;
 }
 
-value_t has_tag(call_scope_t& args) {
-  item_t& item(find_scope<item_t>(args));
-
-  if (args.size() == 1) {
-    if (args[0].is_string())
-      return item.has_tag(args.get<string>(0));
-    else if (args[0].is_mask())
-      return item.has_tag(args.get<mask_t>(0));
-    else
-      throw_(std::runtime_error,
-             _f("Expected string or mask for argument 1, but received %1%") % args[0].label());
-  } else if (args.size() == 2) {
-    if (args[0].is_mask() && args[1].is_mask())
-      return item.has_tag(args.get<mask_t>(0), args.get<mask_t>(1));
-    else
-      throw_(std::runtime_error,
-             _f("Expected masks for arguments 1 and 2, but received %1% and %2%") %
-                 args[0].label() % args[1].label());
-  } else if (args.size() == 0) {
-    throw_(std::runtime_error, _("Too few arguments to function"));
-  } else {
-    throw_(std::runtime_error, _("Too many arguments to function"));
-  }
-  return false;
+value_t item_has_tag(call_scope_t& args) {
+  return metadata_has_tag(find_scope<item_t>(args), args);
 }
 
-value_t get_tag(call_scope_t& args) {
-  item_t& item(find_scope<item_t>(args));
-  std::optional<value_t> val;
-
-  if (args.size() == 1) {
-    if (args[0].is_string())
-      val = item.get_tag(args.get<string>(0));
-    else if (args[0].is_mask())
-      val = item.get_tag(args.get<mask_t>(0));
-    else
-      throw_(std::runtime_error,
-             _f("Expected string or mask for argument 1, but received %1%") % args[0].label());
-  } else if (args.size() == 2) {
-    if (args[0].is_mask() && args[1].is_mask())
-      val = item.get_tag(args.get<mask_t>(0), args.get<mask_t>(1));
-    else
-      throw_(std::runtime_error,
-             _f("Expected masks for arguments 1 and 2, but received %1% and %2%") %
-                 args[0].label() % args[1].label());
-  } else if (args.size() == 0) {
-    throw_(std::runtime_error, _("Too few arguments to function"));
-  } else {
-    throw_(std::runtime_error, _("Too many arguments to function"));
-  }
-
-  return val ? *val : NULL_VALUE;
+value_t item_get_tag(call_scope_t& args) {
+  return metadata_get_tag(find_scope<item_t>(args), args);
 }
 
 value_t get_pathname(item_t& item) {
@@ -620,10 +361,8 @@ expr_t::ptr_op_t item_t::lookup(const symbol_t::kind_t kind, const string& name)
     break;
 
   case 'h':
-    if (name == "has_tag")
-      return WRAP_FUNCTOR(ledger::has_tag);
-    else if (name == "has_meta")
-      return WRAP_FUNCTOR(ledger::has_tag);
+    if (name == "has_tag" || name == "has_meta")
+      return WRAP_FUNCTOR(item_has_tag);
     break;
 
   case 'i':
@@ -635,7 +374,7 @@ expr_t::ptr_op_t item_t::lookup(const symbol_t::kind_t kind, const string& name)
 
   case 'm':
     if (name == "meta")
-      return WRAP_FUNCTOR(ledger::get_tag);
+      return WRAP_FUNCTOR(item_get_tag);
     break;
 
   case 'n':
@@ -661,7 +400,7 @@ expr_t::ptr_op_t item_t::lookup(const symbol_t::kind_t kind, const string& name)
 
   case 't':
     if (name == "tag")
-      return WRAP_FUNCTOR(ledger::get_tag);
+      return WRAP_FUNCTOR(item_get_tag);
     break;
 
   case 'u':
@@ -804,25 +543,6 @@ string item_context(const item_t& item, const string& desc) {
   print_item(out, item, "> ");
 
   return out.str();
-}
-
-/**
- * @brief Serialize metadata tags into a property tree for XML/JSON output.
- *
- * Valueless tags are written as `<tag>name</tag>` elements.  Key/value
- * pairs are written as `<value key="name">...</value>` elements with
- * the value serialized by put_value().
- */
-void put_metadata(property_tree::ptree& st, const item_t::string_map& metadata) {
-  for (const item_t::string_map::value_type& pair : metadata) {
-    if (pair.second.first) {
-      property_tree::ptree& vt(st.add("value", ""));
-      vt.put("<xmlattr>.key", pair.first);
-      put_value(vt, *pair.second.first);
-    } else {
-      st.add("tag", pair.first);
-    }
-  }
 }
 
 } // namespace ledger

--- a/src/item.h
+++ b/src/item.h
@@ -59,6 +59,7 @@
  */
 #pragma once
 
+#include "metadata.h"
 #include "scope.h"
 
 namespace ledger {
@@ -124,7 +125,7 @@ struct position_t {
  * The metadata system uses a custom case-insensitive comparator so that
  * `Payee`, `payee`, and `PAYEE` all refer to the same tag.
  */
-class item_t : public flags::supports_flags<uint_least16_t>, public scope_t {
+class item_t : public flags::supports_flags<uint_least16_t>, public metadata_t, public scope_t {
 public:
 #define ITEM_NORMAL 0x00 ///< No special flags; a regular user-entered item.
 #define ITEM_GENERATED                                                                             \
@@ -148,24 +149,13 @@ public:
    */
   enum state_t : uint8_t { UNCLEARED = 0, CLEARED, PENDING };
 
-  /// A metadata entry: an optional value paired with a bool indicating
-  /// whether the tag was parsed from a comment line (true) vs. set
-  /// programmatically (false).
-  using tag_data_t = std::pair<std::optional<value_t>, bool>;
-
-  /// Case-insensitive ordered map from tag names to their values.
-  /// The comparator function uses boost::algorithm::ilexicographical_compare
-  /// so that "Payee" and "payee" are treated as the same key.
-  using string_map = std::map<string, tag_data_t, std::function<bool(string, string)>>;
-
   scope_t*
       parent; ///< Enclosing scope for expression evaluation (e.g., the transaction for a posting).
-  state_t _state;                ///< Current clearing state (UNCLEARED, CLEARED, or PENDING).
-  optional<date_t> _date;        ///< Primary date of the item.
-  optional<date_t> _date_aux;    ///< Auxiliary (effective) date, written after `=` in date syntax.
-  optional<string> note;         ///< Free-form note text from `;` comment lines.
-  optional<position_t> pos;      ///< Source file location for error reporting and `print` output.
-  optional<string_map> metadata; ///< Structured metadata tags parsed from comment lines.
+  state_t _state;             ///< Current clearing state (UNCLEARED, CLEARED, or PENDING).
+  optional<date_t> _date;     ///< Primary date of the item.
+  optional<date_t> _date_aux; ///< Auxiliary (effective) date, written after `=` in date syntax.
+  optional<string> note;      ///< Free-form note text from `;` comment lines.
+  optional<position_t> pos;   ///< Source file location for error reporting and `print` output.
   bool defining_; ///< Re-entrancy guard for define(); prevents infinite recursion when setting tags
                   ///< triggers expression evaluation.
 
@@ -188,6 +178,12 @@ public:
    * postings for automated transactions.  Does not copy the parent
    * pointer (which is set separately by the owning transaction).
    */
+  /// Backwards-compatible aliases.  metadata storage and types now live on
+  /// metadata_t; keeping these names available avoids touching every call
+  /// site that references `item_t::string_map` (Python bindings, etc.).
+  using string_map = metadata_t::string_map;
+  using tag_data_t = metadata_t::tag_data_t;
+
   virtual void copy_details(const item_t& item) {
     set_flags(item.flags());
     set_state(item.state());
@@ -226,61 +222,13 @@ public:
   std::size_t seq() const { return pos ? pos->sequence : 0L; }
 
   /**
-   * @brief Test whether a metadata tag exists on this item.
-   * @param tag   Tag name to look up (case-insensitive).
-   * @param inherit  If true, also search ancestor scopes (overridden
-   *                 by post_t to check the parent transaction).
-   */
-  virtual bool has_tag(const string& tag, bool inherit = true) const;
-
-  /** @brief Test whether any tag matching a regex pattern exists.
-   * @param tag_mask    Regex to match against tag names.
-   * @param value_mask  Optional regex to additionally match the tag's value.
-   * @param inherit     If true, also search ancestor scopes.
-   */
-  virtual bool has_tag(const mask_t& tag_mask, const std::optional<mask_t>& value_mask = {},
-                       bool inherit = true) const;
-
-  /**
-   * @brief Retrieve the value of a metadata tag.
-   * @param tag   Tag name to look up (case-insensitive).
-   * @param inherit  If true, also search ancestor scopes.
-   * @return The tag's value, or nullopt if the tag does not exist.
-   */
-  virtual std::optional<value_t> get_tag(const string& tag, bool inherit = true) const;
-
-  /** @brief Retrieve the first tag value matching a regex pattern.
-   * @param tag_mask    Regex to match against tag names.
-   * @param value_mask  Optional regex to additionally match the tag's value.
-   * @param inherit     If true, also search ancestor scopes.
-   */
-  virtual std::optional<value_t> get_tag(const mask_t& tag_mask,
-                                         const std::optional<mask_t>& value_mask = {},
-                                         bool inherit = true) const;
-
-  /**
-   * @brief Set or overwrite a metadata tag on this item.
-   * @param tag                Tag name (case-insensitive key).
-   * @param value              Optional value to associate with the tag.
-   * @param overwrite_existing If false, an existing tag is not modified.
-   * @return Iterator to the inserted or existing tag entry.
-   *
-   * If the metadata map does not yet exist, it is created with a
-   * CaseInsensitiveKeyCompare comparator.  Null or empty-string values
-   * are stored as valueless tags.
-   */
-  virtual string_map::iterator set_tag(const string& tag, const std::optional<value_t>& value = {},
-                                       const bool overwrite_existing = true);
-
-  /**
    * @brief Parse metadata tags from a comment line.
    *
-   * Recognizes three forms of metadata in comment text:
-   *   - `[date=auxdate]` -- bracketed date/auxiliary-date override
-   *   - `:tag1:tag2:tag3:` -- colon-delimited bare tags (no values)
-   *   - `Key: value` -- a key/value metadata pair (first token ending in `:`)
-   *   - `Key:: expr` -- like `Key:` but the value is an expression that
-   *     is evaluated in the current scope before being stored
+   * In addition to the `:tag:` and `Key:` / `Key::` forms handled by
+   * metadata_t, item_t recognizes a leading `[date]` or `[date=auxdate]`
+   * bracketed override that updates this item's primary and/or auxiliary
+   * date.  Accounts do not have dates and therefore inherit
+   * metadata_t::parse_metadata_tags directly.
    *
    * @param p                  Raw comment text (without the leading `;`).
    * @param scope              Scope for evaluating `Key::` expressions.
@@ -383,13 +331,5 @@ void print_item(std::ostream& out, const item_t& item, const string& prefix = ""
  * followed by the source text, for use in error reporting.
  */
 string item_context(const item_t& item, const string& desc);
-
-/**
- * @brief Serialize metadata tags into a property tree for XML output.
- *
- * Valueless tags are written as `<tag>name</tag>` elements; key/value
- * pairs are written as `<value key="name">...</value>` elements.
- */
-void put_metadata(property_tree::ptree& pt, const item_t::string_map& metadata);
 
 } // namespace ledger

--- a/src/item.h
+++ b/src/item.h
@@ -165,7 +165,8 @@ public:
     TRACE_CTOR(item_t, "flags_t, const string&");
   }
   item_t(const item_t& item)
-      : supports_flags<uint_least16_t>(item), scope_t(), parent(nullptr), defining_(false) {
+      : supports_flags<uint_least16_t>(item), metadata_t(item), scope_t(), parent(nullptr),
+        defining_(false) {
     copy_details(item);
     TRACE_CTOR(item_t, "copy");
   }

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2003-2025, John Wiegley.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * - Neither the name of New Artisans LLC nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <system.hh>
+
+#include "metadata.h"
+#include "ptree.h"
+
+namespace ledger {
+
+namespace {
+/**
+ * @brief Case-insensitive ordering for metadata tag names.
+ *
+ * Used as the comparator for metadata_t::string_map so that lookups
+ * by exact string are case-insensitive: a tag set as "Payee" can be
+ * retrieved via has_tag("payee") or get_tag("PAYEE").
+ */
+struct CaseInsensitiveKeyCompare {
+  bool operator()(const string& s1, const string& s2) const {
+    return boost::algorithm::ilexicographical_compare(s1, s2);
+  }
+};
+} // namespace
+
+bool metadata_t::has_tag(const string& tag, bool) const {
+  DEBUG("metadata", "Checking if holder has tag: " << tag);
+  if (!metadata) {
+    DEBUG("metadata", "Holder has no metadata at all");
+    return false;
+  }
+  string_map::const_iterator i = metadata->find(tag);
+#if DEBUG_ON
+  if (SHOW_DEBUG("metadata")) {
+    if (i == metadata->end())
+      DEBUG("metadata", "Holder does not have this tag");
+    else
+      DEBUG("metadata", "Holder has the tag!");
+  }
+#endif
+  return i != metadata->end();
+}
+
+bool metadata_t::has_tag(const mask_t& tag_mask, const std::optional<mask_t>& value_mask,
+                         bool) const {
+  if (metadata) {
+    for (const string_map::value_type& data : *metadata) {
+      if (tag_mask.match(data.first)) {
+        if (!value_mask)
+          return true;
+        else if (data.second.first)
+          return value_mask->match(data.second.first->to_string());
+      }
+    }
+  }
+  return false;
+}
+
+std::optional<value_t> metadata_t::get_tag(const string& tag, bool) const {
+  DEBUG("metadata", "Getting tag: " << tag);
+  if (metadata) {
+    string_map::const_iterator i = metadata->find(tag);
+    if (i != metadata->end())
+      return i->second.first;
+  }
+  return std::nullopt;
+}
+
+std::optional<value_t> metadata_t::get_tag(const mask_t& tag_mask,
+                                           const std::optional<mask_t>& value_mask, bool) const {
+  if (metadata) {
+    for (const string_map::value_type& data : *metadata) {
+      if (tag_mask.match(data.first) &&
+          (!value_mask ||
+           (data.second.first && value_mask->match(data.second.first->to_string())))) {
+        return data.second.first;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+metadata_t::string_map::iterator metadata_t::set_tag(const string& tag,
+                                                     const std::optional<value_t>& value,
+                                                     const bool overwrite_existing) {
+  assert(!tag.empty());
+
+  if (!metadata)
+    metadata = string_map(CaseInsensitiveKeyCompare());
+
+  DEBUG("metadata", "Setting tag '" << tag << "' to value '"
+                                    << (value ? *value : string_value("<none>")) << "'");
+
+  std::optional<value_t> data = value;
+  if (data && (data->is_null() || (data->is_string() && data->as_string().empty())))
+    data = std::nullopt;
+
+  string_map::iterator i = metadata->find(tag);
+  if (i == metadata->end()) {
+    auto [iter, inserted] = metadata->insert(string_map::value_type(tag, tag_data_t(data, false)));
+    assert(inserted);
+    return iter;
+  }
+  if (overwrite_existing)
+    i->second = tag_data_t(data, false);
+  return i;
+}
+
+void metadata_t::parse_metadata_tags(const char* p, scope_t& outer_scope, scope_t& self_scope,
+                                     bool overwrite_existing) {
+  // Skip any additional leading `;` characters (with interleaved whitespace).
+  // The first `;` has already been consumed by the caller, but comments
+  // written as `;;Key: value` or `;  ;Key: value` would otherwise see the
+  // extra semicolon glom onto the tag name (fixes #1786).
+  while (*p == ' ' || *p == '\t' || *p == ';')
+    ++p;
+
+  if (!std::strchr(p, ':'))
+    return;
+
+  string str(p);
+  string::size_type pos = 0;
+
+  string tag;
+  bool by_value = false;
+  bool first = true;
+
+  while (pos < str.length()) {
+    pos = str.find_first_not_of(" \t", pos);
+    if (pos == string::npos)
+      break;
+
+    string::size_type end = str.find_first_of(" \t", pos);
+    if (end == string::npos)
+      end = str.length();
+
+    string token = str.substr(pos, end - pos);
+    if (token.length() < 2) {
+      pos = end;
+      continue;
+    }
+
+    if (token[0] == ':' && token[token.length() - 1] == ':') { // a series of tags
+      string tag_str(token, 1, token.length() - 2);
+      std::vector<string> tag_names;
+      boost::split(tag_names, tag_str, boost::is_any_of(":"));
+      for (const string& tag_name : tag_names) {
+        if (!tag_name.empty()) {
+          string_map::iterator i = set_tag(tag_name, std::nullopt, overwrite_existing);
+          i->second.second = true;
+        }
+      }
+    } else if (first && token[token.length() - 1] == ':') { // a metadata setting
+      std::size_t index = 1;
+      if (token[token.length() - 2] == ':') {
+        by_value = true;
+        index = 2;
+      }
+      tag = token.substr(0, token.length() - index);
+
+      string_map::iterator i;
+      string field(p + end); // NOLINT(bugprone-unused-local-non-trivial-variable)
+      trim(field);
+      if (by_value) {
+        bind_scope_t bound_scope(outer_scope, self_scope);
+        i = set_tag(tag, expr_t(field).calc(bound_scope), overwrite_existing);
+      } else {
+        i = set_tag(tag, string_value(field), overwrite_existing);
+      }
+      i->second.second = true;
+      break;
+    }
+    first = false;
+    pos = end;
+  }
+}
+
+value_t metadata_has_tag(metadata_t& target, call_scope_t& args) {
+  if (args.size() == 1) {
+    if (args[0].is_string())
+      return target.has_tag(args.get<string>(0));
+    else if (args[0].is_mask())
+      return target.has_tag(args.get<mask_t>(0));
+    else
+      throw_(std::runtime_error,
+             _f("Expected string or mask for argument 1, but received %1%") % args[0].label());
+  } else if (args.size() == 2) {
+    if (args[0].is_mask() && args[1].is_mask())
+      return target.has_tag(args.get<mask_t>(0), args.get<mask_t>(1));
+    else
+      throw_(std::runtime_error,
+             _f("Expected masks for arguments 1 and 2, but received %1% and %2%") %
+                 args[0].label() % args[1].label());
+  } else if (args.size() == 0) {
+    throw_(std::runtime_error, _("Too few arguments to function"));
+  } else {
+    throw_(std::runtime_error, _("Too many arguments to function"));
+  }
+  return false;
+}
+
+value_t metadata_get_tag(metadata_t& target, call_scope_t& args) {
+  std::optional<value_t> val;
+
+  if (args.size() == 1) {
+    if (args[0].is_string())
+      val = target.get_tag(args.get<string>(0));
+    else if (args[0].is_mask())
+      val = target.get_tag(args.get<mask_t>(0));
+    else
+      throw_(std::runtime_error,
+             _f("Expected string or mask for argument 1, but received %1%") % args[0].label());
+  } else if (args.size() == 2) {
+    if (args[0].is_mask() && args[1].is_mask())
+      val = target.get_tag(args.get<mask_t>(0), args.get<mask_t>(1));
+    else
+      throw_(std::runtime_error,
+             _f("Expected masks for arguments 1 and 2, but received %1% and %2%") %
+                 args[0].label() % args[1].label());
+  } else if (args.size() == 0) {
+    throw_(std::runtime_error, _("Too few arguments to function"));
+  } else {
+    throw_(std::runtime_error, _("Too many arguments to function"));
+  }
+
+  return val ? *val : NULL_VALUE;
+}
+
+void put_metadata(property_tree::ptree& st, const metadata_t::string_map& metadata) {
+  for (const metadata_t::string_map::value_type& pair : metadata) {
+    if (pair.second.first) {
+      property_tree::ptree& vt(st.add("value", ""));
+      vt.put("<xmlattr>.key", pair.first);
+      put_value(vt, *pair.second.first);
+    } else {
+      st.add("tag", pair.first);
+    }
+  }
+}
+
+} // namespace ledger

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2003-2025, John Wiegley.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * - Neither the name of New Artisans LLC nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @addtogroup data
+ */
+
+/**
+ * @file   metadata.h
+ * @author John Wiegley
+ *
+ * @ingroup data
+ *
+ * @brief  Shared metadata-tag storage and parser for journal items and accounts.
+ *
+ * metadata_t is a non-virtual mixin holding the case-insensitive
+ * `string_map` used by both item_t (and its derivatives xact_t, post_t)
+ * and account_t.  It provides the local has_tag/get_tag/set_tag
+ * operations and the `:tag:` / `Key: value` / `Key:: expr` parser.
+ * Subclasses override the lookup methods to add their own inheritance
+ * walk (post_t walks its parent xact, account_t walks its parent
+ * account); item_t additionally extends the parser with bracketed
+ * `[date]` syntax.
+ */
+#pragma once
+
+#include "scope.h"
+
+namespace ledger {
+
+/**
+ * @brief Storage and behavior for metadata tags shared by items and accounts.
+ *
+ * Both journal items (transactions and postings) and accounts may carry
+ * a case-insensitive map of metadata tags, parsed from `;`-prefixed
+ * comment lines.  metadata_t centralizes that storage and the parsing
+ * logic so the two class hierarchies share one implementation.
+ */
+class metadata_t {
+public:
+  /// A metadata entry: an optional value paired with a bool indicating
+  /// whether the tag was parsed from a comment line (true) vs. set
+  /// programmatically (false).
+  using tag_data_t = std::pair<std::optional<value_t>, bool>;
+
+  /// Case-insensitive ordered map from tag names to their values.
+  using string_map = std::map<string, tag_data_t, std::function<bool(string, string)>>;
+
+  optional<string_map> metadata; ///< Structured metadata tags parsed from comment lines.
+
+  metadata_t() = default;
+  metadata_t(const metadata_t&) = default;
+  metadata_t& operator=(const metadata_t&) = default;
+  virtual ~metadata_t() = default;
+
+  /**
+   * @brief Test whether a metadata tag exists locally on this holder.
+   *
+   * The @p inherit parameter is unused by the base class; subclasses
+   * override this to add an inheritance walk (post_t -> xact_t,
+   * account_t -> parent account).
+   */
+  virtual bool has_tag(const string& tag, bool inherit = true) const;
+
+  /// @copydoc has_tag(const string&, bool) const
+  virtual bool has_tag(const mask_t& tag_mask, const std::optional<mask_t>& value_mask = {},
+                       bool inherit = true) const;
+
+  /**
+   * @brief Retrieve the value of a metadata tag from this holder.
+   *
+   * Subclasses override to add inheritance.  Returns nullopt when the
+   * tag is absent or its value is unset.
+   */
+  virtual std::optional<value_t> get_tag(const string& tag, bool inherit = true) const;
+
+  /// @copydoc get_tag(const string&, bool) const
+  virtual std::optional<value_t> get_tag(const mask_t& tag_mask,
+                                         const std::optional<mask_t>& value_mask = {},
+                                         bool inherit = true) const;
+
+  /**
+   * @brief Set or overwrite a metadata tag, creating the map if needed.
+   *
+   * The map is initialized lazily with a case-insensitive comparator.
+   * Null or empty-string values are normalized to nullopt.
+   */
+  virtual string_map::iterator set_tag(const string& tag, const std::optional<value_t>& value = {},
+                                       bool overwrite_existing = true);
+
+  /**
+   * @brief Parse `:tag:` and `Key:`/`Key::` metadata from a comment line.
+   *
+   * Recognizes:
+   *   - `:tag1:tag2:tag3:` -- colon-delimited bare tags.
+   *   - `Key: value`       -- the first whitespace-delimited token ending
+   *                           in `:` names a key whose value is the rest of
+   *                           the line as a string.
+   *   - `Key:: expr`       -- like `Key:` but the value is parsed and
+   *                           evaluated as an expression in @p outer_scope
+   *                           bound through @p self_scope.
+   *
+   * Skips a leading run of `;`/whitespace so that comments written as
+   * `;;Key: value` parse the same as `; Key: value` (issue #1786).
+   *
+   * @param p                  Raw comment text.
+   * @param outer_scope        Scope used to evaluate `Key:: expr` forms.
+   * @param self_scope         Scope to bind through (this object as a scope_t).
+   * @param overwrite_existing Whether to overwrite tags that already exist.
+   */
+  void parse_metadata_tags(const char* p, scope_t& outer_scope, scope_t& self_scope,
+                           bool overwrite_existing);
+};
+
+/**
+ * @brief Dispatch a `has_tag(...)` expression call to a metadata target.
+ *
+ * Used by item_t::lookup() and account_t::lookup() to translate the
+ * expression-engine's argument shape into a call on the resolved
+ * metadata_t.  Validates argument counts and types and throws on misuse.
+ */
+value_t metadata_has_tag(metadata_t& target, call_scope_t& args);
+
+/**
+ * @brief Dispatch a `tag(...)` / `meta(...)` expression call.
+ *
+ * Mirror of metadata_has_tag for value retrieval; returns NULL_VALUE
+ * when no matching tag is found.
+ */
+value_t metadata_get_tag(metadata_t& target, call_scope_t& args);
+
+/**
+ * @brief Serialize metadata tags into a property tree for XML/JSON output.
+ *
+ * Valueless tags are written as `<tag>name</tag>` elements; key/value
+ * pairs are written as `<value key="name">...</value>` elements.
+ */
+void put_metadata(property_tree::ptree& pt, const metadata_t::string_map& metadata);
+
+} // namespace ledger

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -622,6 +622,18 @@ void instance_t::account_directive_body(char* line, account_t* parent, std::size
     if (!*q)
       break;
 
+    // A comment line under an account directive (e.g.
+    // `    ; Contribution: 12.97 EUR`) carries metadata tags for the
+    // account rather than a sub-directive.  Parsing it through
+    // account_t::parse_tags makes the `:tag:` and `Key: value` forms
+    // available to balance-format expressions such as
+    // `%(tag("Contribution"))` (issue #1681).
+    if (*q == ';' || *q == '#' || *q == '*' || *q == '|') {
+      char* body = skip_ws(q + 1);
+      account->parse_tags(body, *context.scope, true);
+      continue;
+    }
+
     char* b = next_element(q);
     string keyword(q);
     // Ensure there's an argument for the directives that need one.

--- a/test/regress/1681.test
+++ b/test/regress/1681.test
@@ -1,0 +1,64 @@
+; Regression test for GitHub issue #1681
+;
+; Feature request: allow an `account` directive's `;`-prefixed comment lines
+; to declare metadata tags that are then reachable from balance-format
+; expressions through `tag()`, `meta()`, `has_tag()`, and `has_meta()`.
+;
+; Before this change the account lookup() dispatcher had no tag bindings and
+; account_t had no metadata storage, so a balance format like
+; `%(tag("Contribution"))` failed with "Unknown identifier 'tag'".
+
+account Assets:Budget
+    ; Category: Monthly
+
+account Assets:Budget:Food
+    ; Contribution: 50 EUR
+    ; Target: 100 EUR
+    ; :Important:
+
+account Assets:Budget:Housing
+    ; Contribution: 500 EUR
+    ; Target: 800 EUR
+
+2024/01/01 Opening
+    Assets:Budget:Food         25 EUR
+    Assets:Budget:Housing     200 EUR
+    Equity:Opening
+
+; Tag retrieval through the balance format.  Each displayed leaf account
+; carries its own Contribution/Target metadata, and the sub-total row for
+; Assets:Budget correctly reports no Contribution of its own.
+test bal --no-total --balance-format "%(partial_account)  C=%(tag(\"Contribution\"))  T=%(tag(\"Target\"))\n" ^Assets
+Assets:Budget  C=  T=
+Food  C=50 EUR  T=100 EUR
+Housing  C=500 EUR  T=800 EUR
+end test
+
+; `meta()` is the long-form alias for `tag()` and must return the same value.
+test bal --no-total --balance-format "%(partial_account)  M=%(meta(\"Target\"))\n" Food
+Assets:Budget:Food  M=100 EUR
+end test
+
+; Bare tags set with the `:name:` syntax are detectable via has_tag/has_meta
+; even though they have no associated value.
+test bal --no-total --balance-format "%(partial_account)  imp=%(has_tag(\"Important\"))  hm=%(has_meta(\"Important\"))\n" ^Assets
+Assets:Budget  imp=false  hm=false
+Food  imp=true  hm=true
+Housing  imp=false  hm=false
+end test
+
+; Tag inheritance: Food and Housing inherit `Category: Monthly` from their
+; parent Assets:Budget, which is itself a declared account with metadata.
+test bal --no-total --balance-format "%(partial_account)  cat=%(tag(\"Category\"))\n" ^Assets
+Assets:Budget  cat=Monthly
+Food  cat=Monthly
+Housing  cat=Monthly
+end test
+
+; Regex lookups work the same way they do for postings: a mask matches
+; both the Contribution and Target tag names.
+test bal --no-total --balance-format "%(partial_account)  any=%(has_tag(/^(Contribution|Target)$/))\n" ^Assets
+Assets:Budget  any=false
+Food  any=true
+Housing  any=true
+end test


### PR DESCRIPTION
## Summary

- Comment lines beneath an `account` directive are now parsed as metadata tags (same `Key: value`, `Key:: expr`, and `:tag:` syntaxes as transaction/posting tags).
- Tags are exposed to balance-format expressions via `tag`, `meta`, `has_tag`, and `has_meta` functions bound on the account scope, so a format like `%(tag("Contribution"))` works in a `balance` report.
- Tag lookups walk up the account hierarchy, so a tag on a parent account is inherited by its children.

Closes #1681.

## Test plan

- [x] Added `test/regress/1681.test` with five blocks covering `tag`/`meta` value retrieval, `has_tag`/`has_meta` for bare `:tag:` form, parent-account inheritance, and regex masks.
- [x] Full `ctest` suite passes (4312/4312), including new `RegressTest_1681`.
- [x] Full lefthook pre-commit pipeline (configure + build + ctest + doxygen + manual + nix build) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)