### PR TITLE
Fix #3212: accounts command ignored regex argument

### DIFF
--- a/src/output.cc
+++ b/src/output.cc
@@ -357,15 +357,28 @@ void format_accounts::operator()(account_t& account) {
 /*--- report_accounts: Account Listing ---*/
 
 namespace {
-/// @brief Recursively collect all accounts marked as ACCOUNT_KNOWN into the
-///        map, so that accounts referenced in the journal but not matched by
-///        the current query still appear in the `accounts` listing.
-void collect_known_accounts(account_t& account, report_accounts::accounts_report_map& accounts) {
-  if (account.has_flags(ACCOUNT_KNOWN) && accounts.find(&account) == accounts.end())
-    accounts.insert(report_accounts::accounts_report_map::value_type(&account, 0));
+/// @brief Recursively collect accounts marked as ACCOUNT_KNOWN into the
+///        map, so that declared-but-unused accounts still appear in the
+///        `accounts` listing.  When the report carries a --limit predicate
+///        (the regex form of `accounts <regex>` becomes one), require that
+///        each candidate match it -- otherwise an `account` directive for
+///        an unrelated account would surface in `accounts Bank`, ignoring
+///        the filter (#3212).  Visited accounts have already been filtered
+///        upstream by filter_posts.
+void collect_known_accounts(account_t& account, report_accounts::accounts_report_map& accounts,
+                            report_t& report) {
+  if (account.has_flags(ACCOUNT_KNOWN) && accounts.find(&account) == accounts.end()) {
+    bool admit = true;
+    if (report.HANDLED(limit_)) {
+      bind_scope_t limit_scope(report, account);
+      admit = predicate_t(report.HANDLER(limit_).str(), report.what_to_keep())(limit_scope);
+    }
+    if (admit)
+      accounts.insert(report_accounts::accounts_report_map::value_type(&account, 0));
+  }
 
   for (accounts_map::value_type& pair : account.accounts)
-    collect_known_accounts(*pair.second, accounts);
+    collect_known_accounts(*pair.second, accounts, report);
 }
 } // namespace
 
@@ -389,7 +402,7 @@ void report_accounts::flush() {
   if (do_append_format)
     append_format.parse_format(report.HANDLER(append_format_).str());
 
-  collect_known_accounts(*report.session.journal->master, accounts);
+  collect_known_accounts(*report.session.journal->master, accounts, report);
 
   for (accounts_pair& entry : accounts) {
     bind_scope_t bound_scope(report, *entry.first);

--- a/test/regress/3212.test
+++ b/test/regress/3212.test
@@ -1,0 +1,58 @@
+; Regression test for issue #3212: `ledger accounts <regex>` ignored the
+; regex argument and listed every account declared with an `account`
+; directive, even those that did not match the query.
+;
+; Root cause: report_accounts::flush() calls collect_known_accounts(), which
+; walks the master account tree and unconditionally admits every account
+; flagged ACCOUNT_KNOWN.  The --limit predicate (which is what the
+; command-line regex becomes) was not consulted, so declared accounts
+; bypassed the filter -- mirroring the bug fixed in #3189 for `bal -E`.
+;
+; The fix applies the same predicate evaluation used by format_accounts'
+; KNOWN+empty admission, restricted to declared accounts that match the
+; query.  Accounts visited by an actual posting are unaffected because
+; they were already filtered upstream by filter_posts.
+
+account Bank
+account Cash
+account Liabilities:Card
+account Expenses:Food
+
+2026-01-01 test
+    Bank   $100
+    Cash
+
+test accounts Bank
+Bank
+end test
+
+test accounts Cash
+Cash
+end test
+
+test accounts
+Bank
+Cash
+Expenses:Food
+Liabilities:Card
+end test
+
+test accounts Other
+end test
+
+; Declared-but-unused accounts must still be filtered by the regex.
+test accounts Liabilities
+Liabilities:Card
+end test
+
+test accounts Expenses
+Expenses:Food
+end test
+
+; A broader regex should pick up both visited and declared accounts that
+; match, while excluding those that do not (Expenses:Food has no 'a').
+test accounts a
+Bank
+Cash
+Liabilities:Card
+end test


### PR DESCRIPTION
## Summary
- `ledger accounts <regex>` listed every account declared with an `account` directive, regardless of the regex argument.
- `report_accounts::flush()` ran `collect_known_accounts()` over the master account tree and unconditionally admitted every `ACCOUNT_KNOWN` account, bypassing the `--limit` predicate that the command-line regex becomes.
- Apply the same predicate evaluation used by `format_accounts`'s KNOWN+empty admission (introduced in #3189) so declared-but-unused accounts must match the query before being listed; visited accounts are unaffected since they are already filtered upstream by `filter_posts`.

## Test plan
- [x] `test/regress/3212.test` — covers visited accounts, declared-but-unused accounts, the empty-result case, and a broader regex that hits a mix of both.
- [x] Full `ctest` suite (4353 tests) passes.
- [x] Confirmed test fails on the parent commit and passes on the fix.

Fixes #3212.