### PR TITLE
Fix #3186: add --check-in-file-order to opt out of date-order asserts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -156,7 +156,9 @@ components with their standard-library equivalents.
 - Filter balance assertions by date rather than file order; skip balance
   assertions on UUID-duplicate transactions; check account assertions on
   auto-generated postings; respect `--permissive` for balance assignments with
-  elided amounts (#2005)
+  elided amounts (#2005).  Add `--check-in-file-order` to restore the
+  pre-3.5 file-order accumulation for journals that depend on out-of-order
+  dated entries (#3186).
 
 - Fix balance assertions for accounts with only virtual postings (#1699), with
   quoted commodities (#904), with per-unit price annotations (#1125), with

--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -489,6 +489,10 @@ Specify the format to use for the
 report.
 .It Fl \-by-payee Pq Fl P
 Group postings in the register report by common payee names.
+.It Fl \-check-in-file-order
+Evaluate balance assertions and assignments in file (parse) order rather
+than date order, restoring the pre-3.5 behaviour for journals that rely
+on out-of-order dated entries.
 .It Fl \-check-payees
 Enable strict and pedantic checking for payees as well as accounts,
 commodities and tags.

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -6674,6 +6674,15 @@ Enable strict and pedantic checking for payees as well as accounts,
 commodities and tags.  This only works in conjunction with
 @option{--strict} or @option{--pedantic}.
 
+@item --check-in-file-order
+Evaluate balance assertions and assignments in file (parse) order rather
+than date order.  By default, ledger filters the running account total
+by date so that an assertion dated July 10 sees only postings dated on
+or before July 10, even when a July 20 transaction was parsed earlier
+in the file.  Specify this option to restore the pre-3.5 behaviour
+where every posting parsed so far contributes to the running total
+regardless of date.
+
 @item --immediate
 Instruct ledger to evaluate calculations immediately rather than lazily.
 
@@ -7032,6 +7041,11 @@ the resolution order.
 Enable strict and pedantic checking for payees as well as accounts,
 commodities and tags.  This only works in conjunction with
 @option{--strict} or @option{--pedantic}.
+
+@item --check-in-file-order
+Evaluate balance assertions and assignments in file (parse) order
+rather than date order.  See @ref{Error Checking and Calculation
+Options} for details.
 
 @item --commodity-value-expr @var{VEXPR}
 Set a default valuation expression for all commodities that do not

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -119,6 +119,7 @@ void journal_t::initialize() {
   checking_style = CHECK_NORMAL;
   recursive_aliases = false;
   no_aliases = false;
+  check_in_file_order = false;
 
   // Pre-register built-in metadata tags so --strict/--pedantic don't
   // warn about them.  These are tags that ledger uses internally.

--- a/src/journal.h
+++ b/src/journal.h
@@ -151,12 +151,13 @@ public:
       known_payees; ///< Payees declared with `payee` directive (for --strict validation).
   std::set<string> known_tags; ///< Tags declared with `tag` directive (for --strict validation).
   bool was_loaded;             ///< True after at least one successful read().
-  bool check_payees;      ///< True if payee validation is enabled (payee directives were seen).
-  bool day_break;         ///< True if day-break transactions should be inserted between days.
-  int time_round;         ///< Round timelog durations up to this many seconds (0 = no rounding).
-  bool recursive_aliases; ///< If true, alias expansion repeats until no more aliases match.
-  bool no_aliases;        ///< If true, all alias expansion is suppressed.
-  bool check_in_file_order; ///< If true, balance assertions/assignments use file order, not date order.
+  bool check_payees;        ///< True if payee validation is enabled (payee directives were seen).
+  bool day_break;           ///< True if day-break transactions should be inserted between days.
+  int time_round;           ///< Round timelog durations up to this many seconds (0 = no rounding).
+  bool recursive_aliases;   ///< If true, alias expansion repeats until no more aliases match.
+  bool no_aliases;          ///< If true, all alias expansion is suppressed.
+  bool check_in_file_order; ///< If true, balance assertions/assignments use file order, not date
+                            ///< order.
   lot_policy_t lot_matching_policy =
       lot_policy_t::none; ///< How commodity lots are matched for consumption.
   payee_alias_mappings_t

--- a/src/journal.h
+++ b/src/journal.h
@@ -156,6 +156,7 @@ public:
   int time_round;         ///< Round timelog durations up to this many seconds (0 = no rounding).
   bool recursive_aliases; ///< If true, alias expansion repeats until no more aliases match.
   bool no_aliases;        ///< If true, all alias expansion is suppressed.
+  bool check_in_file_order; ///< If true, balance assertions/assignments use file order, not date order.
   lot_policy_t lot_matching_policy =
       lot_policy_t::none; ///< How commodity lots are matched for consumption.
   payee_alias_mappings_t

--- a/src/session.cc
+++ b/src/session.cc
@@ -183,6 +183,9 @@ std::size_t session_t::read_data(const string& master_account) {
   if (HANDLED(explicit)) {
     // No-op
   }
+  if (HANDLED(check_in_file_order))
+    journal->check_in_file_order = true;
+
   if (HANDLED(check_payees))
     journal->check_payees = true;
 
@@ -422,7 +425,8 @@ option_t<session_t>* session_t::lookup_option(const char* p) {
     OPT(account_value_expr_);
     break;
   case 'c':
-    OPT(check_payees);
+    OPT(check_in_file_order);
+    else OPT(check_payees);
     else OPT(commodity_value_expr_);
     break;
   case 'd':

--- a/src/session.h
+++ b/src/session.h
@@ -171,6 +171,7 @@ public:
   /// Dump all session-level option values to the output stream.
   void report_options(std::ostream& out) {
     HANDLER(account_value_expr_).report(out);
+    HANDLER(check_in_file_order).report(out);
     HANDLER(check_payees).report(out);
     HANDLER(commodity_value_expr_).report(out);
     HANDLER(day_break).report(out);
@@ -206,6 +207,11 @@ public:
    */
 
   OPTION(session_t, account_value_expr_); ///< Default account-level valuation expression
+  OPTION_(
+      session_t, check_in_file_order, DO() {
+        if (parent->journal)
+          parent->journal->check_in_file_order = true;
+      });
   OPTION_(
       session_t, check_payees, DO() {
         if (parent->journal)

--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -408,11 +408,18 @@ static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t*
     real_only = false;
   }
   value_t account_total;
-  if (item_t::use_aux_date && !post->aux_date()) {
-    // In --effective mode, postings without an explicit effective date
-    // use file-order accumulation so that balance assertions are not
-    // confused by other postings whose effective dates land after the
-    // current posting's primary date (fixes #2966).
+  bool use_file_order =
+      (context.journal && context.journal->check_in_file_order) ||
+      (item_t::use_aux_date && !post->aux_date());
+  if (use_file_order) {
+    // File-order accumulation: sum every posting parsed so far for this
+    // account, regardless of date.  This is required in --effective mode
+    // for postings without an explicit effective date so that assertions
+    // are not confused by other postings whose effective dates land after
+    // the current posting's primary date (fixes #2966).  It is also
+    // selected via --check-in-file-order to restore the pre-#1092
+    // behaviour for users who depend on file order rather than date
+    // order (issue #3186).
     account_total = post->account->self_total(real_only);
   } else {
     // Filter account posts by date so that balance assertions respect
@@ -420,7 +427,7 @@ static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t*
     // an explicit effective date this uses effective-date ordering
     // (fixes #2071); otherwise it uses primary-date ordering so that
     // an assertion dated before later-dated transactions in the file
-    // is not polluted by those future-dated posts (fixes #847).
+    // is not polluted by those future-dated posts (fixes #847, #1092).
     date_t cutoff = post->date();
     std::set<const post_t*> seen;
     for (const post_t* p : post->account->posts) {

--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -408,9 +408,8 @@ static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t*
     real_only = false;
   }
   value_t account_total;
-  bool use_file_order =
-      (context.journal && context.journal->check_in_file_order) ||
-      (item_t::use_aux_date && !post->aux_date());
+  bool use_file_order = (context.journal && context.journal->check_in_file_order) ||
+                        (item_t::use_aux_date && !post->aux_date());
   if (use_file_order) {
     // File-order accumulation: sum every posting parsed so far for this
     // account, regardless of date.  This is required in --effective mode

--- a/test/baseline/opt-check-in-file-order.test
+++ b/test/baseline/opt-check-in-file-order.test
@@ -1,0 +1,20 @@
+; Baseline test for --check-in-file-order: when set, balance assertions
+; and assignments accumulate postings in file order rather than date
+; order, restoring the pre-#1092 behaviour for users who depend on
+; reverse-dated entries (issue #3186).
+
+2026/04/02 * Balance
+    Assets:Bank                               $10.00
+    Equity
+
+2026/04/01 * Expense
+    Expenses:Food                              $7.00
+    Assets:Bank                               $-7.00 = $3.00
+
+test bal --check-in-file-order
+               $3.00  Assets:Bank
+             $-10.00  Equity
+               $7.00  Expenses:Food
+--------------------
+                   0
+end test

--- a/test/regress/3186.test
+++ b/test/regress/3186.test
@@ -1,0 +1,41 @@
+; Regression test for issue #3186: --check-in-file-order restores the
+; pre-#1092 behaviour where balance assertions/assignments accumulate
+; postings in file (parse) order rather than date order.
+;
+; Journal data (used by every test block below): the entries deliberately
+; appear in reverse date order so that file-order and date-order
+; accumulation yield different results.  Date-order accumulation will
+; reject the second transaction's assertion because, on 2026/04/01,
+; the only posting to Assets:Bank seen so far in date order is -$7,
+; not $3.
+
+2026/04/02 * Balance
+    Assets:Bank                               $10.00
+    Equity
+
+2026/04/01 * Expense
+    Expenses:Food                              $7.00
+    Assets:Bank                               $-7.00 = $3.00
+
+; Default (post-#1092) behaviour: the assertion fails because
+; 2026/04/01 precedes 2026/04/02 in date order, so the $10 deposit
+; is not yet visible when the $-7 posting is checked.
+test -f $FILE bal -> 1
+__ERROR__
+While parsing file "$FILE", line 18:
+While parsing posting:
+  Assets:Bank                               $-7.00 = $3.00
+                                                     ^^^^^
+Error: Balance assertion off by $10.00 (expected to see $-7.00)
+end test
+
+; --check-in-file-order restores the pre-#1092 file-order accumulation.
+; In file order the $10 deposit is parsed before the $-7 posting, so the
+; running total of Assets:Bank is $10 - $7 = $3 and the assertion holds.
+test --check-in-file-order -f $FILE bal
+               $3.00  Assets:Bank
+             $-10.00  Equity
+               $7.00  Expenses:Food
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

- Add a `--check-in-file-order` session option that restores the
  pre-3.5 file-order accumulation for balance assertions and
  assignments (#3186), reusing `account_t::self_total()` to mirror
  the original semantics.
- Compose it with the existing `--effective` special case from #2966
  so `compute_balance_diff()` keeps the right behaviour when both
  apply.
- Document the option in `ledger.1`, `ledger3.texi`, and the v3.5.0
  NEWS entry, and ship `test/regress/3186.test` plus the baseline
  test required by `CheckBaselineTests`.

## Background

The v3.5 series filters balance assertions by date (#847, #1092,
#2071) so that an assertion dated July 10 sees only postings whose
entry date is on or before July 10, even when a July 20 transaction
was parsed earlier in the file.  This caught long-standing
parse-order surprises, but as @drdv reported in #3186 it breaks
journals that intentionally arrange transactions in
reverse-chronological file order while still relying on every
prior posting contributing to the running total.

The new flag toggles the helper back to `self_total(real_only)`,
which sums every posting parsed so far for the account regardless
of date — i.e., the v3.3 behaviour.

## Test plan

- [x] `ctest --test-dir build` (all 4343 tests pass)
- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/regress/3186.test`
- [x] `python3 test/RegressTests.py --ledger ./build/ledger --sourcepath . test/baseline/opt-check-in-file-order.test`
- [x] Manual reproduction of the issue's journal: default fails with the date-order error, `--check-in-file-order` succeeds.