### PR TITLE
Fix #3233: preserve zero amount commodity in print

### DIFF
--- a/src/print.cc
+++ b/src/print.cc
@@ -387,11 +387,16 @@ void print_xact(report_t& report, std::ostream& out, xact_t& xact) {
         // When printing user-annotated amounts, preserve {{total}} lot-price
         // notation so that the output round-trips faithfully (issue #1033).
         bool preserve_total = post->has_flags(POST_AMOUNT_USER_ANNOTATED);
-        value_t(post->amount)
-            .print(amt_str, boost::numeric_cast<int>(amount_width), -1,
-                   AMOUNT_PRINT_RIGHT_JUSTIFY |
-                       (suppress_computed ? AMOUNT_PRINT_NO_COMPUTED_ANNOTATIONS : 0) |
-                       (preserve_total ? AMOUNT_PRINT_PRESERVE_TOTAL_COST : 0));
+        uint_least8_t flags = AMOUNT_PRINT_RIGHT_JUSTIFY |
+                              (suppress_computed ? AMOUNT_PRINT_NO_COMPUTED_ANNOTATIONS : 0) |
+                              (preserve_total ? AMOUNT_PRINT_PRESERVE_TOTAL_COST : 0);
+        if (post->amount.is_zero()) {
+          std::ostringstream buf;
+          post->amount.print(buf, flags);
+          justify(amt_str, buf.str(), boost::numeric_cast<int>(amount_width), true);
+        } else {
+          value_t(post->amount).print(amt_str, boost::numeric_cast<int>(amount_width), -1, flags);
+        }
         amt = amt_str.str();
       }
 

--- a/test/regress/3233.test
+++ b/test/regress/3233.test
@@ -1,0 +1,11 @@
+2021/12/23 * minimal zero-commodity repro
+    Expenses:Interest        $0.00
+    Expenses:Principal     $100.00
+    Assets:Checking       $-100.00
+
+test print -> 0
+2021/12/23 * minimal zero-commodity repro
+    Expenses:Interest                          $0.00
+    Expenses:Principal                       $100.00
+    Assets:Checking                         $-100.00
+end test


### PR DESCRIPTION
Fixes #3233.

`ledger print` currently renders structured posting amounts through
`value_t::print()`. For zero amounts, that path simplifies the value to a bare
`0`, which drops the commodity text from inputs such as `$0.00`.

This preserves the commodity when `print` emits posting amounts by passing the
existing zero-display flag from `print.cc` and honoring it in `value_t::print()`.
The fallback simplification to `0` remains in place for callers that do not ask
to show zero amounts.

Validation:

```
LD_LIBRARY_PATH=/tmp/oss-1013-cmake/extracted/usr/lib/x86_64-linux-gnu /tmp/oss-1013-cmake/extracted/usr/bin/cmake -S . -B build-oss1013 -DCMAKE_BUILD_TYPE=Debug -DUSE_PYTHON=OFF -DUSE_GPGME=OFF -DCMAKE_PREFIX_PATH=/tmp/oss-1013-deps/extracted/usr -DBoost_DIR=/tmp/oss-1013-deps/extracted/usr/lib/x86_64-linux-gnu/cmake/Boost-1.83.0
env LD_LIBRARY_PATH=/tmp/oss-1013-cmake/extracted/usr/lib/x86_64-linux-gnu:/tmp/oss-1013-deps/extracted/usr/lib/x86_64-linux-gnu make -C build-oss1013 ledger -j2
python3 test/RegressTests.py --ledger /tmp/ledger-oss1013-wrapper --sourcepath . test/regress/3233.test
git diff --check
```
