### PR TITLE
Fix #3227: keep commodity-swap cost in the base currency

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -752,24 +752,29 @@ bool xact_base_t::finalize() {
               DEBUG("xact.finalize", "Commodity swap to_cost = " << to_cost);
 
               // Calculate gain/loss in the base commodity
-              if (amount_t gain_loss = from_cost - to_cost) {
-                DEBUG("xact.finalize", "Commodity swap gain_loss = " << gain_loss);
-                if (gain_loss.has_commodity())
-                  gain_loss.in_place_roundto(static_cast<int>(gain_loss.commodity().precision()) +
-                                             static_cast<int>(post->amount.precision()));
-                gain_loss.in_place_round();
-                DEBUG("xact.finalize", "Commodity swap gain_loss rounds to = " << gain_loss);
+              amount_t gain_loss = from_cost - to_cost;
+              if (gain_loss.has_commodity())
+                gain_loss.in_place_roundto(static_cast<int>(gain_loss.commodity().precision()) +
+                                           static_cast<int>(post->amount.precision()));
+              gain_loss.in_place_round();
+              DEBUG("xact.finalize", "Commodity swap gain_loss rounds to = " << gain_loss);
 
-                if (post->must_balance())
-                  add_or_set_value(balance, gain_loss.reduced());
+              if (gain_loss && post->must_balance())
+                add_or_set_value(balance, gain_loss.reduced());
 
-                // Modify the post->cost to reflect the adjusted value
-                *post->cost = to_cost + gain_loss;
+              // Always rewrite the posting's cost into the common base
+              // currency, even when the gain/loss is zero (i.e. both
+              // commodities have the same base-currency value).  The
+              // base-currency cost is `to_cost + gain_loss`, which equals
+              // `from_cost`.  Skipping this assignment in the zero-gain case
+              // left the cost denominated in the secondary commodity, so
+              // `--basis` reported the lot in that commodity rather than the
+              // base currency -- or produced no output at all when the two
+              // sides cancelled (#3227).
+              *post->cost = to_cost + gain_loss;
 
-                DEBUG("xact.finalize", "added commodity swap gain_loss, balance = " << balance);
-              } else {
-                DEBUG("xact.finalize", "Commodity swap gain_loss would have displayed as zero");
-              }
+              DEBUG("xact.finalize",
+                    "commodity swap cost = " << *post->cost << ", balance = " << balance);
             }
           }
         }

--- a/test/regress/3227.test
+++ b/test/regress/3227.test
@@ -1,0 +1,54 @@
+; Regression test for GitHub issue #3227:
+; "Commodity Swaps Over a Common Base Currency: No Cost Basis Reported Under
+; Certain Circumstances"
+;
+; When two commodities are swapped over a common base currency and both legs
+; carry a base-currency lot price (e.g. BTC {$100} exchanged for ETH {$50}),
+; xact_base_t::finalize() rewrites the swapping leg's cost into that base
+; currency, so that --basis (-B) reports the lot's cost basis in dollars
+; rather than in the intermediate commodity.
+;
+; The rewrite was only performed when the computed gain/loss was non-zero.
+; When both sides had the *same* base-currency value the gain/loss was exactly
+; zero, the rewrite was skipped, and the cost was left denominated in the
+; secondary commodity.  Here 100 BTC at $100 is worth $10,000 and the 200 ETH
+; received at $50 is also worth $10,000, so a -B report showed the BTC lot's
+; basis as "200 ETH" instead of "$10,000.00" -- and a report spanning both
+; legs failed to reconcile, since one leg was in ETH and the other in dollars.
+;
+; The fix always rewrites the cost into the base currency, even when the
+; gain/loss rounds to zero (the base-currency cost has already been computed).
+
+D $1,000.00
+
+2001-01-01 Coinbase
+    Assets:Coinbase            100 BTC {$100} @ 2 ETH {$50}
+    Assets:Coinbase           -200 ETH {$50}
+
+; The BTC lot's cost basis is its dollar value, $10,000.00 -- not the 200 ETH
+; that were paid for it.  This is the specific regression from #3227.
+test bal --limit "commodity == 'BTC'" -B Assets
+          $10,000.00  Assets:Coinbase
+end test
+
+; The ETH leg was already reported in dollars; confirm it still is, so the two
+; legs are expressed in the same common base currency.
+test bal --limit "commodity == 'ETH'" -B Assets
+         $-10,000.00  Assets:Coinbase
+end test
+
+; Across the whole swap both legs are now denominated in dollars, so the
+; running cost-basis total returns to zero: the swap neither created nor
+; destroyed cost basis.
+test reg -B
+01-Jan-01 Coinbase              Assets:Coinbase          $10,000.00   $10,000.00
+                                Assets:Coinbase         $-10,000.00            0
+end test
+
+; The annotations round-trip unchanged: the fix only affects the derived cost,
+; not the stored amounts.
+test print
+2001/01/01 Coinbase
+    Assets:Coinbase                     100 BTC {$100.00} @ 2 ETH {$50.00}
+    Assets:Coinbase                     -200 ETH {$50.00}
+end test


### PR DESCRIPTION
## Summary

Fixes #3227. When two commodities are swapped over a common base currency
(§5.19, "Commodity swaps over common base currency") and **both** legs carry a
base-currency lot price, `xact_base_t::finalize()` rewrites the swapping leg's
cost into that base currency so that `--basis` (`-B`) reports the lot's cost
basis in the base currency rather than in the intermediate commodity.

That rewrite was guarded by `if (gain_loss)`, so it only ran when the two sides
had *different* base-currency values. When the values were equal — e.g.
`100 BTC {$100}` exchanged for `200 ETH {$50}`, both worth `$10,000` — the
gain/loss was exactly zero, the rewrite was skipped, and the cost was left
denominated in the secondary commodity (ETH).

```
$ ledger -f bad.dat --limit "commodity == 'BTC'" --basis balance Assets
             200 ETH  Assets:Coinbase      # before: basis reported in ETH
          $10,000.00  Assets:Coinbase      # after:  basis reported in dollars
```

A report spanning both legs also failed to reconcile (one leg in ETH, the other
in dollars), or produced no output at all when the two cancelled.

## Fix

Always rewrite the cost into the base currency; the base-currency value
(`to_cost + gain_loss`) is already computed and equals `from_cost`. The
gain/loss is still only added to the running balance when it is non-zero, so
transactions with a real gain or loss are byte-for-byte unchanged
(`test/baseline/feat-commodity_swap.test` still passes unchanged).

## Tests

`test/regress/3227.test` exercises the zero-gain swap and asserts the BTC and
ETH legs are both reported in dollars, that a register over both legs
reconciles to a zero running total, and that the annotations round-trip through
`print`. The test fails before the fix (BTC basis = `200 ETH`) and passes after.

The full baseline + regression suite (4342 tests) passes.

## Notes / out of scope

The issue also mentions two secondary observations:

- Annotating only the primary commodity (`100 BTC {$100} @ 2 ETH`, with no
  price on the ETH) still reports the cost in ETH. The documentation requires a
  price annotation on **both** the source and destination commodities, so this
  journal does not use the feature as specified; left unchanged.
- `--limit "commodity == 'ETH'" --basis` already reports the ETH leg in dollars
  (`$8,000.00`) on current `main`; no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
