### PR TITLE
Fix #3210: --pivot-only doesn't work with built-in property

### DIFF
--- a/src/chain.cc
+++ b/src/chain.cc
@@ -91,6 +91,26 @@ post_handler_ptr chain_pre_post_handlers(post_handler_ptr base_handler, report_t
   if (report.HANDLED(anon))
     handler = std::make_shared<anonymize_posts>(handler);
 
+  // --pivot-only (issue #1153) replaces the original account entirely with
+  // "Tag:Value" rather than prepending it.  Because the original account
+  // hierarchy is dropped, command-line account queries must be evaluated
+  // against the ORIGINAL account name (before the rename); otherwise filters
+  // like `bal Assets --pivot-only commodity` would never match the pivoted
+  // "commodity:CAD" accounts and produce empty output (#3210).  Adding the
+  // transformer here -- before the --limit filter below -- makes the filter
+  // wrap the pivot in the data flow, so the predicate sees the original
+  // account.
+  //
+  // --account, --pivot, and --pivot-only are mutually exclusive; --account
+  // stays in chain_post_handlers because it does not interact with query
+  // filtering.
+  if (report.HANDLED(pivot_only_) && !report.HANDLED(account_)) {
+    string pivot = report.HANDLER(pivot_only_).str();
+    pivot = string("\"") + pivot + ":\" + tag(\"" + pivot + "\")";
+    handler = std::make_shared<transfer_details>(handler, transfer_details::SET_ACCOUNT_REPLACE,
+                                                 report.session.journal->master, pivot, report);
+  }
+
   // This filter_posts will only pass through posts matching the `predicate'.
   if (report.HANDLED(limit_)) {
     DEBUG("report.predicate", "Report predicate expression = " << report.HANDLER(limit_).str());
@@ -110,21 +130,10 @@ post_handler_ptr chain_pre_post_handlers(post_handler_ptr base_handler, report_t
   // --limit terms) match the pivoted account names rather than the original
   // ones.  This makes `bal --pivot Tag Value` filter by the pivoted name
   // "Tag:Value:..." instead of the original account name.  (See #1154.)
-  //
-  // --pivot-only (issue #1153) differs from --pivot in that it replaces the
-  // original account entirely with "Tag:Value" rather than prepending.  This
-  // gives a cleaner pivot view when the original account hierarchy is not
-  // wanted (e.g. "Member:John Doe" instead of "Member:John Doe:Income:Fees").
-  //
-  // --account, --pivot, and --pivot-only are mutually exclusive; --account
-  // stays in chain_post_handlers because it does not interact with query
-  // filtering.
-  if (report.HANDLED(pivot_only_) && !report.HANDLED(account_)) {
-    string pivot = report.HANDLER(pivot_only_).str();
-    pivot = string("\"") + pivot + ":\" + tag(\"" + pivot + "\")";
-    handler = std::make_shared<transfer_details>(handler, transfer_details::SET_ACCOUNT_REPLACE,
-                                                 report.session.journal->master, pivot, report);
-  } else if (report.HANDLED(pivot_) && !report.HANDLED(account_)) {
+  // Because --pivot keeps the original account as a suffix, a query like
+  // `bal --pivot Project Expenses` still matches the original "Expenses"
+  // segment, so the same filter works for both pivoted and unpivoted names.
+  if (report.HANDLED(pivot_) && !report.HANDLED(account_)) {
     string pivot = report.HANDLER(pivot_).str();
     pivot = string("\"") + pivot + ":\" + tag(\"" + pivot + "\")";
     handler = std::make_shared<transfer_details>(handler, transfer_details::SET_ACCOUNT,

--- a/test/baseline/opt-pivot-only.test
+++ b/test/baseline/opt-pivot-only.test
@@ -71,7 +71,6 @@ test bal --pivot-only Invoice --empty -p "until 2014-05-05"
             0.00 GBP    102
             0.00 GBP    103
             0.00 GBP    104
-                   0    105
 --------------------
                    0
 end test
@@ -94,7 +93,6 @@ test bal --pivot-only Customer --empty -p "until 2014-05-05"
             0.00 GBP    AAA
             0.00 GBP    BBB
             0.00 GBP    CCC
-                   0    DDD
           -25.00 GBP  Equity:Opening balance
 --------------------
                    0

--- a/test/regress/1153.test
+++ b/test/regress/1153.test
@@ -42,9 +42,22 @@ test bal --pivot-only Member
                    0
 end test
 
-; Filtering by the pivoted name works with --pivot-only as well.
-test bal --pivot-only Member "Member:John Doe"
+; Filters apply to the pre-pivot account hierarchy, so command-line account
+; queries select the original postings before they are renamed.  To filter
+; one Member's bucket, use a -l predicate against the tag value rather than
+; the pivoted account name (#3210).
+test bal --pivot-only Member -l "tag(\"Member\") =~ /John Doe/"
              $-84.00  Member:John Doe
+end test
+
+; Filtering by an original account name selects pre-pivot postings, then
+; the rename happens on what remains.
+test bal --pivot-only Member Income:Fees
+            $-114.00  Member
+             $-30.00    Jane Roe
+             $-84.00    John Doe
+--------------------
+            $-114.00
 end test
 
 ; --pivot-only also works on a register report.

--- a/test/regress/3210.test
+++ b/test/regress/3210.test
@@ -1,0 +1,110 @@
+; Regression test for issue #3210: --pivot-only doesn't work with built-in
+; properties.
+; https://github.com/ledger/ledger/issues/3210
+;
+; --pivot-only replaces the original account name entirely with the pivot
+; expression's value.  When the pivot key is a built-in property like
+; `commodity` or `account_base`, every posting evaluates to a non-empty
+; value, so every posting gets renamed.  Command-line account queries
+; (e.g. `bal Assets --pivot-only commodity`) must filter the pre-pivot
+; postings; otherwise the original "Assets" hierarchy is gone by the time
+; the filter sees the postings and the report is empty.  --pivot-only's
+; filter is now evaluated before the rename, so the query matches the
+; original account names.
+
+2026-01-01
+        Assets:BankA  10 CAD
+        Assets:BankA  10 USD
+        Assets:BankA  10 EUR
+        Assets:BankB  20 CAD
+        Assets:BankB  20 USD
+        Assets:BankB  20 EUR
+        Cash
+
+; --pivot-only with the built-in `commodity` property: the Assets filter
+; matches the pre-pivot accounts, and the rename groups the matching
+; postings under "commodity:<symbol>".
+test bal Assets --pivot-only commodity
+              30 CAD
+              30 EUR
+              30 USD  commodity
+              30 CAD    CAD
+              30 EUR    EUR
+              30 USD    USD
+--------------------
+              30 CAD
+              30 EUR
+              30 USD
+end test
+
+; --pivot-only with the built-in `account_base` property splits each
+; original account by its leaf segment.  The Assets filter keeps only the
+; BankA and BankB postings (Cash is dropped pre-pivot).
+test bal Assets --pivot-only account_base
+              30 CAD
+              30 EUR
+              30 USD  account_base
+              10 CAD
+              10 EUR
+              10 USD    BankA
+              20 CAD
+              20 EUR
+              20 USD    BankB
+--------------------
+              30 CAD
+              30 EUR
+              30 USD
+end test
+
+; The register report agrees: each posting is reassigned to the
+; commodity:<symbol> bucket, with the original Assets postings selected
+; pre-pivot.
+test reg Assets --pivot-only commodity --sort commodity
+26-Jan-01 <Unspecified payee>   commodity:CAD                10 CAD       10 CAD
+26-Jan-01 <Unspecified payee>   commodity:CAD                20 CAD       30 CAD
+26-Jan-01 <Unspecified payee>   commodity:EUR                10 EUR       30 CAD
+                                                                          10 EUR
+26-Jan-01 <Unspecified payee>   commodity:EUR                20 EUR       30 CAD
+                                                                          30 EUR
+26-Jan-01 <Unspecified payee>   commodity:USD                10 USD       30 CAD
+                                                                          30 EUR
+                                                                          10 USD
+26-Jan-01 <Unspecified payee>   commodity:USD                20 USD       30 CAD
+                                                                          30 EUR
+                                                                          30 USD
+end test
+
+; Without a filter, every posting is renamed and the report is non-empty
+; once --empty is given (without it, the balance nets to zero per
+; commodity bucket because the Cash balancing posting offsets the Assets
+; postings).
+test bal --pivot-only commodity --empty
+                   0  commodity
+               0 CAD    CAD
+               0 EUR    EUR
+               0 USD    USD
+--------------------
+                   0
+end test
+
+; --pivot (not --pivot-only) keeps the original account hierarchy as a
+; suffix, so an Assets filter has always worked here.  This is the
+; baseline behaviour the issue compared against.
+test bal Assets --pivot commodity
+              30 CAD
+              30 EUR
+              30 USD  commodity
+              30 CAD    CAD:Assets
+              10 CAD      BankA
+              20 CAD      BankB
+              30 EUR    EUR:Assets
+              10 EUR      BankA
+              20 EUR      BankB
+              30 USD    USD:Assets
+              10 USD      BankA
+              20 USD      BankB
+--------------------
+              30 CAD
+              30 EUR
+              30 USD
+end test


### PR DESCRIPTION
## Summary

`bal Assets --pivot-only commodity` and `bal Assets --pivot-only account_base` produced empty output even though the matching `--pivot` invocations worked.  Reordered the `chain_pre_post_handlers` so the `--pivot-only` transformer runs INSIDE the limit filter (in data-flow terms), meaning command-line account queries are evaluated against the original account hierarchy before the rename drops it.

- `bal Assets --pivot-only commodity` now collects every commodity bucket from the Assets postings, with the clean `commodity:<symbol>` naming.
- `--pivot` keeps the original suffix, so its existing #1154 behaviour (filter matches the pivoted name) is unchanged.
- Updated `test/regress/1153.test` to use a tag-value predicate via `-l` and to add a complementary case filtering by the original account.
- Updated `test/baseline/opt-pivot-only.test` because postings dated on/after the period cutoff no longer materialise their pivot accounts (the period filter drops them pre-rename).

Fixes #3210.

## Test plan

- [x] `ctest -j8` — 4350/4354 pass (the 4 "Not Run" are pre-existing Boost-tests not built in this configuration)
- [x] New `test/regress/3210.test` exercises both reported pivots (`commodity`, `account_base`), the register variant, the `--empty` no-filter case, and the matching `--pivot` baseline for comparison
- [x] Existing pivot regression tests still pass: `RegressTest_1048`, `RegressTest_1153`, `RegressTest_1154`, `BaselineTest_opt-pivot-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)