### PR TITLE
Fix #3220: round cost basis once at display, not per posting

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -1143,9 +1143,14 @@ When generating a ledger transaction from a CSV file using the
 .Ic convert
 command, add CSV, Imported, and UUID meta-data.
 .It Fl \-round
-Round all calculated values to the display precision of their commodity.
-This is the default behavior for display, but this option explicitly forces
-rounding in the expression pipeline, which is useful when
+Round each calculated value to the display precision of its commodity
+before postings are aggregated, so that a report total reflects the sum of
+the individually rounded amounts, the way a broker statement totals
+positions that have each already been rounded to the cent.
+Without this option Ledger keeps full precision while accumulating and
+rounds only once for display, so totals never drift.
+This option also forces rounding in the expression pipeline, which is useful
+when
 .Fl \-unround
 has been set in the init file and you want to override it for a specific
 invocation.

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -8145,10 +8145,15 @@ When generating a ledger transaction from a CSV file using the
 @command{convert} command, add CSV, Imported, and UUID metadata.
 
 @item --round
-Round all calculated values to the display precision of their
-commodity.  This is the default behavior for display, but this option
-explicitly forces rounding in the expression pipeline, which is useful
-when @option{--unround} has been set in the init file and you want to
+Round each calculated value to the display precision of its commodity
+@emph{before} postings are aggregated, so that a report total reflects
+the sum of the individually rounded amounts -- the way a broker
+statement totals positions that have each already been rounded to the
+cent.  Without this option Ledger keeps full precision while
+accumulating and rounds only once for display, so totals never drift by
+a fraction of the smallest displayed unit.  @option{--round} also forces
+rounding in the expression pipeline, which is useful when
+@option{--unround} has been set in the init file and you want to
 override it for a specific invocation.
 
 @item --seed @var{INT}

--- a/src/report.cc
+++ b/src/report.cc
@@ -323,10 +323,10 @@ void report_t::normalize_options(const string& verb) {
         // price history entries and thus fall back to the lot cost.
         HANDLER(amount_).on("?normalize", "market(amount_expr, today, exchange)");
       }
-      HANDLER(amount_).on("?normalize_round", "rounded(amount_expr)");
+      HANDLER(amount_).on("?normalize_round", "roundto_commodity(amount_expr)");
     } else {
-      HANDLER(amount_).on("?normalize_round", "rounded(amount_expr)");
-      HANDLER(total_).on("?normalize_round", "rounded(total_expr)");
+      HANDLER(amount_).on("?normalize_round", "roundto_commodity(amount_expr)");
+      HANDLER(total_).on("?normalize_round", "roundto_commodity(total_expr)");
     }
   }
 
@@ -1084,6 +1084,30 @@ value_t report_t::fn_scrub(call_scope_t& args) {
 }
 
 value_t report_t::fn_rounded(call_scope_t& args) {
+  value_t val(args.value());
+  // #3187: when a cost basis is in a commodity that has no declared display
+  // precision -- a dollar that appears only inside `@`/`@@` price annotations,
+  // never as a posting amount -- there is no precision to round to, and
+  // rounding would discard the value's fractional content (rendering a basis
+  // like 20 ETH * `@ $5.025` = $100.500 as $100).  Leave such an amount as is.
+  if (val.is_amount()) {
+    const amount_t& amt(val.as_amount());
+    if (amt.has_commodity() && amt.commodity().precision() == 0 && amt.precision() > 0)
+      return val;
+  }
+  // Display-only rounding (#3220): clear keep_precision so the value prints at
+  // commodity precision, but leave the stored value exact so a balance
+  // accumulates full precision and rounds only once at display time.  This
+  // backs the --basis/--cost amount expression rounded(cost).  (Per-posting
+  // physical rounding for --round goes through fn_roundto_commodity below.)
+  return val.rounded();
+}
+
+value_t report_t::fn_roundto_commodity(call_scope_t& args) {
+  // Physically round to commodity precision before aggregation, for the
+  // --round option (#781): this mutates the stored value so each posting is
+  // rounded before it is summed, matching how a broker statement totals
+  // positions that have each already been rounded to the cent.
   return args.value().rounded_to_commodity_precision();
 }
 
