### PR TITLE
Fix #3187: preserve --basis precision when commodity has none

### DIFF
--- a/src/amount.cc
+++ b/src/amount.cc
@@ -955,6 +955,13 @@ void amount_t::in_place_round_to_commodity_precision() {
         set_keep_precision(false);
       return;
     }
+    // When the commodity has not been observed at any specific precision
+    // (comm_prec == 0) but the value carries non-trivial fractional digits
+    // (e.g. a --basis cost computed from `@ $5.025`), keep the precision
+    // flag so that display preserves the actual value rather than
+    // truncating it to the integer commodity precision (#3187).
+    if (comm_prec == 0 && keep_precision() && quantity->prec > 0)
+      return;
   }
 
   if (keep_precision()) {

--- a/src/amount.cc
+++ b/src/amount.cc
@@ -955,11 +955,13 @@ void amount_t::in_place_round_to_commodity_precision() {
         set_keep_precision(false);
       return;
     }
-    // When the commodity has not been observed at any specific precision
-    // (comm_prec == 0) but the value carries non-trivial fractional digits
-    // (e.g. a --basis cost computed from `@ $5.025`), keep the precision
-    // flag so that display preserves the actual value rather than
-    // truncating it to the integer commodity precision (#3187).
+    // A cleared keep_precision flag is a post-condition that we rounded to
+    // a meaningful commodity precision (the #1765 invariant: rounded(x)
+    // must not drift if the commodity widens later).  When comm_prec == 0
+    // there is no such precision to round to, so clearing the flag is
+    // unearned -- it would erase the value's actual fractional content,
+    // making a --basis cost like 20 ETH * `@ $5.025` = $100.500 render
+    // as $100.  Preserve the flag in that case (#3187).
     if (comm_prec == 0 && keep_precision() && quantity->prec > 0)
       return;
   }

--- a/test/regress/3187.test
+++ b/test/regress/3187.test
@@ -1,0 +1,29 @@
+; Regression test for issue #3187:
+; Cost basis was rounded to integer when the dollar commodity never appeared
+; as a posting amount (only as `@`/`@@` price annotations).  Without any
+; explicit USD posting, USD's display precision stays at 0, and the computed
+; basis (e.g. 20 ETH * $5.025 = $100.500) was being rounded to $100.
+;
+; in_place_round_to_commodity_precision now leaves keep_precision in place
+; when the commodity precision is 0 and the value has fractional digits, so
+; the unrounded value flows through to display.
+
+2026-04-21 * Swap
+    Assets        -10 BTC @ $10.05
+    Assets         20 ETH @ $5.025
+
+test --limit "commodity == 'ETH'" --basis balance Assets
+              $100.5  Assets
+end test
+
+test --limit "commodity == 'BTC'" --basis balance Assets
+             $-100.5  Assets
+end test
+
+; Adding `--unround` is the workaround the original report mentions; it should
+; produce the same result now that --basis no longer rounds away the
+; fractional digits when the commodity has no declared precision.
+
+test --limit "commodity == 'ETH'" --unround --basis balance Assets
+              $100.5  Assets
+end test


### PR DESCRIPTION
## Summary

Fixes #3187 -- `--basis` rounded the cost basis to integer when the cost
commodity (typically `$`) appeared only in `@`/`@@` price annotations and
never as a posting amount.

`--basis` reports the cost as `rounded(cost)`. The cost amount carries
`keep_precision()` from PARSE_NO_MIGRATE, so it preserves the value's
internal precision. `in_place_round_to_commodity_precision()` skipped its
rounding branch when the commodity precision was 0 but still cleared
`keep_precision`, leaving the displayed precision pinned to the
commodity's zero. A computed basis like `20 ETH * $5.025 = $100.500` then
rendered as `$100`.

The fix detects that case (comm_prec == 0 with `keep_precision()` and a
non-zero quantity precision) and bails out without clearing the flag, so
the actual computed value flows through to display. No change for
commodities with a declared precision, and no change when the value has
no fractional digits.

## Test plan

- [x] Added `test/regress/3187.test` covering the issue's example, the
      inverse balance (BTC side), and the `--unround` workaround.
- [x] All 4308 tests pass under `ctest`.
- [x] Pre-commit lefthook (configure + build + 4308 ctest + doxygen +
      manual + nix flake build) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)