### PR TITLE
Implement #3211: --display-account option and account name helpers

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -634,6 +634,21 @@ reports.
 .It Fl \-display Ar EXPR Pq Fl d
 Display lines that satisfy the expression
 .Ar EXPR .
+.It Fl \-display-account Ar EXPR
+Apply a transformation to the
+.Em displayed
+account name (in format strings that reference
+.Em display_account ) .
+The expression sees the raw account name as
+.Em account ;
+the helpers
+.Em account_prefix ,
+.Em account_suffix ,
+.Em account_skip_prefix ,
+and
+.Em account_skip_suffix
+can pick out colon-separated components.  Virtual-posting wrappers are
+reapplied to the transformed name.
 .It Fl \-display-amount Ar EXPR
 Apply a transformation to the
 .Em displayed

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -7545,6 +7545,15 @@ in the register and prices reports.
 @item --display @var{EXPR}
 Display only lines that satisfy the expression @var{EXPR}.
 
+@item --display-account @var{EXPR}
+Apply a transformation to the @emph{displayed} account name in format
+strings that reference @code{display_account} (register, csv, prices, etc.).
+The expression sees the raw account name as @code{account}; the four helper
+functions @code{account_prefix}, @code{account_suffix},
+@code{account_skip_prefix}, and @code{account_skip_suffix} can pick out
+specific colon-separated components.  Virtual-posting wrappers (@code{()}
+or @code{[]}) are reapplied to the transformed name.
+
 @item --display-amount @var{EXPR}
 Apply a transformation to the @emph{displayed} amount.  This happens
 after calculations occur.
@@ -11664,9 +11673,27 @@ terminal character colors and font highlights in a normal TTY session.
 @subsection Quantities and Calculations
 
 @table @code
+@item account_prefix(@var{name}, @var{n})
+Return the first @var{n} colon-separated components of an account name.
+For example, @code{account_prefix("Assets:Bank:HSBC", 2)} returns
+@code{"Assets:Bank"}.  When @var{n} is greater than the depth, returns the
+full name; when @var{n} is zero or negative, returns the empty string.
+@item account_suffix(@var{name}, @var{n})
+Return the last @var{n} colon-separated components of an account name.
+For example, @code{account_suffix("Assets:Bank:HSBC", 2)} returns
+@code{"Bank:HSBC"}.
+@item account_skip_prefix(@var{name}, @var{n})
+Drop the first @var{n} colon-separated components of an account name.
+For example, @code{account_skip_prefix("Assets:Bank:HSBC", 2)} returns
+@code{"HSBC"}.
+@item account_skip_suffix(@var{name}, @var{n})
+Drop the last @var{n} colon-separated components of an account name.
+For example, @code{account_skip_suffix("Assets:Bank:HSBC", 2)} returns
+@code{"Assets"}.
 @item amount_expr
 @item abs
 @item commodity
+@item display_account
 @item display_amount
 @item display_total
 @item floor

--- a/src/post.cc
+++ b/src/post.cc
@@ -52,6 +52,7 @@
 #include "journal.h"
 #include "format.h"
 #include "pool.h"
