### PR TITLE
Fix #3218: verify balance assertions in date order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -158,7 +158,10 @@ components with their standard-library equivalents.
   auto-generated postings; respect `--permissive` for balance assignments with
   elided amounts (#2005).  Add `--check-in-file-order` to restore the
   pre-3.5 file-order accumulation for journals that depend on out-of-order
-  dated entries (#3186).
+  dated entries (#3186).  Verify date-ordered balance assertions after the
+  whole file is read so they account for transactions dated earlier but
+  written later in the file, fixing both spurious failures and assertions
+  that were silently accepted when they should have failed (#3218).
 
 - Fix balance assertions for accounts with only virtual postings (#1699), with
   quoted commodities (#904), with per-unit price annotations (#1125), with

--- a/src/textual.cc
+++ b/src/textual.cc
@@ -83,38 +83,14 @@ void instance_t::parse() {
       }
     } catch (const std::exception& err) {
       error_flag = true;
-
-      string current_context = error_context();
-
-      if (parent) {
-        std::list<instance_t*> instances;
-
-        for (instance_t* instance = parent; instance; instance = instance->parent)
-          instances.push_front(instance);
-
-        for (instance_t* instance : instances)
-          add_error_context(_f("In file included from %1%") % instance->context.location());
-      }
-      add_error_context(_f("While parsing file %1%") % context.location());
-
-      if (caught_signal != NONE_CAUGHT)
-        throw;
-
-      string err_context = error_context();
-      if (!err_context.empty())
-        std::cerr << err_context << '\n';
-
-      if (!current_context.empty())
-        std::cerr << current_context << '\n';
-
-      std::cerr << _("Error: ") << err.what() << '\n';
-      context.errors++;
-      if (!current_context.empty())
-        context.last = current_context + "\n" + err.what();
-      else
-        context.last = err.what();
+      report_parse_error(err);
     }
   }
+
+  // Every transaction in this file has now been parsed and finalized, so each
+  // account holds all of its postings.  Verify the balance assertions that
+  // were deferred during parsing, now in true date order (issue #3218).
+  verify_deferred_assertions();
 
   // After the file is fully parsed, propagate any epoch/year changes made
   // by year/Y directives back to the global state so that subsequent files
@@ -131,6 +107,38 @@ void instance_t::parse() {
 #endif // TIMELOG_SUPPORT
 
   TRACE_STOP(instance_parse, 1);
+}
+
+void instance_t::report_parse_error(const std::exception& err) {
+  string current_context = error_context();
+
+  if (parent) {
+    std::list<instance_t*> instances;
+
+    for (instance_t* instance = parent; instance; instance = instance->parent)
+      instances.push_front(instance);
+
+    for (instance_t* instance : instances)
+      add_error_context(_f("In file included from %1%") % instance->context.location());
+  }
+  add_error_context(_f("While parsing file %1%") % context.location());
+
+  if (caught_signal != NONE_CAUGHT)
+    throw;
+
+  string err_context = error_context();
+  if (!err_context.empty())
+    std::cerr << err_context << '\n';
+
+  if (!current_context.empty())
+    std::cerr << current_context << '\n';
+
+  std::cerr << _("Error: ") << err.what() << '\n';
+  context.errors++;
+  if (!current_context.empty())
+    context.last = current_context + "\n" + err.what();
+  else
+    context.last = err.what();
 }
 
 /// Return true if a Unicode codepoint is a whitespace character.

--- a/src/textual_internal.h
+++ b/src/textual_internal.h
@@ -144,6 +144,42 @@ public:
   time_log_t timelog; ///< Accumulates clock-in/out events for time tracking
 #endif
 
+  /**
+   * @brief A balance assertion whose verification is deferred until the whole
+   *        file has been parsed (issue #3218).
+   *
+   * The default (date-order) balance-assertion check is unsound when verified
+   * inline during a single forward pass: a transaction dated earlier but
+   * appearing later in the file has not been parsed yet, so its posting is
+   * missing from the account total.  We therefore record each assertion as it
+   * is parsed and verify them all in date order from verify_deferred_assertions()
+   * once every posting in the file is present.
+   *
+   * @c real_only and @c strip are captured at parse time because they depend on
+   * the account's posting history as it stood when the posting was parsed
+   * (e.g. the virtual-only-history rule of #1699); the remaining fields
+   * reproduce the exact parse-time error context if the assertion fails.
+   *
+   * The @c post pointer is safe to dereference at verification time because a
+   * record is discarded (see xact_directive()) if its transaction fails to
+   * finalize -- the only case in which the posting would be destroyed.  Every
+   * surviving record therefore belongs to a transaction the journal owns.
+   */
+  struct deferred_assertion_t {
+    post_t* post;        ///< The posting carrying the assertion.
+    amount_t amt;        ///< The asserted target balance.
+    bool strip;          ///< Whether to strip lot annotations before comparing.
+    bool real_only;      ///< Whether only real postings count (captured at parse time).
+    std::size_t linenum; ///< Source line of the posting (for error context).
+    std::string buf;     ///< The posting line text (for error context).
+    std::size_t beg;     ///< Byte offset of the assertion amount within @c buf.
+    std::size_t len;     ///< Length of the posting line (for error context).
+  };
+  /// Balance assertions in this file awaiting date-order verification (#3218).
+  /// A vector so xact_directive() can drop the trailing records of a
+  /// transaction that fails to finalize.
+  std::vector<deferred_assertion_t> deferred_assertions;
+
   instance_t(parse_context_stack_t& _context_stack, parse_context_t& _context,
              instance_t* _parent = nullptr, const bool _no_assertions = false,
              const hash_type_t _hash_type = NO_HASHES)
@@ -186,6 +222,15 @@ public:
 
   /// @brief Main parse loop: reads lines until EOF, dispatching each to read_next_directive().
   void parse();
+
+  /// @brief Report a parse-time exception to stderr with full source context
+  ///        and record it in the parse context's error count.  Shared by the
+  ///        main parse loop and verify_deferred_assertions().
+  void report_parse_error(const std::exception& err);
+
+  /// @brief Verify every deferred balance assertion in date order, now that
+  ///        the whole file is parsed and all postings are present (#3218).
+  void verify_deferred_assertions();
 
   /**
    * @brief Read the next line from the input stream into context.linebuf.

--- a/src/textual_xacts.cc
+++ b/src/textual_xacts.cc
@@ -342,18 +342,29 @@ void instance_t::period_xact_directive(char* line) {
 xact_t* instance_t::xact_directive(char* line, std::streamsize len, xact_t* previous_xact) {
   TRACE_START(xacts, 2, "Time spent handling transactions:");
 
-  if (xact_t* xact = parse_xact(line, len, top_account(), previous_xact)) {
-    unique_ptr<xact_t> manager(xact);
+  // parse_xact() appends a deferred-assertion record (#3218) for each balance
+  // assertion it parses.  If the transaction is then rejected or fails to
+  // finalize, its postings are destroyed, so drop those trailing records to
+  // keep every surviving record's post pointer valid.
+  const std::size_t saved_assertions = deferred_assertions.size();
+  try {
+    if (xact_t* xact = parse_xact(line, len, top_account(), previous_xact)) {
+      unique_ptr<xact_t> manager(xact);
 
-    if (context.journal->add_xact(xact)) {
-      context.count++;
-      return manager.release(); // it's owned by the journal now
+      if (context.journal->add_xact(xact)) {
+        context.count++;
+        return manager.release(); // it's owned by the journal now
+      }
+      // It's perfectly valid for the journal to reject the xact, which it
+      // will do if the xact has no substantive effect (for example, a
+      // checking xact, all of whose postings have null amounts).
+      deferred_assertions.resize(saved_assertions);
+    } else {
+      throw parse_error(_("Failed to parse transaction"));
     }
-    // It's perfectly valid for the journal to reject the xact, which it
-    // will do if the xact has no substantive effect (for example, a
-    // checking xact, all of whose postings have null amounts).
-  } else {
-    throw parse_error(_("Failed to parse transaction"));
+  } catch (...) {
+    deferred_assertions.resize(saved_assertions);
+    throw;
   }
 
   TRACE_STOP(xacts, 2);
@@ -379,6 +390,28 @@ void detail::parse_amount_expr(std::istream& in, scope_t& scope, post_t& post, a
 }
 
 /**
+ * Decide whether a posting's balance assertion/assignment counts only real
+ * postings.  A real posting uses real_only=true so that the real and virtual
+ * balances of an account can be asserted independently (#543).  Exception: if
+ * the account has no prior real postings at all, fall back to the combined
+ * (real + virtual) total so that patterns like setting up an account with a
+ * virtual balance assignment and then settling with a real posting remain
+ * assertable (#1699).
+ *
+ * The decision depends on the account's posting history as it stood when the
+ * posting was parsed, so deferred assertions (#3218) capture this value at
+ * parse time and replay it during verify_deferred_assertions().
+ */
+static bool posting_real_only(const post_t* post) {
+  if (post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG))
+    return false;
+  for (const post_t* p : post->account->posts)
+    if (!p->has_flags(POST_VIRTUAL | POST_IS_TIMELOG))
+      return true;
+  return false;
+}
+
+/**
  * Compute the difference between the assigned/asserted amount and the
  * current account balance, subtracting amounts from previous posts to
  * the same account in the current transaction.
@@ -389,24 +422,7 @@ void detail::parse_amount_expr(std::istream& in, scope_t& scope, post_t& post, a
  */
 static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t* xact,
                                       bool strip_annotations, parse_context_t& context) {
-  // A real posting uses real_only=true so that the real and virtual balances
-  // of an account can be asserted independently (#543).  Exception: if the
-  // account has no prior real postings at all, fall back to the combined
-  // (real + virtual) total so that patterns like setting up an account with
-  // a virtual balance assignment and then settling with a real posting
-  // remain assertable (#1699).
-  bool real_only;
-  if (!post->has_flags(POST_VIRTUAL | POST_IS_TIMELOG)) {
-    real_only = false;
-    for (const post_t* p : post->account->posts) {
-      if (!p->has_flags(POST_VIRTUAL | POST_IS_TIMELOG)) {
-        real_only = true;
-        break;
-      }
-    }
-  } else {
-    real_only = false;
-  }
+  bool real_only = posting_real_only(post);
   value_t account_total;
   bool use_file_order = (context.journal && context.journal->check_in_file_order) ||
                         (item_t::use_aux_date && !post->aux_date());
@@ -477,6 +493,75 @@ static balance_t compute_balance_diff(const amount_t& amt, post_t* post, xact_t*
   DEBUG("post.assign", "line " << context.linenum << ": " << "diff = " << diff);
 
   return diff;
+}
+
+void instance_t::verify_deferred_assertions() {
+  for (const deferred_assertion_t& da : deferred_assertions) {
+    post_t* post = da.post;
+    const amount_t& amt(da.amt);
+
+    // Sum every posting to this account that falls on or before this posting
+    // in (date, file-sequence) order, excluding the posting itself (subtracted
+    // separately below, mirroring the inline check).  This is the account
+    // balance as of this posting in true date order, now that every posting in
+    // the file is present.  Same-date postings keep file order via the
+    // sequence tie-break, so chronological journals behave exactly as before;
+    // only earlier-dated transactions appearing later in the file -- invisible
+    // to the inline check -- now contribute (issue #3218).
+    post_t::compare_by_date_and_sequence in_order;
+    value_t account_total;
+    for (post_t* p : post->account->posts) {
+      if (p == post || in_order(post, p))
+        continue; // the posting itself, or a posting that sorts after it
+      if (da.real_only && p->has_flags(POST_VIRTUAL))
+        continue;
+      if (!p->amount.is_null())
+        add_or_set_value(account_total, p->amount);
+    }
+    if (da.strip)
+      account_total = account_total.strip_annotations(keep_details_t());
+
+    balance_t diff = amt;
+    switch (account_total.type()) {
+    case value_t::AMOUNT:
+      diff -= account_total.as_amount().reduced();
+      break;
+    case value_t::BALANCE:
+      diff -= account_total.as_balance();
+      break;
+    default:
+      break;
+    }
+
+    // If amt has a commodity, restrict balancing to that.  Otherwise it is the
+    // blanket '0' and every commodity must be zero.
+    if (amt.has_commodity()) {
+      optional<amount_t> wanted_commodity = diff.commodity_amount(amt.commodity());
+      if (!wanted_commodity)
+        diff = amt - amt; // this is '0' with the correct commodity.
+      else
+        diff = *wanted_commodity;
+    }
+
+    amount_t post_amt(da.strip ? post->amount.reduced().strip_annotations(keep_details_t())
+                               : post->amount.reduced());
+    diff -= post_amt;
+
+    if (!diff.is_zero()) {
+      balance_t tot = da.strip ? (-diff + amt).strip_annotations(keep_details_t()) : (-diff + amt);
+      // Reproduce the parse-time error context (file, line, posting, caret) so
+      // the diagnostic is identical to an inline balance-assertion failure.
+      context.linenum = da.linenum;
+      try {
+        add_error_context(_("While parsing posting:"));
+        add_error_context(line_context(da.buf, da.beg, da.len));
+        throw_(parse_error, _f("Balance assertion off by %1% (expected to see %2%)") %
+                                diff.to_string() % tot.to_string());
+      } catch (const std::exception& err) {
+        report_parse_error(err);
+      }
+    }
+  }
 }
 
 /*--- Posting Parsing ---*/
@@ -806,7 +891,24 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
         // (the behavior that bug #1055 depends on).
         bool strip = !amt.has_annotation();
 
-        if (!is_uuid_dup) {
+        // A balance ASSERTION in the default mode cannot be verified yet: the
+        // running account total is filtered by date, but a transaction dated
+        // earlier and appearing later in the file has not been parsed, so its
+        // posting is still missing.  Defer the assertion and verify it in date
+        // order once the whole file is read (issue #3218).  Balance ASSIGNMENTS
+        // are computed inline (their amount feeds transaction balancing), and
+        // --check-in-file-order and --effective keep their own ordering and are
+        // also checked inline.  UUID duplicates are skipped entirely (#1771).
+        bool defer_assertion = !is_uuid_dup && !post->amount.is_null() &&
+                               !(context.journal && context.journal->check_in_file_order) &&
+                               !item_t::use_aux_date;
+
+        if (defer_assertion) {
+          if (!no_assertions)
+            deferred_assertions.push_back({post.get(), amt, strip, posting_real_only(post.get()),
+                                           context.linenum, buf, static_cast<std::size_t>(beg),
+                                           static_cast<std::size_t>(len)});
+        } else if (!is_uuid_dup) {
           DEBUG("post.assign", "line " << context.linenum << ": "
                                        << "post amount = " << post->amount
                                        << " (is_zero = " << post->amount.is_zero() << ")");
@@ -870,7 +972,7 @@ post_t* instance_t::parse_post(char* line, std::streamsize len, account_t* accou
             }
             post->add_flags(POST_CALCULATED);
           } else {
-            // balance assertion
+            // balance assertion (inline: --check-in-file-order or --effective)
             amount_t post_amt(strip ? post->amount.reduced().strip_annotations(keep_details_t())
                                     : post->amount.reduced());
             diff -= post_amt;

--- a/test/regress/3218.test
+++ b/test/regress/3218.test
@@ -1,0 +1,61 @@
+; Regression test for issue #3218: balance assertions must be verified in
+; date order, not in the order the transactions happen to appear in the file.
+;
+; Before the fix each assertion was checked inline as its posting was parsed,
+; so a transaction dated earlier but written later in the file had not been
+; read yet and its posting was missing from the running account total.  This
+; produced two opposite symptoms, both demonstrated below:
+;
+;   * spurious "off by" failures, when the not-yet-seen posting would have
+;     satisfied the assertion (3218a.dat); and
+;
+;   * silently accepted assertions that a complete date-ordered total would
+;     have rejected (3218b.dat).
+;
+; Both data files list a 2026-05-13 transaction (carrying the assertion)
+; before the 2026-05-12 transaction it depends on.  In date order the running
+; balance of Assets:Checking is EUR 1.00 on 05-12 and EUR 2.00 on 05-13.
+
+; 3218a.dat asserts "= EUR 2.00", which is correct in date order, so the
+; default report now succeeds even though the transactions are newest-first.
+test -f $sourcepath/test/regress/3218a.dat bal
+                   0  Assets
+           EUR -2.00    Cash
+            EUR 2.00    Checking
+--------------------
+                   0
+end test
+
+; --check-in-file-order restores the pre-3.5 file-order behaviour: the
+; 2026-05-13 posting is checked before the 05-12 deposit it relies on and so
+; sees only its own EUR 1.00, failing the assertion.
+test -f $sourcepath/test/regress/3218a.dat --check-in-file-order bal -> 1
+__ERROR__
+While parsing file "$sourcepath/test/regress/3218a.dat", line 2:
+While parsing posting:
+  Assets:Checking          EUR 1.00 = EUR 2.00
+                                      ^^^^^^^^
+Error: Balance assertion off by EUR 1.00 (expected to see EUR 1.00)
+end test
+
+; 3218b.dat uses the same layout but asserts "= EUR 1.00", which is wrong once
+; the backdated 05-12 deposit is included.  Date order now catches it.
+test -f $sourcepath/test/regress/3218b.dat bal -> 1
+__ERROR__
+While parsing file "$sourcepath/test/regress/3218b.dat", line 2:
+While parsing posting:
+  Assets:Checking          EUR 1.00 = EUR 1.00
+                                      ^^^^^^^^
+Error: Balance assertion off by EUR -1.00 (expected to see EUR 2.00)
+end test
+
+; The same journal under --check-in-file-order slips through unchecked -- the
+; exact bug #3218 fixes.  In file order the assertion is verified before the
+; backdated deposit is read, sees EUR 1.00, and is wrongly accepted.
+test -f $sourcepath/test/regress/3218b.dat --check-in-file-order bal
+                   0  Assets
+           EUR -2.00    Cash
+            EUR 2.00    Checking
+--------------------
+                   0
+end test

--- a/test/regress/3218a.dat
+++ b/test/regress/3218a.dat
@@ -1,0 +1,7 @@
+2026-05-13 * Newer, written first
+    Assets:Checking          EUR 1.00 = EUR 2.00
+    Assets:Cash
+
+2026-05-12 * Older, written second
+    Assets:Checking          EUR 1.00
+    Assets:Cash

--- a/test/regress/3218b.dat
+++ b/test/regress/3218b.dat
@@ -1,0 +1,7 @@
+2026-05-13 * Newer, written first
+    Assets:Checking          EUR 1.00 = EUR 1.00
+    Assets:Cash
+
+2026-05-12 * Older, written second
+    Assets:Checking          EUR 1.00
+    Assets:Cash


### PR DESCRIPTION
## Summary

Balance assertions are now verified in **date order** even when transactions
appear out of order in the file. Fixes #3218.

The 3.5 series filters balance assertions by date (#2005, #847, #1092) so an
assertion sees only postings dated on or before its own date. That filtering
was performed **inline as each posting was parsed**, which is unsound: a
transaction dated earlier but written *later* in the file has not been read
yet, so its posting is missing from the running total.

The behaviour was order-dependent and wrong in both directions:

- a **spurious failure** when the not-yet-seen posting would have satisfied
  the assertion (the issue's first example); and
- a **silently accepted** assertion that a complete date-ordered total would
  have rejected (the issue's third example).

## Fix

Defer each balance assertion (in the default date-order mode) and verify them
all from `instance_t::verify_deferred_assertions()` once the whole file is
parsed and every posting is present, ordering postings by `(date, file
sequence)`. Same-date postings keep file order, so chronological journals are
completely unaffected — only genuinely out-of-order entries change.

- Balance **assignments** stay inline (their computed amount feeds transaction
  balancing).
- `--check-in-file-order` (#3186) and `--effective` keep their own inline
  ordering, unchanged.
- `real_only`/`strip` are captured at parse time because they depend on the
  account's posting history as it stood then (e.g. the virtual-only-history
  rule of #1699); the recorded posting line reproduces the **identical**
  parse-time diagnostic on failure.
- A deferred record is dropped if its transaction fails to finalize, so the
  stored posting pointer is always valid at verification time.

`report_parse_error()` and `posting_real_only()` were extracted so the deferred
verification reuses the existing error reporting and real/virtual decision
unchanged.

## Tests

`test/regress/3218.test` (+ `3218a.dat`, `3218b.dat`) covers both symptoms with
mirror-image journals that list the asserting `2026-05-13` transaction before
the `2026-05-12` deposit it depends on:

| journal | default mode | `--check-in-file-order` |
|---|---|---|
| `3218a.dat` (asserts the true date-order balance) | **passes** (was a spurious failure) | fails |
| `3218b.dat` (asserts a file-order-only balance)   | **fails** (was silently accepted) | passes |

Full suite: 4360/4360 passing; `clang-format` clean.
