### PR TITLE
Add real regression test for source command (#743)

### DIFF
--- a/test/regress/743.test
+++ b/test/regress/743.test
@@ -1,19 +1,41 @@
-; Regression test for issue #743: ledger source: does it take file from argument or -f? (BZ#743)
+; Regression test for issue #743: ledger source: does it take file from
+; argument or -f? (BZ#743)
 ; https://github.com/ledger/ledger/issues/743
 ;
-; The 'source' command parses a journal file and checks it for errors.
-; When given a filename argument, it uses that file (not the -f file).
-; When given no argument, it uses the -f file.
-; Both behaviors should work correctly.
+; Two related bugs were reported:
+;   (1) Arguments to `source` were ignored; the file specified by -f was
+;       parsed instead.  E.g. `ledger -f a source b` reported errors from
+;       file `a`, not `b`.
+;   (2) `source` with no argument hung waiting for stdin even when -f
+;       pointed at a valid journal.
+;
+; Both were fixed by moving `source` from a regular COMMAND to a PRECOMMAND
+; that calls session.read_journal(arg) when given an argument and
+; session.read_journal_files() otherwise.
 
 2024/01/01 Valid Transaction
     Expenses:Food    $10.00
     Assets:Cash
 
-; Test 1: source with no argument uses the -f file (the test file itself)
+; Test 1: `source` with no argument validates the -f file.  Under the
+;         original bug this command would hang reading from stdin and the
+;         test harness would time out.
 test source
 end test
 
-; Test 2: source with $FILE as argument uses the argument file
+; Test 2: `source <file>` parses the argument file as a journal.  Under
+;         the original bug source would have parsed the file as Ledger
+;         expressions and rejected the journal entries.
 test source $FILE
+end test
+
+; Test 3: When -f and the source argument differ, the source argument
+;         wins.  /dev/null is used as -f so any error must come from the
+;         source argument.  We point at a non-existent file and expect a
+;         "Cannot read journal file" error -- proving the argument is
+;         honoured rather than silently replaced by the -f file (which
+;         would have produced no error under the original bug).
+test -f /dev/null source /no/such/file/for-issue-743 -> 1
+__ERROR__
+Error: Cannot read journal file "/no/such/file/for-issue-743"
 end test


### PR DESCRIPTION
## Summary

The regression test added in #3011 for issue #743 used `$FILE` as both
the `-f` journal and the `source` argument, so neither test actually
demonstrated that the original bug was fixed -- both `source`
invocations exercised the same file regardless of whether the source
argument was honoured. As @bcc32 noted on the issue, the test did not
exercise the bug.

This PR replaces it with three checks that exercise both bugs originally
reported and would all fail under the pre-fix behaviour:

1. `source` with no argument completes immediately on a valid `-f` file
   (under the bug it hung reading stdin and the harness would time out).
2. `source <file>` parses the argument as a journal (under the bug it
   was parsed as Ledger expressions and would reject journal entries).
3. When `-f` and the source argument differ, the argument wins -- using
   a non-existent file as the source argument with `/dev/null` as `-f`
   produces `Cannot read journal file` (under the bug `-f` would have
   been parsed instead and no error would surface).

The underlying fix landed in commit a70171f71 ("Fix source command to
work as a journal validator (issue #1682)"), which moved `source` from
the COMMAND to the PRECOMMAND section and routed it through
`session.read_journal()` / `session.read_journal_files()`. No source
changes are required here.

Closes #743.

## Test plan

- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/743.test` passes (3 checks)
- [x] Full `ctest -R "(RegressTest|BaselineTest)"` passes (4292 tests, 0 failures)
- [x] Pre-commit hook passes (cmake-checks + nix-flake-build)