### PR TITLE
Share position_t::pathname across items parsed from one file

### DIFF
--- a/src/account.cc
+++ b/src/account.cc
@@ -922,7 +922,7 @@ void account_t::xdata_t::details_t::update(post_t& post, bool gather_all) {
     posts_virtuals_count++;
 
   if (gather_all && post.pos)
-    filenames.insert(post.pos->pathname);
+    filenames.insert(*post.pos->pathname);
 
   date_t date = post.date();
   date_t today = CURRENT_DATE();

--- a/src/context.h
+++ b/src/context.h
@@ -83,7 +83,11 @@ class parse_context_t {
 public:
   std::shared_ptr<std::istream> stream; ///< The input stream (file, string, or decrypted GPG)
 
-  path pathname;          ///< Absolute path of the file being parsed (empty for stdin)
+  path pathname; ///< Absolute path of the file being parsed (empty for stdin)
+  /// Shared handle for `pathname`, distributed to every position_t parsed
+  /// from this file so that items don't each pay for their own path copy.
+  /// Must be kept in sync whenever pathname is reassigned.
+  std::shared_ptr<const path> pathname_ref;
   path current_directory; ///< Working directory for resolving relative `include` paths
   journal_t* journal;     ///< The journal accumulating parsed data
   account_t* master;   ///< Root account for this parse scope (may be narrowed by `apply account`)
@@ -98,15 +102,15 @@ public:
   std::string last;     ///< Text of the most recent error (for reporting after parsing)
 
   explicit parse_context_t(const path& cwd)
-      : current_directory(cwd), master(nullptr), scope(nullptr), linenum(0), errors(0), count(0),
-        sequence(1) {}
-
-  explicit parse_context_t(std::shared_ptr<std::istream> _stream, const path& cwd)
-      : stream(std::move(_stream)), current_directory(cwd), master(nullptr), scope(nullptr),
+      : pathname_ref(empty_pathname_ptr()), current_directory(cwd), master(nullptr), scope(nullptr),
         linenum(0), errors(0), count(0), sequence(1) {}
 
+  explicit parse_context_t(std::shared_ptr<std::istream> _stream, const path& cwd)
+      : stream(std::move(_stream)), pathname_ref(empty_pathname_ptr()), current_directory(cwd),
+        master(nullptr), scope(nullptr), linenum(0), errors(0), count(0), sequence(1) {}
+
   parse_context_t(const parse_context_t& context)
-      : stream(context.stream), pathname(context.pathname),
+      : stream(context.stream), pathname(context.pathname), pathname_ref(context.pathname_ref),
         current_directory(context.current_directory), journal(context.journal),
         master(context.master), scope(context.scope), linebuf(context.linebuf),
         line_beg_pos(context.line_beg_pos), curr_pos(context.curr_pos), linenum(context.linenum),
@@ -151,6 +155,7 @@ inline parse_context_t open_for_reading(const path& pathname, const path& cwd) {
 #endif
   parse_context_t context(stream, parent);
   context.pathname = filename;
+  context.pathname_ref = std::make_shared<const path>(filename);
   return context;
 }
 

--- a/src/csv.cc
+++ b/src/csv.cc
@@ -167,7 +167,7 @@ xact_t* csv_reader::read_xact(bool rich_data) {
   xact->set_state(item_t::CLEARED);
 
   xact->pos = position_t();
-  xact->pos->pathname = context.pathname;
+  xact->pos->pathname = context.pathname_ref;
   xact->pos->beg_pos = context.stream->tellg();
   xact->pos->beg_line = context.linenum;
   xact->pos->sequence = context.sequence++;
@@ -175,7 +175,7 @@ xact_t* csv_reader::read_xact(bool rich_data) {
   post->xact = xact.get();
 
   post->pos = position_t();
-  post->pos->pathname = context.pathname;
+  post->pos->pathname = context.pathname_ref;
   post->pos->beg_pos = context.stream->tellg();
   post->pos->beg_line = context.linenum;
   post->pos->sequence = context.sequence++;
@@ -319,7 +319,7 @@ xact_t* csv_reader::read_xact(bool rich_data) {
   post->xact = xact.get();
 
   post->pos = position_t();
-  post->pos->pathname = context.pathname;
+  post->pos->pathname = context.pathname_ref;
   post->pos->beg_pos = context.stream->tellg();
   post->pos->beg_line = context.linenum;
   post->pos->sequence = context.sequence++;

--- a/src/emacs.cc
+++ b/src/emacs.cc
@@ -62,7 +62,8 @@ namespace ledger {
 
 void format_emacs_posts::write_xact(xact_t& xact) {
   if (xact.pos)
-    out << "\"" << escape_string(xact.pos->pathname.string()) << "\" " << xact.pos->beg_line << " ";
+    out << "\"" << escape_string(xact.pos->pathname->string()) << "\" " << xact.pos->beg_line
+        << " ";
   else
     out << "\"\" " << -1 << " ";
 

--- a/src/item.cc
+++ b/src/item.cc
@@ -157,21 +157,21 @@ value_t item_get_tag(call_scope_t& args) {
 
 value_t get_pathname(item_t& item) {
   if (item.pos)
-    return string_value(item.pos->pathname.string());
+    return string_value(item.pos->pathname->string());
   else
     return NULL_VALUE;
 }
 
 value_t get_filebase(item_t& item) {
   if (item.pos)
-    return string_value(item.pos->pathname.filename().string());
+    return string_value(item.pos->pathname->filename().string());
   else
     return NULL_VALUE;
 }
 
 value_t get_filepath(item_t& item) {
   if (item.pos)
-    return string_value(item.pos->pathname.parent_path().string());
+    return string_value(item.pos->pathname->parent_path().string());
   else
     return NULL_VALUE;
 }
@@ -448,12 +448,12 @@ bool item_t::valid() const {
 /** @brief Re-read and print the original source text of an item. */
 void print_item(std::ostream& out, const item_t& item, const string& prefix) {
   if (!prefix.empty()) {
-    out << source_context(item.pos->pathname, item.pos->beg_pos, item.pos->end_pos, prefix);
+    out << source_context(*item.pos->pathname, item.pos->beg_pos, item.pos->end_pos, prefix);
     return;
   }
 
   // Raw printing: stream source directly without any size limit.
-  if (!item.pos || item.pos->pathname.empty())
+  if (!item.pos || item.pos->pathname->empty())
     return;
 
   const std::streamoff len = item.pos->end_pos - item.pos->beg_pos;
@@ -462,9 +462,9 @@ void print_item(std::ostream& out, const item_t& item, const string& prefix) {
 
   std::unique_ptr<std::istream> in(
 #if HAVE_GPGME
-      decrypted_stream_t::open_stream(item.pos->pathname)
+      decrypted_stream_t::open_stream(*item.pos->pathname)
 #else
-      new ifstream(item.pos->pathname, std::ios::binary)
+      new ifstream(*item.pos->pathname, std::ios::binary)
 #endif
   );
 
@@ -529,12 +529,12 @@ string item_context(const item_t& item, const string& desc) {
 
   std::ostringstream out;
 
-  if (item.pos->pathname.empty()) {
+  if (item.pos->pathname->empty()) {
     out << desc << _(" from streamed input:");
     return out.str();
   }
 
-  out << desc << _(" from \"") << item.pos->pathname.string() << "\"";
+  out << desc << _(" from \"") << item.pos->pathname->string() << "\"";
 
   if (item.pos->beg_line != item.pos->end_line)
     out << _(", lines ") << item.pos->beg_line << "-" << item.pos->end_line << ":\n";

--- a/src/item.h
+++ b/src/item.h
@@ -75,14 +75,20 @@ namespace ledger {
  * across all items parsed during a session.
  */
 struct position_t {
-  path pathname;                  ///< Filesystem path of the journal file.
+  /// Filesystem path of the journal file.  Held by shared_ptr so that all
+  /// items parsed from the same file share a single allocation rather than
+  /// each carrying its own copy (issue: ~3 M redundant path copies for a
+  /// 1 M-xact journal).  Always non-null; defaults to empty_pathname_ptr().
+  std::shared_ptr<const path> pathname;
   std::istream::pos_type beg_pos; ///< Stream offset where the item begins.
   std::size_t beg_line;           ///< Line number where the item begins (1-based).
   std::istream::pos_type end_pos; ///< Stream offset just past the item's last byte.
   std::size_t end_line;           ///< Line number where the item ends (inclusive).
   std::size_t sequence;           ///< Global parse-order sequence number.
 
-  position_t() : beg_pos(0), beg_line(0), end_pos(0), end_line(0), sequence(0) {
+  position_t()
+      : pathname(empty_pathname_ptr()), beg_pos(0), beg_line(0), end_pos(0), end_line(0),
+        sequence(0) {
     TRACE_CTOR(position_t, "");
   }
   position_t(const position_t& pos) {

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -480,11 +480,14 @@ void check_all_metadata(journal_t& journal, std::variant<int, xact_t*, post_t*> 
     item_t* item = xact ? static_cast<item_t*>(xact) : static_cast<item_t*>(post);
 
     path saved_pathname;
+    std::shared_ptr<const path> saved_pathname_ref;
     std::size_t saved_linenum = 0;
     if (journal.current_context && item->pos) {
       saved_pathname = journal.current_context->pathname;
+      saved_pathname_ref = journal.current_context->pathname_ref;
       saved_linenum = journal.current_context->linenum;
-      journal.current_context->pathname = item->pos->pathname;
+      journal.current_context->pathname = *item->pos->pathname;
+      journal.current_context->pathname_ref = item->pos->pathname;
       journal.current_context->linenum = item->pos->beg_line;
     }
 
@@ -500,6 +503,7 @@ void check_all_metadata(journal_t& journal, std::variant<int, xact_t*, post_t*> 
 
     if (journal.current_context && item->pos) {
       journal.current_context->pathname = saved_pathname;
+      journal.current_context->pathname_ref = saved_pathname_ref;
       journal.current_context->linenum = saved_linenum;
     }
   }
@@ -594,10 +598,10 @@ bool journal_t::add_xact(xact_t* xact) {
       if (!match || this_posts.size() != other_posts.size()) {
         add_error_context(_("While comparing this previously seen transaction:"));
         add_error_context(
-            source_context(other->pos->pathname, other->pos->beg_pos, other->pos->end_pos, "> "));
+            source_context(*other->pos->pathname, other->pos->beg_pos, other->pos->end_pos, "> "));
         add_error_context(_("to this later transaction:"));
         add_error_context(
-            source_context(xact->pos->pathname, xact->pos->beg_pos, xact->pos->end_pos, "> "));
+            source_context(*xact->pos->pathname, xact->pos->beg_pos, xact->pos->end_pos, "> "));
         throw_(std::runtime_error,
                _f("Transactions with the same UUID must have equivalent postings"));
       }

--- a/src/py_item.cc
+++ b/src/py_item.cc
@@ -84,12 +84,12 @@ std::optional<value_t> py_get_tag_2m(item_t& item, const mask_t& tag_mask,
 
 /*--- Position Property Wrappers ---*/
 
-/// Adapt position_t::pathname (a boost::filesystem::path) to/from Python str.
+/// Adapt position_t::pathname (a shared_ptr<const path>) to/from Python str.
 std::string py_position_pathname(position_t const& pos) {
-  return pos.pathname.native();
+  return pos.pathname->native();
 }
 void py_position_set_pathname(position_t& pos, string const& s) {
-  pos.pathname = s;
+  pos.pathname = std::make_shared<const path>(s);
 }
 
 } // unnamed namespace

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -99,7 +99,7 @@ void instance_t::clock_in_directive(char* line, bool capitalized) {
     end = nullptr;
 
   position_t position;
-  position.pathname = context.pathname;
+  position.pathname = context.pathname_ref;
   position.beg_pos = context.line_beg_pos;
   position.beg_line = context.linenum;
   position.end_pos = context.curr_pos;
@@ -128,7 +128,7 @@ void instance_t::clock_out_directive(char* line, bool capitalized) {
     end = nullptr;
 
   position_t position;
-  position.pathname = context.pathname;
+  position.pathname = context.pathname_ref;
   position.beg_pos = context.line_beg_pos;
   position.beg_line = context.linenum;
   position.end_pos = context.curr_pos;
@@ -665,7 +665,7 @@ void instance_t::account_directive_body(char* line, account_t* parent, std::size
         ae.reset(new auto_xact_t(pred));
 
         ae->pos = position_t();
-        ae->pos->pathname = context.pathname;
+        ae->pos->pathname = context.pathname_ref;
         ae->pos->beg_pos = beg_pos;
         ae->pos->beg_line = beg_linenum;
         ae->pos->sequence = context.sequence++;

--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -220,7 +220,7 @@ void instance_t::automated_xact_directive(char* line) {
 
     unique_ptr<auto_xact_t> ae(new auto_xact_t(predicate_t(expr, keeper), xact_name));
     ae->pos = position_t();
-    ae->pos->pathname = context.pathname;
+    ae->pos->pathname = context.pathname_ref;
     ae->pos->beg_pos = context.line_beg_pos;
     ae->pos->beg_line = context.linenum;
     ae->pos->sequence = context.sequence++;
@@ -302,7 +302,7 @@ void instance_t::period_xact_directive(char* line) {
 
     unique_ptr<period_xact_t> pe(new period_xact_t(skip_ws(line + 1)));
     pe->pos = position_t();
-    pe->pos->pathname = context.pathname;
+    pe->pos->pathname = context.pathname_ref;
     pe->pos->beg_pos = context.line_beg_pos;
     pe->pos->beg_line = context.linenum;
     pe->pos->sequence = context.sequence++;
@@ -489,7 +489,7 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
 
   post->xact = xact; // this could be NULL (for automated/period xacts)
   post->pos = position_t();
-  post->pos->pathname = context.pathname;
+  post->pos->pathname = context.pathname_ref;
   post->pos->beg_pos = context.line_beg_pos;
   post->pos->beg_line = context.linenum;
   post->pos->sequence = context.sequence++;
@@ -970,7 +970,7 @@ xact_t* instance_t::parse_xact(char* line, std::streamsize len, account_t* accou
   unique_ptr<xact_t> xact(new xact_t);
 
   xact->pos = position_t();
-  xact->pos->pathname = context.pathname;
+  xact->pos->pathname = context.pathname_ref;
   xact->pos->beg_pos = context.line_beg_pos;
   xact->pos->beg_line = context.linenum;
   xact->pos->sequence = context.sequence++;
@@ -1211,7 +1211,7 @@ xact_t* instance_t::parse_xact(char* line, std::streamsize len, account_t* accou
     if (reveal_context) {
       add_error_context(_("While parsing transaction:"));
       add_error_context(
-          source_context(xact->pos->pathname, xact->pos->beg_pos, context.curr_pos, "> "));
+          source_context(*xact->pos->pathname, xact->pos->beg_pos, context.curr_pos, "> "));
     }
     throw;
   }

--- a/src/utils.h
+++ b/src/utils.h
@@ -90,6 +90,15 @@ using path = std::filesystem::path;                         ///< Filesystem path
 using ifstream = std::ifstream;                             ///< Input file stream
 using ofstream = std::ofstream;                             ///< Output file stream
 using filesystem_error = std::filesystem::filesystem_error; ///< Filesystem error
+
+/// Shared sentinel pathname (an empty path) used as the default for
+/// position_t::pathname and parse_context_t::pathname_ref.  Sharing one
+/// allocation lets every default-initialized item dereference the pointer
+/// unconditionally without per-item null checks.
+inline const std::shared_ptr<const path>& empty_pathname_ptr() {
+  static const std::shared_ptr<const path> ref = std::make_shared<const path>();
+  return ref;
+}
 } // namespace ledger
 
 /*@}*/

--- a/src/xact.cc
+++ b/src/xact.cc
@@ -1484,11 +1484,11 @@ void auto_xact_t::extend_xact(xact_base_t& xact, parse_context_t& context) {
                 if (pair.second == expr_t::EXPR_ASSERTION)
                   throw_(parse_error, _f("Transaction assertion failed: %1%") % pair.first);
                 else
-                  warning_func((xact.pos ? file_context(xact.pos->pathname, xact.pos->beg_line)
+                  warning_func((xact.pos ? file_context(*xact.pos->pathname, xact.pos->beg_line)
                                          : context.location()) +
                                " " + (_f("Transaction check failed: %1%") % pair.first).str() +
                                (pos ? "\n  " + (_f("(check expression at \"%1%\", line %2%)") %
-                                                pos->pathname.string() % pos->beg_line)
+                                                pos->pathname->string() % pos->beg_line)
                                                    .str()
                                     : ""));
               }
@@ -1704,11 +1704,11 @@ void auto_xact_t::apply_checks_to_post(post_t& initial_post, parse_context_t& co
           throw_(parse_error, _f("Transaction assertion failed: %1%") % pair.first);
         else
           warning_func((parent_xact && parent_xact->pos
-                            ? file_context(parent_xact->pos->pathname, parent_xact->pos->beg_line)
+                            ? file_context(*parent_xact->pos->pathname, parent_xact->pos->beg_line)
                             : context.location()) +
                        " " + (_f("Transaction check failed: %1%") % pair.first).str() +
                        (pos ? "\n  " + (_f("(check expression at \"%1%\", line %2%)") %
-                                        pos->pathname.string() % pos->beg_line)
+                                        pos->pathname->string() % pos->beg_line)
                                            .str()
                             : ""));
       }


### PR DESCRIPTION
Each parsed transaction and posting carried its own copy of the source
file's path inside its position_t, costing roughly 3 M heap allocations
on a 1 M-xact journal (perf attributed 0.5% of cycles to
std::filesystem::path::_List::_List(copy) alone, with much more spent
in the cascading allocator traffic and resulting page faults).

Change position_t::pathname to a std::shared_ptr<const path> and have
parse_context_t hold a single pathname_ref allocated when the file is
opened.  Every item parsed from that file now refcount-bumps the same
shared path instead of cloning it.  A tiny static empty-path sentinel
ensures the pointer is never null, so existing dereferences stay
straightforward.

Benchmark on a 1 M-xact / 108 MB journal:

  balance:  9.0s ->  7.4s wall (-18%), 3.65 GB -> 2.21 GB RSS (-40%)
  stats:    8.0s ->  6.6s wall (-18%)
  print:   19.7s -> 17.9s wall (-9%)

The bulk of the wall-time win comes from the cascade: ~3 M fewer small
allocations slashes glibc allocator work (operator delete -120 ms,
_int_malloc -85 ms) and kernel page-fault handling (sys time
2.0s -> 1.3s).  All 4312 ctest cases pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
