### PR TITLE
Fix #3206: treat balanced (...) inside bare patterns as regex group

### DIFF
--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -6921,6 +6921,7 @@ using FIFO or LIFO order.  @var{POLICY} must be @samp{fifo} or
 * Report Options::
 * Basic options::
 * Report filtering::
+* Search terms::
 * Output customization::
 * Commodity reporting::
 * Environment variables::
@@ -8300,7 +8301,7 @@ relate to.
 
 @end ftable
 
-@node Report filtering, Output customization, Basic options, Detailed Option Description
+@node Report filtering, Search terms, Basic options, Detailed Option Description
 @subsection Report filtering
 
 These options change which postings affect the outcome of a
@@ -8421,51 +8422,147 @@ Set the value expression used for the ``totals'' column in the
 
 @end ftable
 
-@c @node Search Terms, Output Customization, Report Filtering, Detailed Options Description
-@c @subsection Search Terms
+@node Search terms, Output customization, Report filtering, Detailed Option Description
+@subsection Search terms
 
-@c Valid Ledger invocations look like:
-@c @smallexample
-@c ledger [OPTIONS] <COMMAND> <SEARCH-TERMS>
-@c @end smallexample
+Valid Ledger invocations look like:
+@smallexample
+ledger [OPTIONS] <COMMAND> <SEARCH-TERMS>
+@end smallexample
 
-@c Where @code{COMMAND} is any command verb (@pxref{Reporting
-@c Commands}), @code{OPTIONS} can occur anywhere, and
-@c @code{SEARCH-TERM} is one or more of the following:
+Where @code{COMMAND} is any command verb (@pxref{Reporting
+Commands}), @code{OPTIONS} can occur anywhere, and
+@code{SEARCH-TERMS} is zero or more atoms drawn from the following
+table.  Atoms are combined with the boolean connectives shown in the
+``Composition'' rows.
 
-@c @smallexample
-@c word              search for any account containing 'word'
-@c TERM and TERM     boolean AND between terms
-@c TERM or TERM      boolean OR between terms
-@c not TERM          invert the meaning of the term
-@c payee word        search for any payee containing 'word'
-@c @@word            shorthand for 'payee word'
-@c desc word         alternate for 'payee word'
-@c note word         search for any note containing 'word'
-@c &word             shorthand for 'note word'
-@c tag word          search for any metadata tag containing 'word'
-@c tag word=value    search for any metadata tag containing 'word'
-@c                   whose value contains 'value'
-@c %word             shorthand for 'tag word'
-@c %word=value       shorthand for 'tag word=value'
-@c meta word         alternate for 'tag word'
-@c meta word=value   alternate for 'tag word=value'
-@c expr 'EXPR'       apply the given value expression as a predicate
-@c '=EXPR'           shorthand for 'expr EXPR'
-@c \( TERMS \)       group terms; useful if using and/or/not
-@c @end smallexample
+@multitable @columnfractions 0.32 0.68
+@headitem Atom @tab Meaning
 
-@c So, to list all transaction that charged to ``food'' but not
-@c ``dining'' for any payee other than ``chang'' the following three
-@c commands would be equivalent:
+@item @code{word}
+@tab Match any account whose name contains the regex @code{word}.
 
-@c @smallexample
-@c ledger reg food not dining @@chang
-@c ledger reg food and not dining and not payee chang
-@c ledger reg food not dining expr 'payee =~ /chang/'
-@c @end smallexample
+@item @code{/REGEX/}
+@tab Like a bare word, but explicitly delimited; useful when the
+pattern contains characters that the shorthand grammar would
+otherwise treat as operators.  Single quotes (@code{'REGEX'}) and
+double quotes (@code{"REGEX"}) work the same way.
 
