### PR TITLE
Fix #3229: strip insecure RPATH from the Python module

### DIFF
--- a/cmake/SanitizeModuleRPath.cmake
+++ b/cmake/SanitizeModuleRPath.cmake
@@ -1,0 +1,94 @@
+# SanitizeModuleRPath.cmake - remove empty RPATH entries from the Python module.
+#
+# Invoked from src/CMakeLists.txt as a POST_BUILD step:
+#   cmake -DLEDGER_PYTHON_MODULE=<path> -P cmake/SanitizeModuleRPath.cmake
+#
+# Why this is needed (GitHub issue #3229, Debian bug #1138597):
+#
+# The ledger Python extension module is produced by copying the build-tree
+# libledger shared library and is installed with install(PROGRAMS ...).  Because
+# it is a plain file rather than an install(TARGETS ...) artifact, CMake never
+# rewrites its RPATH at install time.  The build-tree RPATH therefore survives
+# into the installed/packaged module -- and when CMAKE_INSTALL_RPATH is set (so
+# CMake can relocate the binary at install time) CMake pads the build-tree RPATH
+# with empty entries to reserve room for the longer install RPATH.  The result,
+# on a system whose dependencies live in the default library directories, is a
+# module whose DT_RUNPATH is a list of empty path elements ("::::::::").
+#
+# ELF dynamic linkers interpret an empty RPATH/RUNPATH element as the current
+# working directory, so such a module searches CWD before the system library
+# directories.  An attacker who can place a shared library in the working
+# directory of a process that imports ledger can then have it loaded ahead of
+# the genuine system libraries (CWE-426 / CWE-427).
+#
+# We remove *only* the empty elements, leaving any genuine directories intact.
+# That is important on systems that install dependencies outside the default
+# search path (e.g. Nix, Homebrew, or a custom --prefix), where the module
+# legitimately needs those directories on its RPATH to find Boost, GMP, Python,
+# etc.  Stripping the RPATH wholesale would break it there.
+
+if(NOT DEFINED LEDGER_PYTHON_MODULE)
+  message(FATAL_ERROR "LEDGER_PYTHON_MODULE must be defined")
+endif()
+
+if(NOT EXISTS "${LEDGER_PYTHON_MODULE}")
+  return()
+endif()
+
+# Read the current RPATH/RUNPATH.  We only need to *read* it; the rewrite below
+# uses CMake's own file(RPATH_*) commands, so no patchelf/chrpath is required.
+find_program(_readelf NAMES readelf llvm-readelf)
+find_program(_objdump NAMES objdump llvm-objdump)
+
+set(_dyn "")
+if(_readelf)
+  execute_process(COMMAND "${_readelf}" -d "${LEDGER_PYTHON_MODULE}"
+    OUTPUT_VARIABLE _dyn ERROR_QUIET)
+elseif(_objdump)
+  execute_process(COMMAND "${_objdump}" -x "${LEDGER_PYTHON_MODULE}"
+    OUTPUT_VARIABLE _dyn ERROR_QUIET)
+else()
+  # Without a reader we cannot inspect the RPATH safely; leave the module alone.
+  message(STATUS
+    "SanitizeModuleRPath: no readelf/objdump found; skipping RPATH check")
+  return()
+endif()
+
+# Find the RPATH/RUNPATH line and capture the bracketed (readelf) or trailing
+# (objdump) path list.
+set(_rpath "")
+set(_found FALSE)
+string(REPLACE "\n" ";" _lines "${_dyn}")
+foreach(_line IN LISTS _lines)
+  if(_line MATCHES "\\((RUNPATH|RPATH)\\).*\\[(.*)\\]")          # readelf
+    set(_rpath "${CMAKE_MATCH_2}")
+    set(_found TRUE)
+    break()
+  elseif(_line MATCHES "^[ \t]*(RUNPATH|RPATH)[ \t]+(.+)$")      # objdump
+    string(STRIP "${CMAKE_MATCH_2}" _rpath)
+    set(_found TRUE)
+    break()
+  endif()
+endforeach()
+
+if(NOT _found)
+  return()                       # no RPATH/RUNPATH at all -- nothing to do
+endif()
+
+# Drop empty elements by collapsing runs of ':' and trimming leading/trailing
+# ones.  Filesystem paths do not contain ':', so this is unambiguous.
+set(_cleaned "${_rpath}")
+string(REGEX REPLACE ":+" ":" _cleaned "${_cleaned}")
+string(REGEX REPLACE "^:" "" _cleaned "${_cleaned}")
+string(REGEX REPLACE ":$" "" _cleaned "${_cleaned}")
+
+if(_cleaned STREQUAL "")
+  # Every element was empty: remove the RPATH/RUNPATH entirely.
+  file(RPATH_REMOVE FILE "${LEDGER_PYTHON_MODULE}")
+elseif(NOT _cleaned STREQUAL _rpath)
+  # Some empty elements were interleaved with real directories: keep the real
+  # directories, drop the empties.  NEW_RPATH is shorter than OLD_RPATH, so the
+  # in-place edit always fits.
+  file(RPATH_CHANGE FILE "${LEDGER_PYTHON_MODULE}"
+    OLD_RPATH "${_rpath}" NEW_RPATH "${_cleaned}")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -259,6 +259,26 @@ if(USE_PYTHON)
       TARGET libledger POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
       $<TARGET_FILE:libledger> "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}")
