### PR TITLE
Fix #3232: --exchange into a lot-price commodity reprices every leg

### DIFF
--- a/src/xact.cc
+++ b/src/xact.cc
@@ -777,6 +777,27 @@ bool xact_base_t::finalize() {
                     "commodity swap cost = " << *post->cost << ", balance = " << balance);
             }
           }
+        } else if (post->has_flags(POST_COST_CALCULATED) && !post->has_flags(POST_COST_VIRTUAL) &&
+                   !post->amount.annotation().has_flags(ANNOTATION_PRICE_FIXATED)) {
+          // Issue #3232: the posting acquires a commodity with a lot price
+          // whose commodity (e.g. C) differs from the cost commodity (e.g.
+          // B), and the cost was *inferred* from balancing the transaction's
+          // legs (POST_COST_CALCULATED) rather than written explicitly.
+          // exchange() above recorded the implied amount-to-cost rate
+          // (A -> B), but the declared lot price (A -> C) was never entered
+          // into the price history.  As a result a report repricing into C
+          // (`--exchange C`) could not chain B -> A -> C and silently fell
+          // back to mixed-commodity output.  Record the lot price so the
+          // valuation graph can traverse it, the same way an "@" cost would
+          // have.  This is restricted to inferred costs so that a lot's cost
+          // basis is never re-published as a spurious market price when the
+          // lot is later sold (an explicit "@" disposal).
+          commodity_pool_t::current_pool->exchange(
+              post->amount.commodity(), *post->amount.annotation().price,
+              datetime_t(post->date(), time_duration(0, 0, 0, 0)));
+          DEBUG("xact.finalize", "recorded inferred lot price "
+                                     << *post->amount.annotation().price << " for "
+                                     << post->amount.commodity().symbol() << " (#3232)");
         }
       } else {
         post->amount =

--- a/test/regress/3232.test
+++ b/test/regress/3232.test
@@ -1,0 +1,84 @@
+; Regression test for GitHub issue #3232:
+; "Unexpected --exchange Register Report Output When Lot Prices Are Specified"
+;
+; When a posting acquires a commodity with a lot price expressed in a third
+; commodity, e.g.
+;
+;     Assets:Brokerage    100 A {3 C}
+;     Assets:Brokerage   -200 B
+;
+; the transaction bakes in two exchange rates: balancing the two legs implies
+; 100 A == 200 B (so 1 A = 2 B), and the lot price declares 1 A = 3 C.
+; xact_base_t::finalize() recorded the first rate (A -> B) in the price
+; history but dropped the declared lot price (A -> C) whenever the cost
+; commodity (B) differed from the lot-price commodity (C) and the cost itself
+; was unannotated.
+;
+; As a result `--exchange A` and `--exchange B` repriced the register report
+; correctly, but `--exchange C` could not chain B -> A -> C, so the -200 B leg
+; was left unconverted and the report silently fell back to mixed-commodity
+; output -- as if --exchange had not been supplied at all.
+;
+; The fix records the declared lot price into the price history, exactly as an
+; explicit "@" cost would have, so the valuation graph can traverse it.
+
+2001-01-01 Per-unit lot price
+    Assets:PerUnit                         100 A {3 C}
+    Assets:PerUnit                        -200 B
+
+2001-01-02 Total lot price
+    Assets:Total                           100 A {{300 C}}
+    Assets:Total                          -200 B
+
+; The per-unit ({3 C}) and total ({{300 C}}) lot-price forms normalize to the
+; same stored per-unit annotation, so the fix applies identically to both.
+test print
+2001/01/01 Per-unit lot price
+    Assets:PerUnit                        100 A {C3}
+    Assets:PerUnit                            -200 B
+
+2001/01/02 Total lot price
+    Assets:Total                          100 A {C3}
+    Assets:Total                              -200 B
+end test
+
+; Repricing into A already worked: the implied 1 A = 2 B rate lets the -200 B
+; leg be expressed as -100 A, and the two legs cancel to zero.
+test reg --exchange A
+01-Jan-01 Per-unit lot price    Assets:PerUnit                100 A        100 A
+                                Assets:PerUnit               -100 A            0
+01-Jan-02 Total lot price       Assets:Total                  100 A        100 A
+                                Assets:Total                 -100 A            0
+end test
+
+; Repricing into B likewise worked.
+test reg --exchange B
+01-Jan-01 Per-unit lot price    Assets:PerUnit                200 B        200 B
+                                Assets:PerUnit               -200 B            0
+01-Jan-02 Total lot price       Assets:Total                  200 B        200 B
+                                Assets:Total                 -200 B            0
+end test
+
+; The regression: repricing into C (the lot-price commodity) must use the
+; baked-in rates -- 100 A == 300 C, and 200 B == 100 A == 300 C -- so both legs
+; convert to C and the running total returns to zero.  Previously the -200 B
+; leg was left unconverted.
+test reg --exchange C Assets:PerUnit
+01-Jan-01 Per-unit lot price    Assets:PerUnit                 C300         C300
+                                Assets:PerUnit                C-300            0
+end test
+
+; The total-price form ({{300 C}}) must behave identically.
+test reg --exchange C Assets:Total
+01-Jan-02 Total lot price       Assets:Total                   C300         C300
+                                Assets:Total                  C-300            0
+end test
+
+; The declared lot price now appears in the price history alongside the implied
+; A -> B rate; the A -> C edge is what lets the valuation graph chain B -> A -> C.
+test prices
+2001/01/01 A                 2 B
+2001/01/02 A                 2 B
+2001/01/01 A                  C3
+2001/01/02 A                  C3
+end test


### PR DESCRIPTION
## Summary

Fixes #3232. When a posting acquires a commodity with a lot price expressed in
a *third* commodity, the transaction bakes in two exchange rates at once:

```
2001-01-01 Exchange
    Assets:Brokerage    100 A {3 C}
    Assets:Brokerage   -200 B
```

Balancing the two legs implies `1 A = 2 B`, and the lot price declares
`1 A = 3 C`. `xact_base_t::finalize()` recorded the implied `A → B` rate in the
price history but **dropped the declared lot price `A → C`** whenever the
inferred cost commodity (`B`) differed from the lot-price commodity (`C`) and
the cost was unannotated.

As a result `--exchange A` and `--exchange B` repriced a register report
correctly, but `--exchange C` could not chain `B → A → C`. The `-200 B` leg was
left unconverted and the report silently fell back to mixed-commodity output,
as if `--exchange` had not been supplied at all:

```
$ ledger -f test.dat --exchange C reg Assets
01-Jan-01 Exchange    Assets:Brokerage     C300     C300     # before: A converted,
                      <Adjustment>          100 A                       # but B left as-is
                                           C-300    100 A
                      Assets:Brokerage     -200 B   100 A
                                                    -200 B

01-Jan-01 Exchange    Assets:Brokerage     C300     C300     # after:  both legs in C,
                      Assets:Brokerage     C-300       0                # total returns to 0
```

## Fix

Record the declared lot price into the price history, exactly as an explicit
`@` cost would have, so the valuation graph (`history.cc`) can traverse the
`A → C` edge and chain `B → A → C`.

The recording is gated on `POST_COST_CALCULATED`, i.e. it only fires when the
cost was *inferred* from balancing the transaction. This deliberately excludes
explicit `@` disposals, so that a lot's cost basis is never re-published as a
spurious market price at the *sale* date when the lot is later sold. Fixated
(`{=...}`) and virtual-cost annotations are also excluded.

## Tests

`test/regress/3232.test` exercises both lot-price spellings (`{3 C}` and
`{{300 C}}`), confirms the previously-working `--exchange A`/`--exchange B`
paths are unchanged, asserts that `--exchange C` now reprices every leg so the
running total returns to zero, and checks that the declared lot price appears
in the price history alongside the implied rate. The `--exchange C` blocks fail
before the fix and pass after.

The full baseline + regression suite (4329 tests) passes.
