### PR TITLE
Fix #3207: balance --group-by no output when combined with --payee/--account/--date

### DIFF
--- a/src/filters.cc
+++ b/src/filters.cc
@@ -74,6 +74,13 @@ void post_splitter::print_title(const value_t& val) {
  * forwarded through the post_chain, which is flushed and optionally cleared
  * (unless --group-by-cumulative is active, which preserves running totals
  * across groups).
+ *
+ * The postflush callback runs before post_chain->clear() so that an
+ * accounts-report flusher can walk the account tree while any temporary
+ * postings created by transfer_details (--payee, --account, --date) are
+ * still attached to their accounts.  Calling clear() first would remove
+ * those temps via temporaries_t::clear(), leaving the account totals
+ * at zero for the group (issue #3207).
  */
 void post_splitter::flush() {
   bool cumulative = report.HANDLED(group_by_cumulative);
@@ -86,13 +93,13 @@ void post_splitter::flush() {
 
     post_chain->flush();
 
+    if (postflush_func)
+      (*postflush_func)(pair.first);
+
     // In cumulative mode, don't clear the chain state between groups
     // so that account totals accumulate across groups.
     if (!cumulative)
       post_chain->clear();
-
-    if (postflush_func)
-      (*postflush_func)(pair.first);
   }
 }
 

--- a/src/output.cc
+++ b/src/output.cc
@@ -341,6 +341,12 @@ void format_accounts::flush() {
   }
 
   out.flush();
+
+  // Drop queued accounts so subsequent group flushes (--group-by) don't see
+  // stale pointers.  Without this, accounts created by transfer_details that
+  // are torn down by post_chain->clear() between groups would leave dangling
+  // entries in posted_accounts, crashing the next group's flush (#3207).
+  posted_accounts.clear();
 }
 
 void format_accounts::operator()(account_t& account) {

--- a/test/regress/3207.test
+++ b/test/regress/3207.test
@@ -1,0 +1,84 @@
+; Regression test for issue #3207: `balance --group-by` produced empty output
+; whenever `--payee`, `--account`, or `--date` was also active (a common case
+; when one of those options is set in `.ledgerrc`).
+;
+; Root cause: post_splitter::flush() called post_chain->clear() before the
+; postflush callback.  clear() propagates through transfer_details::clear()
+; into temporaries_t::clear(), which removes the temporary postings it
+; created from their (non-temp) account's post list.  When the accounts
+; flusher then walked the master account tree, account_t::amount() found
+; no posts with POST_EXT_VISITED and returned zero, so display_value() was
+; falsy and no rows were emitted.  Moving the postflush callback ahead of
+; clear() lets the flusher see the temp postings while they are still
+; attached to their accounts.
+
+2026-01-01 buy
+    Food   100 USD
+    Cash  -100 USD
+
+2026-01-02 sell
+    Misc    50 USD
+    Cash   -50 USD
+
+test bal --payee payee --group-by account
+Cash
+            -150 USD  Cash
+
+Food
+             100 USD  Food
+
+Misc
+              50 USD  Misc
+end test
+
+test bal --account '"X"' --group-by account
+Cash
+            -150 USD  X:Cash
+
+Food
+             100 USD  X:Food
+
+Misc
+              50 USD  X:Misc
+end test
+
+test bal --date 'date' --group-by account
+Cash
+            -150 USD  Cash
+
+Food
+             100 USD  Food
+
+Misc
+              50 USD  Misc
+end test
+
+test bal --payee payee --group-by account --group-by-cumulative
+Cash
+            -150 USD  Cash
+
+Food
+            -150 USD  Cash
+             100 USD  Food
+--------------------
+             -50 USD
+
+Misc
+            -150 USD  Cash
+             100 USD  Food
+              50 USD  Misc
+--------------------
+                   0
+end test
+
+test reg --payee payee --group-by account
+Cash
+26-Jan-01 buy                   Cash                       -100 USD     -100 USD
+26-Jan-02 sell                  Cash                        -50 USD     -150 USD
+
+Food
+26-Jan-01 buy                   Food                        100 USD      100 USD
+
+Misc
+26-Jan-02 sell                  Misc                         50 USD       50 USD
+end test


### PR DESCRIPTION
## Summary

`ledger balance --group-by account` emitted empty output whenever any of
`--payee`, `--account`, or `--date` was also active (a common case when
one of those options is set in `.ledgerrc`).

## Root cause

`post_splitter::flush()` called `post_chain->clear()` before invoking the
postflush callback.  The `clear()` cascade reaches
`temporaries_t::clear()` (via `transfer_details::clear()`), which detaches
all temporary postings it created from their (non-temp) accounts.  By
the time `accounts_flusher` walked the master account tree,
`account_t::amount()` saw no posts with `POST_EXT_VISITED` and returned
zero, so `display_value()` was falsy and no rows were rendered.

## Fix

Two coupled changes in `src/`:

1. `filters.cc` — run the postflush callback **before** `post_chain->clear()`
   so the flusher observes temp postings while they're still attached.
2. `output.cc` — clear `format_accounts::posted_accounts` at the end of
   each `flush()`.  With the new order, the queued accounts include
   temp parent accounts (e.g. created by `--account` or `--pivot`) that
   the subsequent `post_chain->clear()` destroys; without the clear,
   the next group iteration would dereference dangling pointers.

## Test plan
- [x] New regression test `test/regress/3207.test` covering `--payee`,
      `--account`, `--date`, `--group-by-cumulative`, and `reg` variants.
- [x] Full suite passes (`ctest`, 4353 tests).
- [x] Manual verification of issue reporter's exact scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)