-@node Output customization, Commodity reporting, Report filtering, Detailed Option Description
+@item @code{prefix(alt|alt)}
+@tab Once an identifier has started, a balanced parenthesized group
+is treated as part of the regex.  For example,
+@code{Invest:(Stock|Bond)} matches accounts whose names contain
+@code{Invest:Stock} or @code{Invest:Bond}, not all of @code{Invest:},
+@code{Stock}, and @code{Bond} separately.
+
+@item @code{payee WORD}
+@tab Match any payee whose description contains the regex @code{WORD}.
+@code{@@WORD} and @code{desc WORD} are aliases.
+
+@item @code{note WORD}
+@tab Match any note whose text contains the regex @code{WORD}.
+A leading @code{=WORD} at the start of an argument is a shorthand
+for @code{note WORD}.
+
+@item @code{code WORD}
+@tab Match any transaction code containing the regex @code{WORD}.
+@code{#WORD} is an alias.
+
+@item @code{tag WORD}
+@tab Match any metadata tag whose name contains the regex
+@code{WORD}.  @code{meta WORD} and @code{data WORD} are aliases.
+
+@item @code{tag WORD=VALUE}
+@tab Match any metadata tag whose name contains @code{WORD} and
+whose value matches the regex @code{VALUE}.  @code{%WORD=VALUE}
+is the @code{%}-shorthand for this form.
+
+@item @code{tag WORD==VALUE}
+@tab Match any metadata tag whose name contains @code{WORD} and
+whose value is exactly @code{VALUE} (string equality, not regex).
+
+@item @code{%WORD}
+@tab Shorthand for @code{tag WORD}.
+
+@item @code{expr 'EXPR'}
+@tab Apply the given value expression as a predicate.  Inside
+@code{EXPR}, @code{account}, @code{payee}, @code{note},
+@code{commodity}, and other functions are available.
+
+@end multitable
+
+@multitable @columnfractions 0.32 0.68
+@headitem Composition @tab Meaning
+
+@item @code{TERM and TERM}
+@tab Boolean AND.  @code{&} is an alias.
+
+@item @code{TERM or TERM}
+@tab Boolean OR.  @code{|} is an alias.
+
+@item @code{not TERM}
+@tab Invert the sense of @code{TERM}.  @code{!} is an alias.
+
+@item @code{( TERMS )}
+@tab Group terms together; useful when mixing @code{and}/@code{or}
+or when overriding the default precedence.  An opening @code{(} at
+the start of an argument begins a sub-expression; an @code{(} that
+appears in the middle of a bare-word identifier is treated as part
+of a regex group (see @code{prefix(alt|alt)} above).
+
+@item @code{show TERMS}
+@tab After the main predicate, @code{show TERMS} narrows which
+matching items are displayed (equivalent to @option{--display}).
+
+@item @code{only TERMS}
+@tab After the main predicate, @code{only TERMS} further filters
+which postings are retained (equivalent to @option{--only}).
+
+@item @code{bold TERMS}
+@tab Mark matching postings as bold in the output (equivalent
+to @option{--bold-if}).
+
+@item @code{for PERIOD}, @code{since DATE}, @code{until DATE}
+@tab Constrain the report to the given period (equivalent to
+@option{--period}).
+
+@end multitable
+
+To list all transactions that charged to ``food'' but not ``dining''
+for any payee other than ``chang'', the following three commands are
+equivalent:
+
+@smallexample
+ledger reg food not dining @@chang
+ledger reg food and not dining and not payee chang
+ledger reg food not dining expr 'payee =~ /chang/'
+@end smallexample
+
+To match account names that contain @code{Invest:Stock} or
+@code{Invest:Bond}, write the regex group inline:
+
+@smallexample
+ledger reg 'Invest:(Stock|Bond)'
+@end smallexample
+
+The same pattern is accepted in the predicate of an automated
+transaction:
+
+@smallexample
+= Invest:(Stock|Bond)
+    ; :BondsAndStocks:
+@end smallexample
+
+If you want to inspect how a particular search-term string is being
+parsed, use the @command{query} pre-command, which prints the
+expression tree that the search terms desugar to without running a
+report:
+
+@smallexample
+ledger query 'Invest:(Stock|Bond)'
+@end smallexample
+
+@node Output customization, Commodity reporting, Search terms, Detailed Option Description
 @subsection Output customization
 
 These options affect only the output, but not which postings are

--- a/src/query.cc
+++ b/src/query.cc
@@ -162,6 +162,16 @@ query_t::lexer_t::token_t query_t::lexer_t::scan_quoted_pattern() {
   return token_t(token_t::TERM, pat);
 }
 
+/// True when @p ident is a query-language keyword that would consume the
+/// trailing `(` in its own way (e.g., `tag(name)` is a parenthesized tag-name
+/// mask, not a regex group inside a bare account pattern).
+static bool is_query_keyword(const string& ident) {
+  return ident == "and" || ident == "or" || ident == "not" || ident == "code" || ident == "desc" ||
+         ident == "payee" || ident == "note" || ident == "tag" || ident == "meta" ||
+         ident == "data" || ident == "show" || ident == "only" || ident == "bold" ||
+         ident == "for" || ident == "since" || ident == "until" || ident == "expr";
+}
+
 /// Accumulate a bare-word identifier from arg_i until an operator boundary
 /// character is reached or the argument string is exhausted.
 ///
@@ -174,10 +184,19 @@ query_t::lexer_t::token_t query_t::lexer_t::scan_quoted_pattern() {
 /// @param hit_boundary Set to true if scanning stopped at an operator
 ///                     boundary (arg_i points at the boundary char);
 ///                     false if the entire argument was consumed.
+///
+/// Bare-word patterns may embed a balanced parenthesized regex group: once
+/// an identifier has begun (and is not itself a query keyword), an `(`
+/// whose matching `)` lies within the same argument is treated as a regex
+/// grouping character rather than the start of a new sub-expression.  This
+/// lets `Invest:(Stock|Bond)` parse as a single account regex (#3206).
+/// Operator chars (`|`, `&`, etc.) inside such a group are likewise
+/// treated as regex metacharacters.
 string query_t::lexer_t::scan_identifier(token_t::kind_t tok_context, bool consume_next,
                                          bool& hit_boundary) {
   string ident;
   hit_boundary = false;
+  int paren_depth = 0; // Depth of regex-group parens currently inside `ident`.
 
   for (; arg_i != arg_end; ++arg_i) {
     switch (*arg_i) {
@@ -185,23 +204,69 @@ string query_t::lexer_t::scan_identifier(token_t::kind_t tok_context, bool consu
     case '\t':
     case '\n':
     case '\r':
-      if (!multiple_args && !consume_whitespace && !consume_next_arg)
+      // Inside an open regex group, whitespace is a literal char rather
+      // than a token boundary, so single-argument inputs like
+      // `Invest:(Stock | Bond)` still scan as a single pattern.
+      if (paren_depth == 0 && !multiple_args && !consume_whitespace && !consume_next_arg)
         hit_boundary = true;
       else
         ident.push_back(*arg_i);
       break;
 
     case ')':
-      if (unbalanced_braces(ident))
-        consume_next = true;
-      if (!consume_next) {
-        hit_boundary = true;
-      } else {
+      if (paren_depth > 0) {
+        // Closing a regex group that began earlier in this identifier.
+        --paren_depth;
         ident.push_back(*arg_i);
+      } else {
+        if (unbalanced_braces(ident))
+          consume_next = true;
+        if (!consume_next) {
+          hit_boundary = true;
+        } else {
+          ident.push_back(*arg_i);
+        }
       }
       break;
 
     case '(':
+      // When we have already begun an identifier and the preceding char is
+      // not whitespace, treat `(` as a regex grouping char if (and only if)
+      // a balanced `)` lies later in the same argument (and is not blocked
+      // by whitespace in single-argument mode).  Without the balance check
+      // we would silently swallow a stray `(` and turn a missing-close-paren
+      // typo into a regex compile error.  Query-language keywords (`tag`,
+      // `payee`, etc.) are excluded so that `tag(name)` continues to flow
+      // through the parser's TOK_META LPAREN handler.
+      if (!ident.empty() && ident.back() != ' ' && ident.back() != '\t' && ident.back() != '\n' &&
+          ident.back() != '\r' && !is_query_keyword(ident)) {
+        int look_depth = 1;
+        bool balanced = false;
+        for (auto p = arg_i + 1; p != arg_end; ++p) {
+          if (*p == '(') {
+            ++look_depth;
+          } else if (*p == ')') {
+            if (--look_depth == 0) {
+              balanced = true;
+              break;
+            }
+          } else if (!multiple_args && !consume_whitespace &&
+                     (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')) {
+            break;
+          }
+        }
+        if (balanced) {
+          ++paren_depth;
+          ident.push_back(*arg_i);
+          break;
+        }
+      }
+      if (!consume_next && tok_context != token_t::TOK_EXPR)
+        hit_boundary = true;
+      else
+        ident.push_back(*arg_i);
+      break;
+
     case '&':
     case '|':
     case '!':
@@ -209,11 +274,12 @@ string query_t::lexer_t::scan_identifier(token_t::kind_t tok_context, bool consu
     case '#':
     case '%':
     case '=':
-      if (!consume_next && tok_context != token_t::TOK_EXPR) {
-        hit_boundary = true;
-      } else {
+      // Inside an open regex group, these operator chars are literal regex
+      // metacharacters rather than boolean query operators.
+      if (paren_depth > 0 || consume_next || tok_context == token_t::TOK_EXPR)
         ident.push_back(*arg_i);
-      }
+      else
+        hit_boundary = true;
       break;
 
     default:

--- a/test/regress/3206.test
+++ b/test/regress/3206.test
@@ -1,0 +1,62 @@
+; Regression test for issue #3206: a bare-word query pattern with an embedded
+; balanced `(...)` group should be treated as a single regex pattern, not split
+; into an `Invest:` term followed by a `(Stock|Bond)` boolean sub-expression.
+;
+; The user expects `ledger reg Invest:(Stock|Bond)` to match `Invest:Stock` and
+; `Invest:Bond` but not `Invest:Mutual`.  The same expectation applies to the
+; left-hand side of an automated-transaction directive.
+
+= Invest:(Stock|Bond)
+    ; :BondsAndStocks:
+
+2024/01/01 Investing
+    Assets:Invest:Stock      $100.00
+    Assets:Cash
+
+2024/01/02 Investing
+    Assets:Invest:Bond       $200.00
+    Assets:Cash
+
+2024/01/03 Investing
+    Assets:Invest:Mutual     $300.00
+    Assets:Cash
+
+; Bare command-line pattern with an embedded `(alt1|alt2)` regex group.
+test reg 'Invest:(Stock|Bond)'
+24-Jan-01 Investing             Assets:Invest:Stock         $100.00      $100.00
+24-Jan-02 Investing             Assets:Invest:Bond          $200.00      $300.00
+end test
+
+; The slash-delimited form must continue to work and give the same result.
+test reg '/Invest:(Stock|Bond)/'
+24-Jan-01 Investing             Assets:Invest:Stock         $100.00      $100.00
+24-Jan-02 Investing             Assets:Invest:Bond          $200.00      $300.00
+end test
+
+; A leading `(` is still a sub-expression boundary, so `(Stock|Bond)` parses
+; as a parenthesized boolean group with two account-name match terms.
+test reg '(Stock|Bond)'
+24-Jan-01 Investing             Assets:Invest:Stock         $100.00      $100.00
+24-Jan-02 Investing             Assets:Invest:Bond          $200.00      $300.00
+end test
+
+; An unbalanced opening `(` after identifier chars must still produce the
+; familiar "Missing ')'" diagnostic, not a regex-engine error.
+test reg 'Invest:(Stock' -> 1
+__ERROR__
+Error: Missing ')'
+end test
+
+; Nested groups inside the regex are honored.
+test reg 'Invest:((Stock)|Bond)'
+24-Jan-01 Investing             Assets:Invest:Stock         $100.00      $100.00
+24-Jan-02 Investing             Assets:Invest:Bond          $200.00      $300.00
+end test
+
+; The automated-transaction directive at the top of this file uses the same
+; bare-word regex pattern, so the `:BondsAndStocks:` tag must end up on the
+; Invest:Stock and Invest:Bond postings only.
+test reg %BondsAndStocks
+24-Jan-01 Investing             Assets:Invest:Stock         $100.00      $100.00
+24-Jan-02 Investing             Assets:Invest:Bond          $200.00      $300.00
+end test


### PR DESCRIPTION
## Summary

- `ledger reg Invest:(Stock|Bond)` no longer parses as three OR-ed
  terms (`Invest:`, `Stock`, `Bond`).  The lexer now treats a
  parenthesized group embedded in an identifier as a regex grouping
  character, so the whole argument becomes a single account regex.
- The fix is gated three ways to avoid regressions: the prefix must
  not be a query keyword (so `tag(name)` / `payee(...)` still parse
  as before), the matching `)` must lie within the same argument (so
  a typo still surfaces as ``Missing ')'`` rather than a regex
  compile error), and the preceding char must not be whitespace (so
  `food and (bar)` still means `food OR (bar)`).
- Adds `test/regress/3206.test` covering the bare-word, slash-delimited,
  leading-paren-subexpression, unbalanced-paren, nested-group, and
  automated-transaction cases.
- Uncomments and rewrites the previously hidden ``Search terms``
  section of ``doc/ledger3.texi``, including a worked example of the
  new behaviour.

Fixes #3206.

## Test plan

- [x] ``ctest`` passes all 4319 tests (including the new
      ``RegressTest_3206`` and the previously failing-then-fixed
      ``RegressTest_842`` which exercises ``tag("Category") == "food"``)
- [x] Manual checks: ``ledger reg 'Invest:(Stock|Bond)'`` matches
      Stock and Bond but not Mutual; the slash-delimited form gives
      the same result; ``(Stock|Bond)`` (leading paren) still parses
      as a sub-expression; ``Invest:(Stock`` still reports
      ``Missing ')'``
- [x] ``makeinfo --no-validate doc/ledger3.texi`` compiles without
      warnings about the new ``Search terms`` node

🤖 Generated with [Claude Code](https://claude.com/claude-code)