### PR TITLE
Add regression test for #604: print keeps bucket-inferred postings

### DIFF
--- a/test/regress/604.test
+++ b/test/regress/604.test
@@ -1,0 +1,68 @@
+; Issue #604: print used to drop the posting inferred from the bucket
+; directive, producing unbalanced output that could not be re-parsed:
+;
+;   bucket X
+;   2222/11/11 c
+;     Y  1
+;
+; printed only the Y posting, and feeding that output back into ledger
+; failed with "Transaction does not balance".  This was fixed as a side
+; effect of commit f58b19d94 for issue #2220 (first released in 3.4.0),
+; which marks the bucket posting ITEM_INFERRED instead of ITEM_GENERATED,
+; so print no longer skips it.
+;
+; print does not reproduce the bucket directive itself; instead every
+; transaction that was balanced by the bucket is printed with an elided
+; posting to the bucket account.  This round-trips losslessly even when
+; the bucket changes partway through the file, which a single emitted
+; directive could not express.  The A directive is the backwards
+; compatible alias for bucket and must behave identically.
+
+bucket Assets:Checking
+
+2024/01/01 Grocery Store
+    Expenses:Food                              $100
+
+2024/01/15 * Gas Station
+    Expenses:Gas                                $20
+
+A Liabilities:Card
+
+2024/02/01 Bookstore
+    Expenses:Books                              $35
+
+2024/02/14 Coffee Shop
+    Expenses:Coffee                              $5
+    Assets:Cash
+
+test print
+2024/01/01 Grocery Store
+    Expenses:Food                               $100
+    Assets:Checking
+
+2024/01/15 * Gas Station
+    Expenses:Gas                                 $20
+    Assets:Checking
+
+2024/02/01 Bookstore
+    Expenses:Books                               $35
+    Liabilities:Card
+
+2024/02/14 Coffee Shop
+    Expenses:Coffee                               $5
+    Assets:Cash
+end test
+
+test bal
+               $-125  Assets
+                 $-5    Cash
+               $-120    Checking
+                $160  Expenses
+                 $35    Books
+                  $5    Coffee
+                $100    Food
+                 $20    Gas
+                $-35  Liabilities:Card
+--------------------
+                   0
+end test


### PR DESCRIPTION
## Summary

Issue #604 reported that `print` dropped the posting inferred from the `bucket` directive, producing unbalanced output that could not be re-parsed:

```
bucket X
2222/11/11 c
  Y  1
```

printed only the `Y` posting, and reading that output back failed with "Transaction does not balance".

The data loss was fixed as a side effect of f58b19d94 (issue #2220, first released in v3.4.0), which marks the bucket posting `ITEM_INFERRED` instead of `ITEM_GENERATED`. Since `print` only skips `ITEM_TEMP | ITEM_GENERATED` postings, the bucket posting now appears as an elided posting:

```
2222/11/11 c
    Y                                              1
    X
```

That output round-trips losslessly. This PR locks the behavior in with `test/regress/604.test`, covering:

- the `bucket` directive and its backwards-compatible `A` alias
- a mid-file bucket change (each transaction is balanced against the bucket in effect where it was parsed)
- cleared-state propagation to the inferred posting
- a transaction with an explicit elided posting, which the bucket must not affect

## Why not emit the `bucket` directive itself?

An earlier attempt (#2877, closed) emitted `bucket <account>` at the top of print output. That is unnecessary for round-tripping — the elided posting already makes every printed transaction complete — and it is wrong when the bucket changes mid-file, since a single directive at the top cannot express per-transaction buckets. The comment block in the new test documents this.

## Validation

- `RegressTest_604` passes under ctest
- Temporarily reverting f58b19d94's one-line flag change makes the new print test fail exactly as originally reported, confirming the test genuinely guards the fix
- Full suite: 4365/4365 tests pass locally

Fixes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mh7WJiXMHEsPyzbw4Rz3Wu
