### PR TITLE
Fix xact command crashes with copied metadata (#3244)

### DIFF
--- a/src/draft.cc
+++ b/src/draft.cc
@@ -293,6 +293,49 @@ void draft_t::parse_args(const value_t& args) {
 
 /*--- Transaction Construction and Insertion ---*/
 
+namespace {
+/**
+ * @brief Remove any `UUID: ...` tag lines from a note copied off a
+ *        matched transaction.
+ *
+ * A generated draft is a new transaction, not a restatement of the one
+ * it was derived from, so it must not claim the original's UUID: the
+ * UUID deduplication in journal_t::add_xact() would otherwise reject or
+ * silently discard it -- once when the draft is inserted, and again when
+ * the user adds the generated text to the journal (issue #3244).
+ */
+optional<string> strip_uuid_lines(const optional<string>& note) {
+  if (!note)
+    return note;
+
+  std::istringstream in(*note);
+  std::ostringstream out;
+  string line;
+  bool first = true;
+  bool changed = false;
+
+  while (std::getline(in, line)) {
+    string::size_type b = line.find_first_not_of(" \t");
+    if (b != string::npos && line.compare(b, 5, "UUID:") == 0) {
+      changed = true;
+      continue;
+    }
+    if (!first)
+      out << '\n';
+    out << line;
+    first = false;
+  }
+
+  if (!changed)
+    return note;
+
+  string result = out.str();
+  if (result.empty())
+    return none;
+  return result;
+}
+} // namespace
+
 /**
  * @brief Build a new transaction from the template and insert it into
  *        the journal.
@@ -389,14 +432,21 @@ xact_t* draft_t::insert(journal_t& journal) {
   if (matching) {
     added->payee = matching->payee;
     added->code = matching->code;
-    added->note = matching->note;
+    // The draft must not inherit the matched transaction's UUID (see
+    // strip_uuid_lines above), so drop it both from the raw note text
+    // and from the parsed metadata.
+    added->note = strip_uuid_lines(matching->note);
 
-    if (matching->note) {
+    if (added->note) {
       if (matching->has_flags(ITEM_NOTE_ON_NEXT_LINE))
         added->add_flags(ITEM_NOTE_ON_NEXT_LINE);
     }
-    if (matching->metadata)
+    if (matching->metadata) {
       added->metadata = matching->metadata;
+      added->metadata->erase(_("UUID"));
+      if (added->metadata->empty())
+        added->metadata = none;
+    }
 
 #if DEBUG_ON
     DEBUG("draft.xact", "Setting payee from match: " << added->payee);

--- a/src/draft.cc
+++ b/src/draft.cc
@@ -725,17 +725,21 @@ value_t xact_command(call_scope_t& args) {
 
   draft_t draft(args.value());
 
-  unique_ptr<xact_t> new_xact(draft.insert(*report.session.journal.get()));
+  // Once insert() succeeds the generated transaction lives in the journal,
+  // which owns it (and destroys it in ~journal_t); deleting it here as well
+  // freed it out from under the journal, crashing later commands in the
+  // REPL and the --verify teardown (issue #3244).
+  xact_t* new_xact = draft.insert(*report.session.journal.get());
 
   year_directive_year = saved_year_directive;
   if (saved_epoch)
     epoch = saved_epoch;
 
-  if (new_xact.get()) {
+  if (new_xact) {
     // Only consider actual postings for the "xact" command
     report.HANDLER(limit_).on("#xact", "actual");
 
-    report.xact_report(post_handler_ptr(new print_xacts(report)), *new_xact.get());
+    report.xact_report(post_handler_ptr(new print_xacts(report)), *new_xact);
   }
 
   return true;

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -622,12 +622,19 @@ bool journal_t::add_xact(xact_t* xact) {
                               is_equivalent_posting);
 
       if (!match || this_posts.size() != other_posts.size()) {
+        // A transaction that was not parsed from a file -- one built by a
+        // caller of add_xact such as the Python bindings -- has no source
+        // position; fall back to the standard "<no source context>" text
+        // instead of dereferencing an empty optional (issue #3244).
+        auto xact_context = [](const xact_t* x) {
+          return x->pos && x->pos->pathname
+                     ? source_context(*x->pos->pathname, x->pos->beg_pos, x->pos->end_pos, "> ")
+                     : source_context(path(), 0, 0, "> ");
+        };
         add_error_context(_("While comparing this previously seen transaction:"));
-        add_error_context(
-            source_context(*other->pos->pathname, other->pos->beg_pos, other->pos->end_pos, "> "));
+        add_error_context(xact_context(other));
         add_error_context(_("to this later transaction:"));
-        add_error_context(
-            source_context(*xact->pos->pathname, xact->pos->beg_pos, xact->pos->end_pos, "> "));
+        add_error_context(xact_context(xact));
         throw_(std::runtime_error,
                _f("Transactions with the same UUID must have equivalent postings"));
       }

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -215,7 +215,12 @@ account_t* journal_t::register_account(string_view name, post_t* post, account_t
         if (has_template_var) {
           result->add_flags(ACCOUNT_KNOWN);
         } else if (checking_style == CHECK_WARNING) {
-          current_context->warning(_f("Unknown account '%1%'") % result->fullname());
+          // Outside of parsing (e.g. register_account called from Python)
+          // there is no parse context, and thus no source location.
+          if (current_context)
+            current_context->warning(_f("Unknown account '%1%'") % result->fullname());
+          else
+            warning_func((_f("Unknown account '%1%'") % result->fullname()).str());
         } else if (checking_style == CHECK_ERROR) {
           throw_(parse_error, _f("Unknown account '%1%'") % result->fullname());
         }

--- a/src/journal.cc
+++ b/src/journal.cc
@@ -429,7 +429,12 @@ void journal_t::register_metadata(const string& key, const value_t& value,
       if (context.index() == 0) {
         known_tags.insert(key);
       } else if (checking_style == CHECK_WARNING) {
-        current_context->warning(_f("Unknown metadata tag '%1%'") % key);
+        // Outside of parsing (e.g. add_xact called from Python) there is
+        // no parse context, and thus no source location to point at.
+        if (current_context)
+          current_context->warning(_f("Unknown metadata tag '%1%'") % key);
+        else
+          warning_func((_f("Unknown metadata tag '%1%'") % key).str());
       } else if (checking_style == CHECK_ERROR) {
         throw_(parse_error, _f("Unknown metadata tag '%1%'") % key);
       }
@@ -438,13 +443,24 @@ void journal_t::register_metadata(const string& key, const value_t& value,
   }
 
   if (!value.is_null() && context.index() != 0) {
+    // When a transaction enters the journal outside of parsing -- the xact
+    // command inserting a generated draft, or add_xact called from Python --
+    // current_context is null.  Evaluate check expressions against the
+    // global default scope, which is the same report scope a parse context
+    // binds during a normal read, so tag assertions behave uniformly no
+    // matter how the transaction was added (issue #3244).  If no scope is
+    // available at all (embedded uses), skip the checks: there is nothing
+    // to evaluate the expressions in.
+    scope_t* parent_scope = current_context ? current_context->scope : scope_t::default_scope;
+    if (!parent_scope)
+      return;
+
     auto [range_begin, range_end] = tag_check_exprs.equal_range(key);
 
     for (auto i = range_begin; i != range_end; ++i) {
-      bind_scope_t bound_scope(*current_context->scope,
-                               context.index() == 1
-                                   ? static_cast<scope_t&>(*std::get<xact_t*>(context))
-                                   : static_cast<scope_t&>(*std::get<post_t*>(context)));
+      bind_scope_t bound_scope(
+          *parent_scope, context.index() == 1 ? static_cast<scope_t&>(*std::get<xact_t*>(context))
+                                              : static_cast<scope_t&>(*std::get<post_t*>(context)));
       value_scope_t val_scope(bound_scope, value);
 
       (*i).second.first.mark_uncompiled();
@@ -454,12 +470,17 @@ void journal_t::register_metadata(const string& key, const value_t& value,
       // would cause a use-after-free the next time the expression is compiled.
       (*i).second.first.set_context(nullptr);
       if (!holds) {
-        if ((*i).second.second == expr_t::EXPR_ASSERTION)
+        if ((*i).second.second == expr_t::EXPR_ASSERTION) {
           throw_(parse_error, _f("Metadata assertion failed for (%1%: %2%): %3%") % key % value %
                                   (*i).second.first);
-        else
-          current_context->warning(_f("Metadata check failed for (%1%: %2%): %3%") % key % value %
-                                   (*i).second.first);
+        } else {
+          boost::format msg(_f("Metadata check failed for (%1%: %2%): %3%") % key % value %
+                            (*i).second.first);
+          if (current_context)
+            current_context->warning(msg);
+          else
+            warning_func(msg.str());
+        }
       }
     }
   }

--- a/test/regress/3244.py
+++ b/test/regress/3244.py
@@ -1,0 +1,14 @@
+# Regression test for GitHub issue #3244 (Python-facing side):
+# Journal.register_account crashed under --strict when called after
+# parsing had finished, because journal_t::current_context is null
+# outside of read() and the unknown-account warning dereferenced it.
+# The warning now falls back to a location-free form instead.
+
+import ledger
+
+journal = ledger.session.read_journal_files()
+xact = next(iter(journal))
+post = xact[0]
+print("about to call register_account", flush=True)
+journal.register_account("Fresh:Unknown", post)
+print("returned without crash", flush=True)

--- a/test/regress/3244.test
+++ b/test/regress/3244.test
@@ -1,0 +1,68 @@
+; Regression test for issue #3244: the xact command segfaulted when the
+; generated draft carried metadata subject to a `tag ... assert` or
+; `tag ... check` expression.  draft_t::insert() calls add_xact() after
+; parsing has finished, when journal_t::current_context is null, and
+; register_metadata() dereferenced it unconditionally.  Check expressions
+; are now evaluated against the global default scope in that case, and a
+; failing check warns without a source location.
+
+tag testing
+    assert payee
+
+tag posted
+    assert payee
+
+tag checked
+    check date < [2026/07/10]
+
+tag dated
+    assert date < [2026/07/10]
+
+2026/07/01 * Alpha  ; testing: anything
+    Assets:Checking     $1
+    Income:Interest
+
+2026/07/02 * Beta
+    Assets:Checking     $2  ; posted: stuff
+    Income:Interest
+
+2026/07/03 * Gamma  ; checked: anything
+    Assets:Checking     $3
+    Income:Interest
+
+2026/07/04 * Delta  ; dated: anything
+    Assets:Checking     $4
+    Income:Interest
+
+; The reported crash: the draft copies the `testing` tag, whose assert
+; must be evaluated (and pass) without a parse context.
+test --now=2026/07/02 xact alpha
+2026/07/02 Alpha  ; testing: anything
+    Assets:Checking                               $1
+    Income:Interest
+end test
+
+; Same crash via posting-level metadata: the copied posting carries the
+; `posted` tag, so the check runs with a post_t context.
+test xact 2026/07/15 beta
+2026/07/15 Beta
+    Assets:Checking                               $2  ; posted: stuff
+    Income:Interest
+end test
+
+; A failing `check` on the draft warns (without a file position, since
+; the draft was not parsed from a file) but still prints the draft.
+test xact 2026/07/15 gamma
+2026/07/15 Gamma  ; checked: anything
+    Assets:Checking                               $3
+    Income:Interest
+__ERROR__
+Warning: Metadata check failed for (checked: anything): (date < [2026/07/10])
+end test
+
+; A failing `assert` on the draft is an error, exactly as it would be
+; when the generated transaction is parsed from the journal.
+test xact 2026/07/15 delta -> 1
+__ERROR__
+Error: Metadata assertion failed for (dated: anything): (date < [2026/07/10])
+end test

--- a/test/regress/3244_2.test
+++ b/test/regress/3244_2.test
@@ -1,0 +1,27 @@
+; Regression test for issue #3244 (UUID metadata): the xact command
+; copied the matched transaction's UUID tag onto the generated draft,
+; so journal_t::add_xact's UUID deduplication saw the draft as a
+; duplicate of its own template.  A template that altered the postings
+; crashed in the mismatch error path (dereferencing the draft's empty
+; source position), and an unaltered draft was silently discarded and
+; then misreported as "Failed to finalize derived transaction".  A
+; draft is a new transaction: it must not claim the original's UUID.
+
+2026/07/01 * Alpha
+    ; UUID: abc123
+    Assets:Checking     $1
+    Income:Interest
+
+; The generated draft no longer carries the UUID tag line.
+test xact 2026/07/15 alpha
+2026/07/15 Alpha
+    Assets:Checking                               $1
+    Income:Interest
+end test
+
+; Altering the postings used to abort in the UUID-mismatch error path.
+test xact 2026/07/15 alpha Assets:Checking 99
+2026/07/15 Alpha
+    Assets:Checking                              $99
+    Income:Interest
+end test

--- a/test/regress/3244_3.test
+++ b/test/regress/3244_3.test
@@ -1,0 +1,16 @@
+; Regression test for issue #3244 (draft ownership): draft_t::insert
+; adds the generated transaction to the journal, which owns it, but
+; xact_command also wrapped the returned pointer in a unique_ptr and
+; deleted it.  The journal was left holding a dangling pointer: a
+; later command in the same session (the REPL) iterated freed memory,
+; and the --verify teardown double-deleted the transaction.
+
+2026/07/01 * Alpha
+    Assets:Checking     $1
+    Income:Interest
+
+test --verify xact 2026/07/15 alpha
+2026/07/15 Alpha
+    Assets:Checking                               $1
+    Income:Interest
+end test

--- a/test/regress/3244_py.test
+++ b/test/regress/3244_py.test
@@ -1,0 +1,14 @@
+account Assets:Cash
+account Equity:Opening
+commodity $
+
+2026/01/01 Opening
+    Assets:Cash        $100.00
+    Equity:Opening
+
+test --strict python test/regress/3244.py
+about to call register_account
+returned without crash
+__ERROR__
+Warning: Unknown account 'Fresh:Unknown'
+end test


### PR DESCRIPTION
Fixes #3244.

## The reported crash

`ledger xact` segfaulted whenever the generated draft carried metadata
subject to a `tag ... assert` (or `check`) expression:

```
$ cat test.ldg
tag testing
    assert payee

2026/07/01 * Generate  ; testing: anything
    Assets:Checking    $1
    Income:Interest
$ ledger --file test.ldg xact generate
Segmentation fault (core dumped)
```

Two changes on `main` interact: since 5fd831dfb (#2406) the `xact`
command copies the matched transaction's note and metadata onto the
draft, so drafts now carry tags that have registered check expressions;
and since 934f8e109 `journal_t::current_context` is correctly reset to
null once parsing completes. `draft_t::insert()` calls
`journal.add_xact()` *after* parsing, and `register_metadata()` still
dereferenced the null context when evaluating `tag_check_exprs`.
(Released versions read the same expression scope through a *dangling*
— not null — context, which is why 3.4.x appears to work.)

The fix evaluates check expressions against `scope_t::default_scope`
when there is no parse context — in CLI usage that is the same report
scope a parse context binds during a normal read — so tag assertions
behave uniformly however a transaction enters the journal: parsed from
a file, generated by `xact`, or added from Python. A failing `assert`
on a draft is now a clean error (the same error the generated text
would produce when next parsed); a failing `check` warns without a
file position, since a generated transaction has no source location.

## Sibling crashes in the same command

Adversarial review of the fix turned up three more crashes in the
`xact`/`add_xact` family, each verified with a debugger backtrace and
each fixed here in its own commit with its own regression test:

* **`Journal.register_account` from Python under `--strict`** hit the
  same null-context dereference in the unknown-account warning. Same
  fallback treatment. (The unknown-payee/commodity warnings are
  genuinely parse-time-only and need no change.)

* **A `UUID:` tag on the matched transaction** made `add_xact`'s
  deduplication treat the draft as a duplicate of its own template:
  a template that altered postings aborted in the mismatch error path
  (dereferencing the draft's empty source position), and an unaltered
  draft was silently discarded and misreported as "Failed to finalize
  derived transaction (check commodities)". A draft is a new
  transaction, so it no longer inherits the original's UUID (stripped
  from both metadata and note text), and the mismatch error path now
  survives position-less transactions.

* **The draft was owned twice** (since ee641f353, 2012):
  `draft_t::insert()` hands the transaction to the journal, but
  `xact_command()` also wrapped the returned pointer in a `unique_ptr`
  and deleted it. Later commands in the same REPL session iterated the
  freed transaction (`xact alpha` then `reg` → segfault), and
  `--verify` teardown double-deleted it. The journal now solely owns
  the draft, per `insert()`'s documented contract.

## Tests

Eight regression-test blocks across four files, all failing (segfault,
abort, or wrong output) on current `main` and passing with these fixes:

* `test/regress/3244.test` — the reported crash at transaction and
  posting level; failing `check` → location-free warning + draft +
  exit 0; failing `assert` → error + exit 1.
* `test/regress/3244_2.test` — UUID-tagged template: unaltered and
  altered drafts both print, without the UUID line.
* `test/regress/3244_3.test` — `--verify xact` survives teardown.
* `test/regress/3244_py.test` / `3244.py` — Python
  `register_account` under `--strict` warns instead of crashing.

Full suite: 4369/4369 tests pass locally (Debug, macOS, Python
bindings enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017j56dRGtBhhR8oKW9qfK4x
