### PR TITLE
Fix #3198: --depth 0 hides collapsed <Total> rows

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -572,6 +572,12 @@ void handle_value(const value_t& value, account_t* account, xact_t* xact, tempor
 
 void collapse_posts::create_accounts() {
   global_totals_account = &temps.create_account(_("<Total>"), report.session.journal->master);
+  // <Total> is parented to the journal master so that get_account() can walk
+  // up to the real journal root for account() lookups (issue #2985).  But
+  // <Total> is a synthetic top-level summary account; like the other
+  // synthetics (<None>, <Adjustment>, <Revalued>) it must report depth 0 so
+  // that --depth 0 reports include it instead of filtering it out (#3198).
+  global_totals_account->depth = 0;
 }
 
 /**

--- a/test/regress/3198.test
+++ b/test/regress/3198.test
@@ -1,0 +1,29 @@
+; Regression test for issue #3198: --depth 0 (with --collapse) hides
+; every collapsed posting since the fix for #2985 parented the synthetic
+; <Total> account to the journal master.  That gave <Total> depth 1, so
+; the implicit "depth<=0" display predicate filtered every <Total> row
+; out, leaving only empty-period <None> rows visible.
+
+2024/01/01 Open
+    Assets:Cash      $100
+    Equity
+
+2024/01/03 Buy
+    Expenses:Food     $5
+    Assets:Cash
+
+test reg --collapse --depth 0 --daily --empty Assets
+24-Jan-01 - 24-Jan-01           <Total>                        $100         $100
+24-Jan-02 - 24-Jan-02           <None>                            0         $100
+24-Jan-03 - 24-Jan-03           <Total>                         $-5          $95
+end test
+
+test reg --collapse --depth 0 --daily Assets
+24-Jan-01 - 24-Jan-01           <Total>                        $100         $100
+24-Jan-03 - 24-Jan-03           <Total>                         $-5          $95
+end test
+
+test reg --collapse --depth 0 Assets
+24-Jan-01 Open                  <Total>                        $100         $100
+24-Jan-03 Buy                   <Total>                         $-5          $95
+end test


### PR DESCRIPTION
## Summary

- The fix for #2985 ([a380d5b1](https://github.com/ledger/ledger/commit/a380d5b1)) parented the synthetic `<Total>` account that `collapse_posts` creates to the journal master so that `get_account()` could walk up to the real journal root for `account()` lookups inside expressions.
- Side effect: `<Total>` then had depth 1 instead of 0, so the implicit `depth<=0` display predicate produced by `--depth 0` filtered every collapsed `<Total>` row out. Empty-period rows still appeared because `<None>` is created without a parent (depth 0).
- This change explicitly sets `<Total>->depth = 0` after creation, matching the convention used by the other synthetic display accounts (`<None>`, `<Adjustment>`, `<Revalued>`) while keeping the parent pointer that #2985 needs.

## Test plan

- [x] New `test/regress/3198.test` covers `--collapse --depth 0` with `--daily --empty`, with `--daily` only, and without an interval — all three cases now show `<Total>` rows for active days.
- [x] `RegressTest_2985` (the test that motivated parenting `<Total>`) still passes.
- [x] `BaselineTest_opt-empty_collapse` still passes.
- [x] Full ctest suite (4347 tests) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)