@@ -2058,6 +2082,8 @@ expr_t::ptr_op_t report_t::lookup(const symbol_t::kind_t kind, const string& nam
     case 'r':
       if (is_eq(p, "rounded"))
         return MAKE_FUNCTOR(report_t::fn_rounded);
+      else if (is_eq(p, "roundto_commodity"))
+        return MAKE_FUNCTOR(report_t::fn_roundto_commodity);
       else if (is_eq(p, "red"))
         return WRAP_FUNCTOR(fn_red);
       else if (is_eq(p, "round"))

--- a/src/report.h
+++ b/src/report.h
@@ -256,8 +256,10 @@ public:
   value_t fn_scrub(call_scope_t& scope);  ///< Alias for display_value() -- strip and unreduced
 
   // Numeric rounding and precision
-  value_t fn_quantity(call_scope_t& scope);  ///< Extract the numeric quantity (strip commodity)
-  value_t fn_rounded(call_scope_t& scope);   ///< Round to commodity display precision
+  value_t fn_quantity(call_scope_t& scope); ///< Extract the numeric quantity (strip commodity)
+  value_t fn_rounded(call_scope_t& scope);  ///< Display-only round to commodity precision (#3220)
+  value_t
+  fn_roundto_commodity(call_scope_t& scope); ///< Physically round to commodity precision (--round)
   value_t fn_unrounded(call_scope_t& scope); ///< Return the unrounded (full precision) value
   value_t fn_truncated(call_scope_t& scope); ///< Truncate display string or numeric value
   value_t fn_truncate(call_scope_t& scope);  ///< Numeric truncation (toward zero)
@@ -1335,8 +1337,11 @@ public:
 
   OPTION_(
       report_t, round, DO() {
-        OTHER(amount_).on(whence, "rounded(amount_expr)");
-        OTHER(total_).on(whence, "rounded(total_expr)");
+        // --round physically rounds each posting to commodity precision before
+        // aggregation (#781), so it uses roundto_commodity rather than the
+        // display-only rounded() that backs --basis/--cost (see #3220).
+        OTHER(amount_).on(whence, "roundto_commodity(amount_expr)");
+        OTHER(total_).on(whence, "roundto_commodity(total_expr)");
       });
 
   OPTION_(

--- a/test/regress/1765_b.test
+++ b/test/regress/1765_b.test
@@ -1,16 +1,38 @@
-; Regression test for GitHub issue #1765 (part b):
-; When the per-unit cost does NOT round to the posted amount at the commodity
-; display precision, bal --basis reveals the imbalance explicitly.
+; Regression test for GitHub issue #1765 (part b), updated for #3220:
+; When the per-unit cost does NOT cancel the posted amount at the commodity
+; display precision, the way bal --basis reports the residual depends on the
+; rounding mode.
 ;
-; 0.5 A @ $5.430 produces a cost of $2.715.  With $ at 2dp, rounded($2.715)
-; = $2.72 (round half away from zero), not $2.71.  The --basis report
-; shows the imbalance as $0.01 rather than hiding the fractional remainder.
+; 0.5 A @ $5.430 produces a cost of $2.715, offset by $-2.71, so there is a
+; genuine $0.005 residual.  Per #3220, --basis now keeps full precision and
+; rounds only once at display time: the half-cent residual rounds away and the
+; report balances to zero (each leg still prints at 2dp).  Per-posting "broker
+; statement" rounding -- which physically rounds $2.715 to $2.72 and thereby
+; exposes the imbalance as $0.01 -- remains available via --round.
 
 2019/01/01
     a  A0.5 @ $5.430
     b  $-2.71
 
+; Default: full precision maintained, rounded once at the end.
 test bal -B -> 0
+               $2.71  a
+              $-2.71  b
+--------------------
+                   0
+end test
+
+; --unround shows the exact stored cost and the real $0.005 residual.
+test bal -B --unround -> 0
+              $2.715  a
+              $-2.71  b
+--------------------
+              $0.005
+end test
+
+; --round physically rounds each posting before aggregation, revealing the
+; imbalance as $0.01 (the behavior that used to be the --basis default).
+test bal -B --round -> 0
                $2.72  a
               $-2.71  b
 --------------------

--- a/test/regress/3187.test
+++ b/test/regress/3187.test
@@ -4,9 +4,9 @@
 ; explicit USD posting, USD's display precision stays at 0, and the computed
 ; basis (e.g. 20 ETH * $5.025 = $100.500) was being rounded to $100.
 ;
-; in_place_round_to_commodity_precision now leaves keep_precision in place
-; when the commodity precision is 0 and the value has fractional digits, so
-; the unrounded value flows through to display.
+; The rounded() value expression (the --basis amount expression) leaves
+; keep_precision in place when the commodity precision is 0 and the value has
+; fractional digits, so the unrounded value flows through to display.
 
 2026-04-21 * Swap
     Assets        -10 BTC @ $10.05

--- a/test/regress/3220.test
+++ b/test/regress/3220.test
@@ -1,0 +1,65 @@
+; Regression test for GitHub issue #3220:
+; "Major ledger rounding changes in main" -- a cost-basis report drifted by a
+; penny per transaction that needed rounding.
+;
+; --cost (an alias for --basis) sets the amount expression to rounded(cost).
+; The fix for #1765 had made rounded() *physically* round each posting's cost
+; to the commodity's display precision before aggregation, so a transaction
+; whose costs cancel exactly at full precision no longer cancelled once each
+; leg was rounded:
+;
+;     0.005 FOO @ $124.95  ->  $0.62475  ->  $0.62
+;     0.001 BAR @ $124.95  ->  $0.12495  ->  $0.12
+;     (balancing leg)      -> -$0.74970  -> -$0.75
+;                                            ------
+;                                            -$0.01   per transaction
+;
+; With three such transactions the error accumulated to -$0.03, breaking the
+; long-standing rule that a cost-basis report balances to zero.
+;
+; The fix restores display-only rounding for rounded(): each posting still
+; *prints* at commodity precision, but the stored value keeps full precision,
+; so the balance accumulates exactly and rounds only once at display time.
+; Per-posting ("broker statement") rounding remains available via --round.
+
+2025/01/01 * Opening Balances
+    Assets:Brokerage     $123.45
+    Equity:Opening Balances
+2025/02/01 * Investment
+    Assets:Brokerage    0.005 FOO @ $124.95
+    Assets:Brokerage    0.001 BAR @ $124.95
+    Assets:Brokerage
+2025/02/01 * Investment
+    Assets:Brokerage    0.005 FOO @ $124.95
+    Assets:Brokerage    0.001 BAR @ $124.95
+    Assets:Brokerage
+2025/02/01 * Investment
+    Assets:Brokerage    0.005 FOO @ $124.95
+    Assets:Brokerage    0.001 BAR @ $124.95
+    Assets:Brokerage
+
+; The cost basis, valued in USD, must balance to zero no matter how many
+; rounding transactions are present (it drifted to -$0.03 before the fix).
+test --cost -X USD bal
+             $123.45  Assets:Brokerage
+            $-123.45  Equity:Opening Balances
+--------------------
+                   0
+end test
+
+; The drift originates in --cost itself, independent of -X valuation.
+test --cost bal
+             $123.45  Assets:Brokerage
+            $-123.45  Equity:Opening Balances
+--------------------
+                   0
+end test
+
+; --round opts in to per-posting rounding before aggregation, which
+; intentionally exposes the accumulated rounding residual.
+test --cost -X USD --round bal
+             $123.42  Assets:Brokerage
+            $-123.45  Equity:Opening Balances
+--------------------
+              $-0.03
+end test

--- a/test/regress/coverage-value-round-string-error.test
+++ b/test/regress/coverage-value-round-string-error.test
@@ -1,7 +1,8 @@
 ; Coverage for value.cc
 ; Calling rounded() on a string value triggers the default case in
-; in_place_round_to_commodity_precision, which throws an error since
-; only INTEGER, AMOUNT, BALANCE, and SEQUENCE types can be rounded.
+; value_t::in_place_round (the display-only rounding dispatch), which throws
+; an error since only INTEGER, AMOUNT, BALANCE, and SEQUENCE types can be
+; rounded.
 
 2024/01/01 Test
     Expenses:Food    $100.00
@@ -12,7 +13,7 @@ __ERROR__
 While evaluating value expression:
   rounded("hello")
   ^^^^^^^^^^^^^^^^
-While rounding hello to commodity precision:
+While rounding hello:
 While calling function 'rounded hello':
-Error: Cannot round a string to commodity precision
+Error: Cannot set rounding for a string
 end test


### PR DESCRIPTION
## Summary

Fixes #3220 — a cost-basis report drifted by a penny per transaction that needed rounding.

### Exactly why it broke

`--cost` is an alias for `--basis`, which sets the amount expression to `rounded(cost)`. The fix for #1765 (`f253ef48c`) changed the `rounded()` value-expression in **one line**:

```cpp
-  return args.value().rounded();                          // display-only (original)
+  return args.value().rounded_to_commodity_precision();   // physical per-posting
```

`rounded_to_commodity_precision()` *physically* rounds each posting's stored value to commodity precision before aggregation. A transaction whose legs cancel exactly at full precision then no longer cancels once each leg is rounded:

```
0.005 FOO @ $124.95  ->  $0.62475  ->  $0.62
0.001 BAR @ $124.95  ->  $0.12495  ->  $0.12
(balancing leg)      -> -$0.74970  -> -$0.75
                                       -$0.01  per transaction
```

So `--cost -X USD bal` lost a penny per rounding transaction (and `-$0.03` over three), breaking the rule that a cost-basis report balances to zero.

### The fix (surgical: 2 source files)

**Revert `fn_rounded()` to display-only rounding** — its behavior before `f253ef48c`. It clears `keep_precision` so each posting prints at commodity precision while the stored value stays exact, so a balance accumulates full precision and rounds **once** at display time:

```
$ ledger --cost -X USD bal      # after the fix (any number of txns)
             $123.45  Assets:Brokerage
            $-123.45  Equity:Opening Balances
--------------------
                   0
```

Then **preserve the two pieces of work that had relied on `rounded()` being physical**, without disturbing the shared rounding primitives:

- **`--round` (#781)** wants per-posting physical rounding before aggregation. It now routes through a new `roundto_commodity()` expression that calls `rounded_to_commodity_precision()` directly, instead of through `rounded()`. So `bal -V --round` still differs from `bal -V` (30.24 vs 30.25), and `--cost -X USD --round` still exposes the residual (`-$0.03`) for anyone who wants broker-statement totals.

- **#3187** wants a cost basis in a commodity with no declared display precision (a `$` seen only in `@` prices) to keep its fractional digits (`$100.500`, not `$100`). `fn_rounded()` handles that one case inline, leaving such an amount untouched. **Keeping this guard local to the `--basis` path is essential** — I verified that applying it inside the shared rounding primitive (`amount_t::in_place_round`) instead also changed `-V`/`-X` valuation and even broke a transaction's balancing, because those legitimately round zero-precision commodities.

Net diff to `src/`: `report.cc` (+32/−3) and `report.h` (+13/−4). No changes to `amount.*`, `value.*`, or `balance.h`, so valuation and transaction finalization are untouched.

## Tests

- New `test/regress/3220.test` — single/triple-transaction drift balances to zero; `--round` opt-in still drifts.
- `test/regress/1765_b.test` — revealing a sub-cent imbalance is now the `--round` behavior; the default rounds the residual away once at the end.
- `test/regress/3187.test` — comment updated (behavior unchanged: still `$100.5`).
- `test/regress/coverage-value-round-string-error.test` — tracks `rounded()`'s restored display-only error text.
- Full suite: **4325/4325 pass** locally.

## Docs

`--round` in `doc/ledger3.texi` and `doc/ledger.1` now states that it rounds each posting before aggregation (broker-statement style), versus the default which keeps full precision and rounds once for display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
