### PR TITLE
Add --collapse-if to selectively collapse matching accounts

### DIFF
--- a/doc/ledger.1
+++ b/doc/ledger.1
@@ -504,6 +504,17 @@ Specify the format to use for the
 report
 .It Fl \-collapse Pq Fl n
 Print only the top level accounts.
+.It Fl \-collapse-if Ar EXPR
+In an account (balance) report, collapse every account for which
+.Ar EXPR
+is true into a single line showing the rolled-up subtotal of that
+account and all of its descendants.
+Unlike
+.Fl \-collapse ,
+which folds the whole report to its top level, this is selective:
+.Ar EXPR
+is evaluated in each account's scope, so it may match on the account
+name, on account metadata, or on any other account predicate.
 .It Fl \-collapse-if-zero
 Collapse the account display only if it has a zero balance.
 .It Fl \-color

--- a/doc/ledger3.texi
+++ b/doc/ledger3.texi
@@ -7414,6 +7414,18 @@ Strings}).  The default is:
 By default ledger prints all accounts in an account tree.  With
 @option{--collapse} it prints only the top level account specified.
 
+@item --collapse-if @var{EXPR}
+In an account (@command{balance}) report, collapse every account for
+which the value expression @var{EXPR} is true into a single line showing
+the rolled-up subtotal of that account and all of its descendants; the
+descendants themselves are not displayed.  Unlike @option{--collapse},
+which folds the whole report to its top level, @option{--collapse-if} is
+selective: @var{EXPR} is evaluated in each account's scope, so it may
+match on the account name (e.g.@: @code{account =~ /:NotImportant/}), on
+account metadata (e.g.@: @code{has_tag("collapse")}), or on any other
+account predicate.  Only which accounts are displayed is affected; the
+report total is unchanged.
+
 @item --collapse-if-zero
 Collapse the account display only if it has a zero balance.
 

--- a/src/output.cc
+++ b/src/output.cc
@@ -261,13 +261,28 @@ std::size_t format_accounts::post_account(account_t& account, const bool flat) {
   return 0;
 }
 