+
+    # Security fix for issue #3229 / Debian #1138597: the module above is a copy
+    # of the build-tree libledger installed via install(PROGRAMS ...), so CMake
+    # never rewrites its RPATH at install time the way it does for
+    # install(TARGETS ...).  The build-tree RPATH -- which CMake pads with empty
+    # entries to reserve room for the longer install RPATH -- would otherwise
+    # leak into the installed module, and ELF loaders treat an empty
+    # RPATH/RUNPATH element as the current working directory.  Strip the RPATH
+    # from the copied module so the installed artifact cannot be hijacked by a
+    # library planted in CWD.  ELF-only: macOS (Mach-O) and Windows (PE) use
+    # different mechanisms and are not affected.
+    if(UNIX AND NOT APPLE)
+      add_custom_command(
+        TARGET libledger POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+          "-DLEDGER_PYTHON_MODULE=${CMAKE_BINARY_DIR}/${_ledger_python_module_name}"
+          -P "${CMAKE_SOURCE_DIR}/cmake/SanitizeModuleRPath.cmake"
+        COMMENT "Stripping insecure RPATH from ledger Python module (#3229)")
+    endif()
+
     # Use PROGRAMS (not FILES) so the installed Python extension module has
     # executable permissions (mode 755).  Fedora and other distributions
     # require dynamic libraries to be installed with the executable bit set.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,18 @@ if(Python_EXECUTABLE)
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     set_tests_properties(RegressPyTest_513
       PROPERTIES ENVIRONMENT "TZ=${Ledger_TEST_TIMEZONE};PYTHONPATH=.")