+#include "report.h"
 
 namespace ledger {
 
@@ -575,9 +576,17 @@ value_t get_account(call_scope_t& args) {
  *
  * Virtual postings are wrapped in parentheses, balanced virtual postings
  * in brackets, matching the journal syntax the user originally wrote.
+ *
+ * If --display-account is set, the user-supplied expression is evaluated
+ * first to transform the account name (e.g., to drop a leading prefix);
+ * the virtual-posting wrappers are then applied to the transformed name.
  */
 value_t get_display_account(call_scope_t& args) {
-  value_t acct = get_account(args);
+  value_t acct;
+  if (report_t* report = search_scope<report_t>(&args))
+    acct = report->HANDLER(display_account_).expr.calc(args);
+  else
+    acct = get_account(args);
   if (acct.is_string()) {
     post_t& post(args.context<post_t>());
     if (post.has_flags(POST_VIRTUAL)) {

--- a/src/report.cc
+++ b/src/report.cc
@@ -858,6 +858,10 @@ value_t report_t::fn_display_total(call_scope_t& scope) {
   return HANDLER(display_total_).expr.calc(scope);
 }
 
+value_t report_t::fn_display_account(call_scope_t& scope) {
+  return HANDLER(display_account_).expr.calc(scope);
+}
+
 value_t report_t::fn_should_bold(call_scope_t& scope) {
   if (HANDLED(bold_if_))
     return HANDLER(bold_if_).expr.calc(scope);
@@ -1204,6 +1208,77 @@ value_t report_t::fn_join(call_scope_t& args) {
       out << "\\n";
   }
   return string_value(out.str());
+}
+
+namespace {
+/// Split a colon-separated account name into its components.
+std::vector<string> split_account_name(const string& name) {
+  std::vector<string> parts;
+  string::size_type start = 0;
+  while (start <= name.size()) {
+    string::size_type pos = name.find(':', start);
+    if (pos == string::npos) {
+      parts.push_back(name.substr(start));
+      break;
+    }
+    parts.push_back(name.substr(start, pos - start));
+    start = pos + 1;
+  }
+  return parts;
+}
+
+/// Rejoin components with ':' separators.
+string join_account_name(const std::vector<string>& parts, std::size_t begin, std::size_t end) {
+  string result;
+  for (std::size_t i = begin; i < end; ++i) {
+    if (i > begin)
+      result += ':';
+    result += parts[i];
+  }
+  return result;
+}
+
+/// Read the count argument for an account_* helper; clamp negatives to zero.
+std::size_t account_count_arg(call_scope_t& args) {
+  long n = args.get<long>(1);
+  return n < 0 ? 0 : static_cast<std::size_t>(n);
+}
+} // namespace
+
+value_t report_t::fn_account_prefix(call_scope_t& args) {
+  string name(args.get<string>(0)); // NOLINT(bugprone-unused-local-non-trivial-variable)
+  std::size_t n = account_count_arg(args);
+  std::vector<string> parts = split_account_name(name);
+  if (n > parts.size())
+    n = parts.size();
+  return string_value(join_account_name(parts, 0, n));
+}
+
+value_t report_t::fn_account_suffix(call_scope_t& args) {
+  string name(args.get<string>(0)); // NOLINT(bugprone-unused-local-non-trivial-variable)
+  std::size_t n = account_count_arg(args);
+  std::vector<string> parts = split_account_name(name);
+  if (n > parts.size())
+    n = parts.size();
+  return string_value(join_account_name(parts, parts.size() - n, parts.size()));
+}
+
+value_t report_t::fn_account_skip_prefix(call_scope_t& args) {
+  string name(args.get<string>(0)); // NOLINT(bugprone-unused-local-non-trivial-variable)
+  std::size_t n = account_count_arg(args);
+  std::vector<string> parts = split_account_name(name);
+  if (n > parts.size())
+    n = parts.size();
+  return string_value(join_account_name(parts, n, parts.size()));
+}
+
+value_t report_t::fn_account_skip_suffix(call_scope_t& args) {
+  string name(args.get<string>(0)); // NOLINT(bugprone-unused-local-non-trivial-variable)
+  std::size_t n = account_count_arg(args);
+  std::vector<string> parts = split_account_name(name);
+  if (n > parts.size())
+    n = parts.size();
+  return string_value(join_account_name(parts, 0, parts.size() - n));
 }
 
 value_t report_t::fn_format_date(call_scope_t& args) {
@@ -1625,6 +1700,7 @@ option_t<report_t>* report_t::lookup_option(const char* p) {
     else OPT(deviation);
     else OPT_ALT(rich_data, detail);
     else OPT_(display_);
+    else OPT(display_account_);
     else OPT(display_amount_);
     else OPT(display_total_);
     else OPT_ALT(dow, days_of_week);
@@ -1849,6 +1925,14 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind, const string& nam
         return MAKE_FUNCTOR(report_t::fn_abs);
       else if (is_eq(p, "averaged_lots"))
         return MAKE_FUNCTOR(report_t::fn_averaged_lots);
+      else if (is_eq(p, "account_prefix"))
+        return MAKE_FUNCTOR(report_t::fn_account_prefix);
+      else if (is_eq(p, "account_suffix"))
+        return MAKE_FUNCTOR(report_t::fn_account_suffix);
+      else if (is_eq(p, "account_skip_prefix"))
+        return MAKE_FUNCTOR(report_t::fn_account_skip_prefix);
+      else if (is_eq(p, "account_skip_suffix"))
+        return MAKE_FUNCTOR(report_t::fn_account_skip_suffix);
       break;
 
     case 'b':
@@ -1880,6 +1964,8 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind, const string& nam
         return MAKE_FUNCTOR(report_t::fn_display_amount);
       else if (is_eq(p, "display_total"))
         return MAKE_FUNCTOR(report_t::fn_display_total);
+      else if (is_eq(p, "display_account"))
+        return MAKE_FUNCTOR(report_t::fn_display_account);
       else if (is_eq(p, "date"))
         return MAKE_FUNCTOR(report_t::fn_today);
       break;

--- a/src/report.h
+++ b/src/report.h
@@ -238,7 +238,7 @@ public:
   value_t fn_total_expr(call_scope_t& scope);     ///< Evaluate the current --total expression
   value_t fn_display_amount(call_scope_t& scope); ///< Evaluate --display-amount expression
   value_t
-  fn_display_total(call_scope_t& scope);    ///< Evaluate --display-total (with caching fast path)
+  fn_display_total(call_scope_t& scope); ///< Evaluate --display-total (with caching fast path)
   value_t fn_display_account(call_scope_t& scope); ///< Evaluate --display-account expression
   value_t fn_top_amount(call_scope_t& val); ///< Extract the first amount from a balance or sequence
   value_t
@@ -270,12 +270,14 @@ public:
   value_t fn_abs(call_scope_t& scope);             ///< Absolute value
 
   // Formatting and display helpers
-  value_t fn_justify(call_scope_t& scope);     ///< Justify/pad a value within a column width
-  value_t fn_quoted(call_scope_t& scope);      ///< Wrap in double quotes (backslash escaping)
-  value_t fn_quoted_rfc(call_scope_t& scope);  ///< Wrap in double quotes (RFC 4180 CSV escaping)
-  value_t fn_join(call_scope_t& scope);        ///< Replace newlines with \\n in a string
-  value_t fn_account_prefix(call_scope_t& scope); ///< Keep first N colon-separated account components
-  value_t fn_account_suffix(call_scope_t& scope); ///< Keep last N colon-separated account components
+  value_t fn_justify(call_scope_t& scope);    ///< Justify/pad a value within a column width
+  value_t fn_quoted(call_scope_t& scope);     ///< Wrap in double quotes (backslash escaping)
+  value_t fn_quoted_rfc(call_scope_t& scope); ///< Wrap in double quotes (RFC 4180 CSV escaping)
+  value_t fn_join(call_scope_t& scope);       ///< Replace newlines with \\n in a string
+  value_t
+  fn_account_prefix(call_scope_t& scope); ///< Keep first N colon-separated account components
+  value_t
+  fn_account_suffix(call_scope_t& scope); ///< Keep last N colon-separated account components
   value_t
   fn_account_skip_prefix(call_scope_t& scope); ///< Drop first N colon-separated account components
   value_t

--- a/src/report.h
+++ b/src/report.h
@@ -239,6 +239,7 @@ public:
   value_t fn_display_amount(call_scope_t& scope); ///< Evaluate --display-amount expression
   value_t
   fn_display_total(call_scope_t& scope);    ///< Evaluate --display-total (with caching fast path)
+  value_t fn_display_account(call_scope_t& scope); ///< Evaluate --display-account expression
   value_t fn_top_amount(call_scope_t& val); ///< Extract the first amount from a balance or sequence
   value_t
   fn_should_bold(call_scope_t& scope); ///< Evaluate --bold-if expression for conditional formatting
@@ -273,6 +274,12 @@ public:
   value_t fn_quoted(call_scope_t& scope);      ///< Wrap in double quotes (backslash escaping)
   value_t fn_quoted_rfc(call_scope_t& scope);  ///< Wrap in double quotes (RFC 4180 CSV escaping)
   value_t fn_join(call_scope_t& scope);        ///< Replace newlines with \\n in a string
+  value_t fn_account_prefix(call_scope_t& scope); ///< Keep first N colon-separated account components
+  value_t fn_account_suffix(call_scope_t& scope); ///< Keep last N colon-separated account components
+  value_t
+  fn_account_skip_prefix(call_scope_t& scope); ///< Drop first N colon-separated account components
+  value_t
+  fn_account_skip_suffix(call_scope_t& scope); ///< Drop last N colon-separated account components
   value_t fn_format_date(call_scope_t& scope); ///< Format a date: format_date(d [, fmt])
   value_t
   fn_format_datetime(call_scope_t& scope);   ///< Format a datetime: format_datetime(dt [, fmt])
@@ -384,6 +391,7 @@ public:
     HANDLER(depth_).report(out);
     HANDLER(deviation).report(out);
     HANDLER(display_).report(out);
+    HANDLER(display_account_).report(out);
     HANDLER(display_amount_).report(out);
     HANDLER(display_total_).report(out);
     HANDLER(dow).report(out);
@@ -825,6 +833,11 @@ public:
         if (handled)
           value = string("(") + value + ")&(" + str + ")";
       });
+
+  OPTION_CTOR(
+      report_t, display_account_,
+      DECL1(report_t, display_account_, merged_expr_t, expr, ("display_account", "account")) {
+      } DO_() { expr.append(str); });
 
   OPTION_CTOR(
       report_t, display_amount_,

--- a/test/baseline/opt-display-account.test
+++ b/test/baseline/opt-display-account.test
@@ -1,0 +1,13 @@
+2008/01/01 January
+    Expenses:Books          $10.00
+    Assets:Cash
+
+2008/02/01 February
+    Expenses:Books          $20.00
+    Assets:Cash
+
+
+test reg --display-account='account_suffix(account, 1)' books
+08-Jan-01 January               Books                        $10.00       $10.00
+08-Feb-01 February              Books                        $20.00       $30.00
+end test

--- a/test/regress/3211.test
+++ b/test/regress/3211.test
@@ -1,0 +1,144 @@
+; Regression test for issue #3211: feature request for --display-account and
+; account-name manipulation helpers (account_prefix, account_suffix,
+; account_skip_prefix, account_skip_suffix).
+;
+; --display-account works like --display-amount and --display-total: its
+; value expression replaces the per-posting account name in format strings
+; (register, csv, etc.).  Virtual-posting wrappers ('()' or '[]') are still
+; applied to the transformed name.
+;
+; The four account_* helpers split an account name on ':' and rejoin the
+; selected components.  Negative counts are clamped to zero; counts larger
+; than the depth are clamped to the depth.
+
+2024/01/15 Acme
+    Assets:Bank:Checking    $-50.00
+    Expenses:Food:Coffee     $50.00
+
+2024/01/20 Coffee Shop
+    Assets:Bank:Checking    $-10.00
+    Expenses:Food:Dining     $10.00
+
+2024/02/01 Salary
+    Assets:Bank:Savings     $1000.00
+    Income:Salary          $-1000.00
+
+2024/02/05 Virtual move
+    (Assets:Bank:Checking)  $-25.00
+    Expenses:Food:Dining     $25.00
+    Assets:Cash             $-25.00
+
+test reg --display-account='account_prefix(account, 2)'
+24-Jan-15 Acme                  Assets:Bank                 $-50.00      $-50.00
+                                Expenses:Food                $50.00            0
+24-Jan-20 Coffee Shop           Assets:Bank                 $-10.00      $-10.00
+                                Expenses:Food                $10.00            0
+24-Feb-01 Salary                Assets:Bank                $1000.00     $1000.00
+                                Income:Salary             $-1000.00            0
+24-Feb-05 Virtual move          (Assets:Bank)               $-25.00      $-25.00
+                                Expenses:Food                $25.00            0
+                                Assets:Cash                 $-25.00      $-25.00
+end test
+
+test reg --display-account='account_skip_prefix(account, 1)'
+24-Jan-15 Acme                  Bank:Checking               $-50.00      $-50.00
+                                Food:Coffee                  $50.00            0
+24-Jan-20 Coffee Shop           Bank:Checking               $-10.00      $-10.00
+                                Food:Dining                  $10.00            0
+24-Feb-01 Salary                Bank:Savings               $1000.00     $1000.00
+                                Salary                    $-1000.00            0
+24-Feb-05 Virtual move          (Bank:Checking)             $-25.00      $-25.00
+                                Food:Dining                  $25.00            0
+                                Cash                        $-25.00      $-25.00
+end test
+
+test reg --display-account='account_suffix(account, 1)'
+24-Jan-15 Acme                  Checking                    $-50.00      $-50.00
+                                Coffee                       $50.00            0
+24-Jan-20 Coffee Shop           Checking                    $-10.00      $-10.00
+                                Dining                       $10.00            0
+24-Feb-01 Salary                Savings                    $1000.00     $1000.00
+                                Salary                    $-1000.00            0
+24-Feb-05 Virtual move          (Checking)                  $-25.00      $-25.00
+                                Dining                       $25.00            0
+                                Cash                        $-25.00      $-25.00
+end test
+
+test reg --display-account='account_skip_suffix(account, 1)'
+24-Jan-15 Acme                  Assets:Bank                 $-50.00      $-50.00
+                                Expenses:Food                $50.00            0
+24-Jan-20 Coffee Shop           Assets:Bank                 $-10.00      $-10.00
+                                Expenses:Food                $10.00            0
+24-Feb-01 Salary                Assets:Bank                $1000.00     $1000.00
+                                Income                    $-1000.00            0
+24-Feb-05 Virtual move          (Assets:Bank)               $-25.00      $-25.00
+                                Expenses:Food                $25.00            0
+                                Assets                      $-25.00      $-25.00
+end test
+
+; Edge case: count of 0 returns empty string for prefix/suffix, and original
+; for skip_prefix/skip_suffix.
+test reg --display-account='account_prefix(account, 0)'
+24-Jan-15 Acme                                              $-50.00      $-50.00
+                                                             $50.00            0
+24-Jan-20 Coffee Shop                                       $-10.00      $-10.00
+                                                             $10.00            0
+24-Feb-01 Salary                                           $1000.00     $1000.00
+                                                          $-1000.00            0
+24-Feb-05 Virtual move          ()                          $-25.00      $-25.00
+                                                             $25.00            0
+                                                            $-25.00      $-25.00
+end test
+
+; Edge case: count larger than depth is clamped to depth (full name).
+test reg --display-account='account_prefix(account, 10)'
+24-Jan-15 Acme                  Assets:Bank:Checking        $-50.00      $-50.00
+                                Expenses:Food:Coffee         $50.00            0
+24-Jan-20 Coffee Shop           Assets:Bank:Checking        $-10.00      $-10.00
+                                Expenses:Food:Dining         $10.00            0
+24-Feb-01 Salary                Assets:Bank:Savings        $1000.00     $1000.00
+                                Income:Salary             $-1000.00            0
+24-Feb-05 Virtual move          (Assets:Bank:Checking)      $-25.00      $-25.00
+                                Expenses:Food:Dining         $25.00            0
+                                Assets:Cash                 $-25.00      $-25.00
+end test
+
+; The helpers are also usable in arbitrary format strings.
+test reg --format "%-20(account_skip_prefix(account, 2)) %(scrub(display_amount))\n"
+Checking             $-50.00
+Coffee               $50.00
+Checking             $-10.00
+Dining               $10.00
+Savings              $1000.00
+                     $-1000.00
+Checking             $-25.00
+Dining               $25.00
+                     $-25.00
+end test
+
+; Default behavior (no --display-account) is unchanged.
+test reg
+24-Jan-15 Acme                  Assets:Bank:Checking        $-50.00      $-50.00
+                                Expenses:Food:Coffee         $50.00            0
+24-Jan-20 Coffee Shop           Assets:Bank:Checking        $-10.00      $-10.00
+                                Expenses:Food:Dining         $10.00            0
+24-Feb-01 Salary                Assets:Bank:Savings        $1000.00     $1000.00
+                                Income:Salary             $-1000.00            0
+24-Feb-05 Virtual move          (Assets:Bank:Checking)      $-25.00      $-25.00
+                                Expenses:Food:Dining         $25.00            0
+                                Assets:Cash                 $-25.00      $-25.00
+end test
+
+; --display-account also affects the csv command, since the default csv
+; format string also uses `display_account`.
+test csv --display-account='account_skip_prefix(account, 1)'
+"2024/01/15","","Acme","Bank:Checking","$","-50","",""
+"2024/01/15","","Acme","Food:Coffee","$","50","",""
+"2024/01/20","","Coffee Shop","Bank:Checking","$","-10","",""
+"2024/01/20","","Coffee Shop","Food:Dining","$","10","",""
+"2024/02/01","","Salary","Bank:Savings","$","1000","",""
+"2024/02/01","","Salary","Salary","$","-1000","",""
+"2024/02/05","","Virtual move","(Bank:Checking)","$","-25","",""
+"2024/02/05","","Virtual move","Food:Dining","$","25","",""
+"2024/02/05","","Virtual move","Cash","$","-25","",""
+end test


### PR DESCRIPTION
## Summary
- Adds `--display-account=EXPR` (mirroring `--display-amount` and `--display-total`) to transform the account name produced by `display_account` in format strings (register, csv, prices, etc.).  Virtual-posting wrappers (`()` / `[]`) are still applied to the transformed name.
- Adds four colon-component helpers usable from any value expression: `account_prefix`, `account_suffix`, `account_skip_prefix`, `account_skip_suffix`.

## Examples
```
$ ledger -f journal reg --display-account='account_skip_prefix(account, 1)'
24-Jan-15 Acme      Bank:Checking   $-50.00   $-50.00
                    Food:Coffee      $50.00         0
```

The four helpers also work in arbitrary format strings, which makes `--pivot` output much more readable (the original motivation in the issue):
```
%(account_prefix(display_account, 2))
%(account_suffix(display_account, 2))
%(account_skip_prefix(display_account, 1))
%(account_skip_suffix(display_account, 1))
```

Closes #3211.

## Test plan
- [x] New regression test `test/regress/3211.test` covering all four helpers, edge cases (count 0, count > depth), default behavior, csv, and `--format`
- [x] New baseline test `test/baseline/opt-display-account.test`
- [x] Full `ctest` run (4319 tests pass)