### PR TITLE
Fix #3189: --empty must respect the query/--limit predicate

### DIFF
--- a/src/output.cc
+++ b/src/output.cc
@@ -280,9 +280,22 @@ std::pair<std::size_t, std::size_t> format_accounts::mark_accounts(account_t& ac
   DEBUG("account.display", "  it has " << to_display << " children to display");
 #endif
 
+  // For declared-but-unused accounts admitted only by --empty, also require
+  // that the query/--limit predicate match the account.  Otherwise an
+  // `account` directive for an unrelated account (e.g. `Liabilities:C`)
+  // would surface in `bal -E Assets`, ignoring the `Assets` filter.  Visited
+  // accounts have already been filtered upstream by filter_posts.
+  auto known_empty_admit = [&]() -> bool {
+    if (!report.HANDLED(empty) || !account.has_flags(ACCOUNT_KNOWN))
+      return false;
+    if (!report.HANDLED(limit_))
+      return true;
+    bind_scope_t limit_scope(report, account);
+    return predicate_t(report.HANDLER(limit_).str(), report.what_to_keep())(limit_scope);
+  };
+
   if (account.parent && (account.has_xflags(ACCOUNT_EXT_VISITED) || (!flat && visited > 0) ||
-                         (flat && visited > 0 && to_display == 0) ||
-                         (report.HANDLED(empty) && account.has_flags(ACCOUNT_KNOWN)))) {
+                         (flat && visited > 0 && to_display == 0) || known_empty_admit())) {
     bind_scope_t bound_scope(report, account);
     call_scope_t call_scope(bound_scope);
     if ((!flat && to_display > 1) || (!flat && to_display == 1 && !account.posts.empty()) ||

--- a/test/regress/3189.test
+++ b/test/regress/3189.test
@@ -1,0 +1,41 @@
+; Test that --empty respects the query/--limit predicate when admitting
+; declared-but-unused accounts.  An `account` directive for an unrelated
+; account must not surface in `bal -E Assets`; the `Assets` filter has
+; to apply to KNOWN+empty accounts as well.
+
+account Liabilities:C
+
+2026/04/01 * Balance
+    Assets:A                                  €10.00
+    Assets:B                                   €0.00
+    Equity
+
+test bal -E Assets
+              €10.00  Assets
+              €10.00    A
+               €0.00    B
+--------------------
+              €10.00
+end test
+
+test bal -E Liabilities
+                   0  Liabilities:C
+end test
+
+test bal -E
+              €10.00  Assets
+              €10.00    A
+               €0.00    B
+             €-10.00  Equity
+                   0  Liabilities:C
+--------------------
+                   0
+end test
+
+test bal -E --limit "account =~ /Assets/"
+              €10.00  Assets
+              €10.00    A
+               €0.00    B
+--------------------
+              €10.00
+end test


### PR DESCRIPTION
Fixes #3189.

## Summary

- `bal -E Assets` was returning `Liabilities:C` (declared via an `account` directive but never posted to), because the `--empty` branch in `mark_accounts()` admitted *any* `ACCOUNT_KNOWN` account regardless of the active query.
- The KNOWN+empty path now also evaluates the limit predicate in the account scope, matching how visited accounts are filtered upstream by `filter_posts`. When `--limit` is unset the admission is unchanged, so #1204's "declared accounts surface under `--empty`" contract is preserved.
- Added `test/regress/3189.test` covering the original reproducer plus the `Liabilities` filter, the no-filter (#1204) baseline, and the explicit `--limit` form.

## Test plan

- [x] `cd build && ctest` — 4342/4342 pass
- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/3189.test` — 4/4 pass
- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/1204.test` — still passes
- [x] Manual: `ledger -f issue.dat -E bal Assets` no longer prints the unrelated `Liabilities:C` row