+
+    # Regression test for GitHub issue #3229 (Debian #1138597): the ledger
+    # Python extension module must not carry an RPATH/RUNPATH with empty
+    # elements, which ELF dynamic linkers treat as the current working
+    # directory and which therefore permit library-search-path hijacking.  The
+    # check is ELF-specific, so it is skipped on macOS (Mach-O) and Windows
+    # (PE), which use different mechanisms and are not affected.
+    if(UNIX AND NOT APPLE)
+      add_test(NAME RegressPyTest_3229
+        COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/regress/3229.py
+        "${PROJECT_BINARY_DIR}/ledger${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    endif()
   endif()
 endif()
 

--- a/test/regress/3229.py
+++ b/test/regress/3229.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Regression test for GitHub issue #3229 (Debian bug #1138597):
+#
+# The ledger Python extension module is built by copying the build-tree
+# libledger shared library and is installed with install(PROGRAMS ...).  Because
+# it is not an install(TARGETS ...) artifact, CMake never sanitizes its RPATH at
+# install time, so the build-tree RPATH leaked through into the installed
+# module.  When CMAKE_INSTALL_RPATH is set, CMake pads that build-tree RPATH with
+# empty entries to reserve space for the (longer) install RPATH, producing a
+# DT_RUNPATH that is a list of empty path elements, e.g. "[:::::::::::::]".
+#
+# ELF dynamic linkers interpret an empty RPATH/RUNPATH element as the current
+# working directory.  A module with such an entry therefore searches CWD ahead
+# of the system library directories, which permits library-search-path
+# hijacking (CWE-426 / CWE-427).
+#
+# This test inspects the built Python module and fails if any of its RPATH or
+# RUNPATH dynamic entries contains an empty path element.  After the fix the
+# module carries no RPATH/RUNPATH at all, so the test passes.
+#
+# The check is only meaningful on ELF platforms; the CMake test wiring guards it
+# with "UNIX AND NOT APPLE".
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+
+def read_rpath_entries(path):
+    """Return a list of (tag, value) RPATH/RUNPATH dynamic entries for an ELF
+    file, or None if no inspection tool is available."""
+    if shutil.which("readelf"):
+        out = subprocess.run(
+            ["readelf", "-d", path], capture_output=True, text=True
+        ).stdout
+        # e.g. "0x...(RUNPATH)  Library runpath: [:::::::]"
+        pattern = re.compile(r"\((RUNPATH|RPATH)\).*\[(.*)\]")
+        return [
+            (m.group(1), m.group(2))
+            for m in (pattern.search(line) for line in out.splitlines())
+            if m
+        ]
+    if shutil.which("objdump"):
+        out = subprocess.run(
+            ["objdump", "-x", path], capture_output=True, text=True
+        ).stdout
+        # e.g. "  RUNPATH              :::::::"
+        pattern = re.compile(r"^\s*(RUNPATH|RPATH)\s+(.*)$")
+        return [
+            (m.group(1), m.group(2).strip())
+            for m in (pattern.match(line) for line in out.splitlines())
+            if m
+        ]
+    return None
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: 3229.py <path-to-ledger-python-module>", file=sys.stderr)
+        return 2
+
+    module = sys.argv[1]
+
+    if not os.path.isfile(module):
+        # The module is expected to exist whenever this test runs (it is only
+        # registered when the Python bindings are built).  A missing file is a
+        # real problem, not a reason to pass silently.
+        print("FAIL: ledger Python module not found: %s" % module)
+        return 1
+
+    entries = read_rpath_entries(module)
+    if entries is None:
+        # Without readelf/objdump we cannot inspect the binary; skip rather than
+        # report a spurious failure.  CI Linux runners ship binutils.
+        print("SKIP: neither readelf nor objdump is available", file=sys.stderr)
+        return 0
+
+    # An empty element (the whole value empty, a leading/trailing ':', or "::")
+    # is the vulnerability: the loader treats it as the current directory.
+    insecure = [
+        (tag, value) for tag, value in entries if "" in value.split(":")
+    ]
+
+    if insecure:
+        print(
+            "FAIL: ledger Python module %s has insecure RPATH/RUNPATH entries"
+            % module
+        )
+        for tag, value in insecure:
+            print("    %s = [%s]" % (tag, value))
+        print(
+            "An empty RPATH/RUNPATH element is searched as the current working "
+            "directory and permits library-search-path hijacking."
+        )
+        return 1
+
+    if entries:
+        for tag, value in entries:
+            print("OK: %s = [%s] (no empty elements)" % (tag, value))
+    else:
+        print("OK: %s carries no RPATH/RUNPATH" % module)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes #3229 (Debian bug [#1138597](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1138597)).

The installed `ledger` Python extension module carries a `RUNPATH` made up
entirely of **empty** path elements:

```
RUNPATH [:::::::::::::::]
```

ELF dynamic linkers interpret an empty `RPATH`/`RUNPATH` element as the **current
working directory**, so the module searches CWD ahead of the system library
directories. An attacker who can place a shared library in the working directory
of a process that imports `ledger` can have it loaded in place of the genuine
system library — a library-search-path hijack (CWE-426 / CWE-427).

## Root cause

The Python module is produced by **copying** the build-tree `libledger` shared
library and installing it with `install(PROGRAMS ...)`:

```cmake
add_custom_command(TARGET libledger POST_BUILD
  COMMAND ${CMAKE_COMMAND} -E copy_if_different
  $<TARGET_FILE:libledger> "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}")
install(PROGRAMS "${CMAKE_BINARY_DIR}/${_ledger_python_module_name}" ...)
```

CMake's install-time RPATH sanitisation runs only for `install(TARGETS ...)`
artifacts, never for a plain file installed with `install(PROGRAMS ...)`. So the
**build-tree** RPATH survives into the installed module. And because
`CMAKE_INSTALL_RPATH` is set (so the `ledger` binary can find `libledger.so`),
CMake pads the build-tree RPATH with empty entries to reserve room for rewriting
it to the longer install RPATH in place — padding that, for this module, is never
rewritten and ships as a list of empty elements.

The `ledger` executable and `libledger.so` are **not** affected: they are
installed via `install(TARGETS ...)`, so CMake rewrites their RPATH at install
time.

## Fix

A `POST_BUILD` step (`cmake/SanitizeModuleRPath.cmake`) removes the **empty**
elements from the copied module's RPATH:

- reads the current `RPATH`/`RUNPATH` with `readelf` (falling back to `objdump`);
- if every element is empty → `file(RPATH_REMOVE)`;
- if empties are interleaved with real directories → `file(RPATH_CHANGE)` to keep
  the real directories and drop the empties;
- otherwise leaves it untouched.

Only the empty elements are removed. Genuine directories are **preserved**,
because on systems that install dependencies outside the default search path
(Nix, Homebrew, a custom `--prefix`) the module legitimately needs them on its
RPATH to find Boost, GMP, Python, etc. The rewrite uses CMake's own
`file(RPATH_*)` commands, so no `patchelf`/`chrpath` is required.

The change is ELF-only (`UNIX AND NOT APPLE`); macOS (Mach-O) and Windows (PE)
use different mechanisms and are not affected.

## Regression test

`RegressPyTest_3229` (`test/regress/3229.py`) inspects the built module's dynamic
section with `readelf` (falling back to `objdump`) and fails if any
`RPATH`/`RUNPATH` entry contains an empty element. It is registered only on ELF
platforms and runs in the Ubuntu CI job (which builds with `-DUSE_PYTHON=ON`).
Before the fix the module's `DT_RUNPATH` is a list of empty elements and the test
fails; after the fix no empty element remains and the test passes.

## Verification

- Full `cmake` configure + build + `ctest` (4362 tests, `USE_PYTHON=ON`) pass with
  the change applied.
- The test's RPATH parsing/detection and the CMake cleaning logic were both
  exercised end-to-end against synthetic `readelf` output for the buggy
  (`[:::::]`), mixed real+empty (`[/nix/store/a::/nix/store/b]`), benign
  (`[/usr/lib]`), and clean (no RPATH) cases.
- The native-ELF before/after check is performed by the Ubuntu CI build job; the
  Nix Flake job confirms that legitimate (`/nix/store`) RPATH entries are
  preserved.
