### PR TITLE
Fix #3192: ignore bracketed dates inside metadata values

### DIFF
--- a/src/item.cc
+++ b/src/item.cc
@@ -71,21 +71,23 @@ void item_t::parse_tags(const char* p, scope_t& scope, bool overwrite_existing) 
   while (*d == ' ' || *d == '\t' || *d == ';')
     ++d;
 
-  if (const char* b = std::strchr(d, '[')) {
-    if (*(b + 1) != '\0' &&
-        (std::isdigit(static_cast<unsigned char>(*(b + 1))) || *(b + 1) == '=')) {
-      if (const char* e = std::strchr(b, ']')) {
-        char buf[256];
-        std::strncpy(buf, b + 1, static_cast<std::size_t>(e - b - 1));
-        buf[e - b - 1] = '\0';
+  // Only treat `[date]` / `[=auxdate]` as a date directive when it is the
+  // first non-whitespace, non-`;` token of the comment.  A bracketed date
+  // appearing later in the line (e.g. as a value within typed metadata
+  // such as `; Due:: [2024/01/01]`) is a value, not a directive (#3192).
+  if (*d == '[' &&
+      (std::isdigit(static_cast<unsigned char>(*(d + 1))) || *(d + 1) == '=')) {
+    if (const char* e = std::strchr(d, ']')) {
+      char buf[256];
+      std::strncpy(buf, d + 1, static_cast<std::size_t>(e - d - 1));
+      buf[e - d - 1] = '\0';
 
-        if (char* pp = std::strchr(buf, '=')) {
-          *pp++ = '\0';
-          _date_aux = parse_date(pp);
-        }
-        if (buf[0])
-          _date = parse_date(buf);
+      if (char* pp = std::strchr(buf, '=')) {
+        *pp++ = '\0';
+        _date_aux = parse_date(pp);
       }
+      if (buf[0])
+        _date = parse_date(buf);
     }
   }
 

--- a/src/item.cc
+++ b/src/item.cc
@@ -75,8 +75,7 @@ void item_t::parse_tags(const char* p, scope_t& scope, bool overwrite_existing) 
   // first non-whitespace, non-`;` token of the comment.  A bracketed date
   // appearing later in the line (e.g. as a value within typed metadata
   // such as `; Due:: [2024/01/01]`) is a value, not a directive (#3192).
-  if (*d == '[' &&
-      (std::isdigit(static_cast<unsigned char>(*(d + 1))) || *(d + 1) == '=')) {
+  if (*d == '[' && (std::isdigit(static_cast<unsigned char>(*(d + 1))) || *(d + 1) == '=')) {
     if (const char* e = std::strchr(d, ']')) {
       char buf[256];
       std::strncpy(buf, d + 1, static_cast<std::size_t>(e - d - 1));

--- a/test/regress/3192.test
+++ b/test/regress/3192.test
@@ -1,0 +1,50 @@
+; Regression test for issue #3192: typed date metadata is taken as the
+; effective date if no other effective date is given.
+;
+; A bracketed date expression that appears as a *value* of a metadata tag
+; (e.g. "; key:: [2020-01-01]") must not be misread as the posting's
+; actual or effective date.  Only "[date]" or "[=auxdate]" written as the
+; very first token of the comment (the documented "; [date]" notation)
+; should override the posting date.
+
+2026-05-01 * Sell stuck
+    Assets:Broker  -40 STOCK @ $10.00
+    ; some_random_metadata:: [2020-01-01]
+    ; some_random_metadata_v2:: [2020-02-01]
+    Assets:Cash
+
+; The 2020 period contains no real transactions, so --effective should
+; produce no output.  Before the fix the last bracketed date in the typed
+; metadata (2020-02-01) leaked into the posting's effective date, and
+; --period 2020 incorrectly matched the broker leg.
+
+test reg --period 2020 --effective Assets:Broker
+end test
+
+; Without a period filter, the "Sell stuck" postings keep the actual
+; transaction date (2026-05-01) regardless of any typed metadata
+; bracketed dates.
+
+test reg --effective Assets:Broker
+26-May-01 Sell stuck            Assets:Broker             -40 STOCK    -40 STOCK
+end test
+
+; The typed metadata values themselves remain accessible as date-typed
+; tags, so existing functionality (e.g. format_date(tag('...'))) keeps
+; working.
+
+test reg --format "%(format_date(tag('some_random_metadata'), '%Y-%m-%d')) %(format_date(tag('some_random_metadata_v2'), '%Y-%m-%d'))\n" Assets:Broker
+2020-01-01 2020-02-01
+end test
+
+; The documented "; [=date]" directive (bracketed date as the first
+; token of the comment) continues to override the posting's effective
+; date as before.
+
+2026-06-01 * Backdated invoice
+    Expenses:Office                $100.00  ; [=2020-03-15]
+    Assets:Cash
+
+test reg --period 2020 --effective Expenses
+20-Mar-15 Backdated invoice     Expenses:Office             $100.00      $100.00
+end test


### PR DESCRIPTION
## Summary

- \`item_t::parse_tags()\` searched the entire comment for any \`[\`,
  so typed metadata such as \`; key:: [2020-01-01]\` was misread as a
  posting-date directive — \`register --period 2020 --effective\` could
  surface a 2026 transaction as if it occurred in February 2020.
- Restrict the \`[date]\` / \`[=auxdate]\` directive to the case where
  \`[\` is the first non-whitespace, non-\`;\` character of the comment.
  Anything past that point is left to the metadata parser, which still
  evaluates bracketed dates as date-typed tag values.
- Add \`test/regress/3192.test\` covering the reported case, the
  typed-tag value lookups, and the documented \`; [=date]\` directive.

## Test plan

- [x] \`ctest -j8\` (4309/4309 passing)
- [x] \`python3 ../test/RegressTests.py --ledger ./ledger --sourcepath .. ../test/regress/3192.test\`
- [x] Reproduce the original case: \`ledger --args-only --file sample.ledger register --period 2020 --effective Assets\` produces no output

Fixes #3192

🤖 Generated with [Claude Code](https://claude.com/claude-code)