-std::pair<std::size_t, std::size_t> format_accounts::mark_accounts(account_t& account,
-                                                                   const bool flat) {
+std::pair<std::size_t, std::size_t>
+format_accounts::mark_accounts(account_t& account, const bool flat,
+                               const bool collapsed_by_ancestor) {
+  // A --collapse-if predicate turns every matching account into a collapse
+  // point: it is displayed as a single line carrying the rolled-up subtotal of
+  // its whole subtree, and its descendants are hidden.  Evaluate the predicate
+  // top-down (before recursing) so the first matching ancestor wins; the master
+  // (parent-less) account is never collapsed, as that would fold away the
+  // entire report.
+  bool collapse_here = false;
+  if (collapse_pred && account.parent) {
+    bind_scope_t bound_scope(report, account);
+    collapse_here = collapse_pred(bound_scope);
+  }
+  const bool descendants_collapsed = collapsed_by_ancestor || collapse_here;
+
   std::size_t visited = 0;
   std::size_t to_display = 0;
 
   for (accounts_map::value_type& pair : account.accounts) {
-    auto [child_visited, child_to_display] = mark_accounts(*pair.second, flat);
+    auto [child_visited, child_to_display] =
+        mark_accounts(*pair.second, flat, descendants_collapsed);
     visited += child_visited;
     to_display += child_to_display;
   }
@@ -296,15 +311,23 @@ std::pair<std::size_t, std::size_t> format_accounts::mark_accounts(account_t& ac
 
   if (account.parent && (account.has_xflags(ACCOUNT_EXT_VISITED) || (!flat && visited > 0) ||
                          (flat && visited > 0 && to_display == 0) || known_empty_admit())) {
-    bind_scope_t bound_scope(report, account);
-    call_scope_t call_scope(bound_scope);
-    if ((!flat && to_display > 1) || (!flat && to_display == 1 && !account.posts.empty()) ||
-        ((flat || to_display != 1 || account.has_xflags(ACCOUNT_EXT_VISITED)) &&
-         (report.HANDLED(empty) || report.display_value(report.fn_display_total(call_scope))) &&
-         disp_pred(bound_scope))) {
-      account.xdata().add_flags(ACCOUNT_EXT_TO_DISPLAY);
-      DEBUG("account.display", "Marking account as TO_DISPLAY");
-      to_display = 1;
+    // An account folded into a collapsing ancestor is never displayed in its
+    // own right; only its visited-ness propagates upward so the ancestor knows
+    // it has a subtree to summarise.  Because the collapse flag is passed down
+    // to every descendant, such an account also contributes no displayable
+    // children (to_display stays 0), leaving the collapse point itself to stand
+    // in for the entire subtree.
+    if (!collapsed_by_ancestor) {
+      bind_scope_t bound_scope(report, account);
+      call_scope_t call_scope(bound_scope);
+      if ((!flat && to_display > 1) || (!flat && to_display == 1 && !account.posts.empty()) ||
+          ((flat || to_display != 1 || account.has_xflags(ACCOUNT_EXT_VISITED)) &&
+           (report.HANDLED(empty) || report.display_value(report.fn_display_total(call_scope))) &&
+           disp_pred(bound_scope))) {
+        account.xdata().add_flags(ACCOUNT_EXT_TO_DISPLAY);
+        DEBUG("account.display", "Marking account as TO_DISPLAY");
+        to_display = 1;
+      }
     }
     visited = 1;
   }
@@ -318,6 +341,11 @@ void format_accounts::flush() {
   if (report.HANDLED(display_)) {
     DEBUG("account.display", "Account display predicate: " << report.HANDLER(display_).str());
     disp_pred.parse(report.HANDLER(display_).str());
+  }
+
+  if (report.HANDLED(collapse_if_)) {
+    DEBUG("account.display", "Account collapse predicate: " << report.HANDLER(collapse_if_).str());
+    collapse_pred.parse(report.HANDLER(collapse_if_).str());
   }
 
   mark_accounts(*report.session.journal->master, report.HANDLED(flat));

--- a/src/output.h
+++ b/src/output.h
@@ -146,6 +146,7 @@ protected:
   format_t append_format;       ///< Optional suffix appended to every output line.
   std::size_t prepend_width;    ///< Width reserved for the prepend column.
   predicate_t disp_pred;        ///< Display predicate from --display option.
+  predicate_t collapse_pred;    ///< Collapse predicate from --collapse-if option.
   bool first_report_title;      ///< True until the first group title has been printed.
   string report_title;          ///< Current group title.
 
@@ -166,12 +167,20 @@ public:
    * --flat flag changes the visibility logic so that intermediate
    * parent accounts are not shown.
    *
-   * @param account  The root of the subtree to mark.
-   * @param flat     True if --flat mode is active.
+   * When a --collapse-if predicate is active and matches an account, that
+   * account becomes a collapse point: its descendants are not marked for
+   * display, so it renders as a single line carrying the rolled-up subtotal.
+   *
+   * @param account               The root of the subtree to mark.
+   * @param flat                  True if --flat mode is active.
+   * @param collapsed_by_ancestor True if an ancestor matched --collapse-if, in
+   *                              which case this account is not displayed on
+   *                              its own (it has been folded into that ancestor).
    * @return         A pair of (visited_count, to_display_count) for the
    *                 subtree.
    */
-  std::pair<std::size_t, std::size_t> mark_accounts(account_t& account, const bool flat);
+  std::pair<std::size_t, std::size_t> mark_accounts(account_t& account, const bool flat,
+                                                    const bool collapsed_by_ancestor = false);
 
   /// @brief Set the group title to be printed before the next account.
   void title(const string& str) override { report_title = str; }
@@ -191,6 +200,7 @@ public:
 
   void clear() override {
     disp_pred.mark_uncompiled();
+    collapse_pred.mark_uncompiled();
     posted_accounts.clear();
 
     report_title = "";

--- a/src/report.cc
+++ b/src/report.cc
@@ -1715,6 +1715,7 @@ option_t<report_t>* report_t::lookup_option(const char* p) {
     else OPT(cleared);
     else OPT(cleared_format_);
     else OPT(collapse);
+    else OPT(collapse_if_);
     else OPT(collapse_if_zero);
     else OPT(color);
     else OPT(columns_);

--- a/src/report.h
+++ b/src/report.h
@@ -381,6 +381,7 @@ public:
     HANDLER(cleared_format_).report(out);
     HANDLER(color).report(out);
     HANDLER(collapse).report(out);
+    HANDLER(collapse_if_).report(out);
     HANDLER(collapse_if_zero).report(out);
     HANDLER(columns_).report(out);
     HANDLER(csv_format_).report(out);
@@ -700,6 +701,12 @@ public:
         // to account xacts
         OTHER(display_).on(whence, "post|depth<=1");
       });
+
+  // --collapse-if EXPR: in an account (balance) report, collapse every account
+  // for which EXPR is true into a single line carrying the rolled-up subtotal
+  // of itself and its descendants.  Unlike --collapse (-n), which folds the
+  // whole report to depth 1, this is selective and predicate-driven (#3222).
+  OPTION(report_t, collapse_if_);
 
   OPTION_(report_t, collapse_if_zero, DO() { OTHER(collapse).on(whence); });
 

--- a/test/baseline/opt-collapse-if.test
+++ b/test/baseline/opt-collapse-if.test
@@ -1,0 +1,19 @@
+2024/01/01 Grocery
+    Expenses:Food:Groceries     $100
+    Assets:Cash
+
+2024/01/02 Dining
+    Expenses:Food:Dining         $50
+    Assets:Cash
+
+2024/01/03 Rent
+    Expenses:Rent              $1000
+    Assets:Cash
+
+test bal --collapse-if 'account =~ /:Food/' Expenses
+               $1150  Expenses
+                $150    Food
+               $1000    Rent
+--------------------
+               $1150
+end test

--- a/test/regress/3222.test
+++ b/test/regress/3222.test
@@ -1,0 +1,89 @@
+; Regression test for GitHub issue #3222:
+; "feature request: --collapse-if"
+;
+; --collapse-if EXPR collapses, in an account (balance) report, every account
+; whose EXPR evaluates true: that account is shown as a single line carrying
+; the rolled-up subtotal of itself and all of its descendants, and its
+; descendants are no longer broken out individually.  Unlike --collapse (-n),
+; which flattens the whole report to depth 1, --collapse-if is selective and
+; driven by a value expression evaluated in each account's scope, so it can
+; match on the account name (account =~ /.../), on account metadata
+; (has_tag(...)), or on any other account-scope predicate.  The grand total is
+; never affected -- only which accounts are displayed.
+
+account Expenses:NotImportant
+    ; collapse: yes
+
+2024/01/01 Grocery
+    Expenses:Food:Groceries        $100
+    Assets:Cash
+
+2024/01/02 Dining
+    Expenses:Food:Dining            $50
+    Assets:Cash
+
+2024/01/03 Rent
+    Expenses:Rent                 $1000
+    Assets:Cash
+
+2024/01/04 Toy
+    Expenses:NotImportant:Toys       $20
+    Assets:Cash
+
+2024/01/05 Candy
+    Expenses:NotImportant:Candy       $5
+    Assets:Cash
+
+; Collapse by account name: the Expenses:NotImportant subtree folds into a
+; single line, while the rest of the tree is unaffected.
+test bal --collapse-if 'account =~ /:NotImportant/' Expenses
+               $1175  Expenses
+                $150    Food
+                 $50      Dining
+                $100      Groceries
+                 $25    NotImportant
+               $1000    Rent
+--------------------
+               $1175
+end test
+
+; Collapse by account metadata: only Expenses:NotImportant carries the
+; "collapse" tag, so the same subtree folds.
+test bal --collapse-if 'has_tag("collapse")' Expenses
+               $1175  Expenses
+                $150    Food
+                 $50      Dining
+                $100      Groceries
+                 $25    NotImportant
+               $1000    Rent
+--------------------
+               $1175
+end test
+
+; A different target: collapse Expenses:Food instead, leaving NotImportant
+; expanded.  Demonstrates that matching is per-account, not global.
+test bal --collapse-if 'account =~ /:Food$/' Expenses
+               $1175  Expenses
+                $150    Food
+                 $25    NotImportant
+                  $5      Candy
+                 $20      Toys
+               $1000    Rent
+--------------------
+               $1175
+end test
+
+; A predicate that matches nothing leaves the report identical to a plain
+; balance: --collapse-if never alters totals or account selection on its own.
+test bal --collapse-if 'account =~ /Nonexistent/' Expenses
+               $1175  Expenses
+                $150    Food
+                 $50      Dining
+                $100      Groceries
+                 $25    NotImportant
+                  $5      Candy
+                 $20      Toys
+               $1000    Rent
+--------------------
+               $1175
+end test


### PR DESCRIPTION
## Summary

Implements the feature requested in #3222: a `--collapse-if EXPR` option.

`--collapse` (`-n`) folds an entire balance report to its top level. When only
a few account subtrees are noise, that is too blunt — there was no way to roll
up, say, `Expenses:NotImportant` while keeping the rest of the tree broken out.

`--collapse-if EXPR` collapses **every account for which the value expression
`EXPR` is true** into a single line carrying the rolled-up subtotal of that
account and all of its descendants. `EXPR` is evaluated in each account's
scope, so it can match on:

- the account name — `bal --collapse-if 'account =~ /:NotImportant/'`
- account metadata — `bal --collapse-if 'has_tag("collapse")'`
- any other account-scope predicate (`total`, `depth`, …)

Only which accounts are *displayed* changes; the report grand total is never
affected.

### Example

```
$ ledger bal Expenses
               $1175  Expenses
                $150    Food
                 $50      Dining
                $100      Groceries
                 $25    NotImportant
                  $5      Candy
                 $20      Toys
               $1000    Rent
--------------------
               $1175

$ ledger bal --collapse-if 'account =~ /:NotImportant/' Expenses
               $1175  Expenses
                $150    Food
                 $50      Dining
                $100      Groceries
                 $25    NotImportant
               $1000    Rent
--------------------
               $1175
```

## Design

The predicate is evaluated top-down in `format_accounts::mark_accounts()` (the
balance-report account-tree walker), before recursing, so the first matching
ancestor wins and deeper matches are subsumed. A matched account's descendants
are not marked for display; only their visited-ness propagates upward so the
collapse point still shows its subtotal. Account totals already roll up through
the tree, so the displayed totals and the grand total are unchanged.

The feature is scoped to **account (balance) reports**, mirroring how
`--collapse` itself maps to a display predicate there (the `collapse_posts`
filter is gated to non-account reports). Register reports are untouched; the
option is harmlessly ignored there.

It composes cleanly with `--flat`, `--group-by`, `--depth`, and `-n`, and an
invalid expression produces the usual value-expression parse error.

## Scope note

The original reporter gave only balance-report examples and did not respond to
the request for more detail, so this implements the clear, well-defined
balance-report behavior. Easy to extend to register reports if that is wanted.

## Tests

- `test/regress/3222.test` — covers regex match, metadata (`has_tag`) match, a
  different collapse target (per-account, not global), and a no-match sanity
  check; each asserts the grand total is unaffected.
- `test/baseline/opt-collapse-if.test` — required by `CheckBaselineTests` for
  every option.
- Full suite: 4359/4359 pass; clang-format and clang-tidy clean; man page and
  texinfo updated (`CheckManpage`/`CheckTexinfo` recognize the option).

Closes #3222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
