### PR TITLE
Add the semantic-bisimulation submodule, ctest, and CI gate

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,6 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         name: Check out repository code
+        with:
+          # The lean/ submodule registers SemanticBisimulation; these
+          # runners have no Lean toolchain, so it reports SKIPPED --
+          # visibly, never as a silent pass.
+          submodules: true
 
       - if: runner.os == 'Linux'
         name: Linux dependencies

--- a/.github/workflows/nix-flake.yml
+++ b/.github/workflows/nix-flake.yml
@@ -20,8 +20,38 @@ jobs:
 
     - uses: actions/checkout@v7
 
+    # Cache the nix store between runs: the semantic-bisimulation
+    # oracle depends on a multi-gigabyte Mathlib artifact tree (the
+    # ledger-semantics flake's `deps` fixed-output derivation) that
+    # would otherwise be re-fetched on every run.  flake.lock pins the
+    # semantics revision, so the key follows every Lean upgrade.
+    # GitHub grants a repository 10 GB of Actions cache in total, so
+    # only one leg gets the cache; two stores of this size would evict
+    # each other (and every other cache in the repository) on every
+    # alternation.  The macOS leg re-fetches the fixed-output
+    # derivation each run instead, which costs minutes, not
+    # correctness.
+    - uses: nix-community/cache-nix-action@v6
+      if: runner.os == 'Linux'
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        gc-max-store-size-linux: 8G
+        purge: true
+        purge-prefixes: nix-${{ runner.os }}-
+        purge-created: 0
+        purge-primary-key: never
+
     - name: Install lefthook
       run: npm install -g lefthook
 
-    - name: Ensure nix flake builds
+    # `nix build .` builds the C++ ledger AND runs its full ctest
+    # suite in the check phase — including SemanticBisimulation, which
+    # replays every positive test journal against the Lean oracle
+    # (test/semantic/check_all.py).  The oracle and its toolchain come
+    # from the ledger-semantics flake input (its deps and oracle
+    # packages), so this job
+    # is the CI gate for the bisimulation: any balance divergence
+    # between the C++ implementation and the Lean semantics fails it.
+    - name: Ensure nix flake builds (includes Lean bisimulation)
       run: lefthook run nix-flake-build

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,7 @@ node_modules/
 # Task files
 tasks.json
 tasks/ 
+
+# Semantic-bisimulation artifacts (regenerable, tuple-pinned)
+test/semantic/artifacts/
+test/semantic/generated/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lean"]
+	path = lean
+	url = https://github.com/ledger/ledger-semantics.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,20 @@ python test/RegressTests.py --ledger ./build/ledger \
 Python 3.10+ is required to run the test harness. All tests run with
 `TZ=America/Chicago`.
 
+The `SemanticBisimulation` ctest replays every positive test journal
+against the Lean oracle in the `lean/` submodule
+(github.com/ledger/ledger-semantics). Development builds enable it
+with `git submodule update --init lean`, then build the oracle once:
+`nix develop ./lean --command bash -c 'lake exe cache get && lake
+build'`. The test runs the oracle through `nix develop` in that tree;
+alternatively `LEDGER_LEAN_DIR` may name any prebuilt oracle tree,
+with the matching `lake` on PATH. Without the submodule the test is
+not registered, so release builds owe users no Lean toolchain; with
+the submodule but no `nix`, or with an oracle that has never been
+built, it exits 77 and shows as SKIPPED. `nix build` runs it
+unconditionally via the flake's `ledger-semantics` input — keep that
+input and the submodule revision in step.
+
 ### Development Commands
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,40 @@
 {
   "nodes": {
+    "ledger-semantics": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1787823899,
+        "narHash": "sha256-YNPHJXn09PB4KSePVHgBIbx0klVkWGutwDnTZNb7k2c=",
+        "owner": "ledger",
+        "repo": "ledger-semantics",
+        "rev": "03abb3e91cf2cfbe2c77ff32ac2428e516458cd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ledger",
+        "repo": "ledger-semantics",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1772736753,
         "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
@@ -18,7 +52,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "ledger-semantics": "ledger-semantics",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,17 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # The machine-checked semantics and its bisimulation oracle (see
+    # the bisimulation section of lean/README.md).  The same repository is also
+    # the `lean/` git submodule, which serves interactive development
+    # (`nix develop ./lean`, warm .lake caches, ctest against a
+    # checkout).  Two pins therefore exist: this flake input drives
+    # `nix build` and CI, the submodule drives the working tree.
+    # Update them together.
+    ledger-semantics.url = "github:ledger/ledger-semantics";
   };
 
-  outputs = { self, nixpkgs }: let
+  outputs = { self, nixpkgs, ledger-semantics }: let
     usePython = true;
     gpgmeSupport = true;
     useLibedit = true;
@@ -19,6 +27,9 @@
 
     packages = forAllSystems (system: let
         pkgs = nixpkgsFor.${system};
+        # The oracle and its exact Lean toolchain come from the
+        # ledger-semantics flake; nothing Lean-specific is built here.
+        semantics = ledger-semantics.packages.${system};
       in with pkgs; {
       ledger = stdenv.mkDerivation {
         pname = "ledger";
@@ -49,6 +60,33 @@
         ];
 
         enableParallelBuilding = true;
+
+        # The check phase replays every positive suite test against the
+        # Lean oracle (ctest SemanticBisimulation): `lake` must be on
+        # PATH and LEDGER_LEAN_DIR must point at the compiled oracle
+        # tree.  LEDGER_LEAN_DIR is a plain env attribute so that it is
+        # visible at CMake configure time too, which is what registers
+        # the test (test/CMakeLists.txt); without oracle and toolchain
+        # the test is not registered, and a registered test without
+        # them exits 77 and shows as SKIPPED — never as a silent pass.
+        nativeCheckInputs = [ semantics.lean git ];
+
+        LEDGER_LEAN_DIR = semantics.oracle;
+        # The semantics revision under comparison, recorded in the
+        # result artifact (the store-path oracle has no repository to
+        # ask).  Absent only when the input is a dirty local override.
+        LEDGER_LEAN_REV = ledger-semantics.rev or "dirty";
+
+        # Lake validates the oracle's dependencies through git; the
+        # store-owned tree needs the ownership check quieted.  Lake
+        # also consults HOME for configuration, and the sandbox's
+        # default is not writable.
+        preCheck = ''
+          export HOME="$TMPDIR"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0=safe.directory
+          export GIT_CONFIG_VALUE_0="*"
+        '';
 
         cmakeFlags = [
           "-DCMAKE_INSTALL_LIBDIR=lib"
@@ -92,6 +130,14 @@
 
     defaultPackage = forAllSystems (system: self.packages.${system}.ledger);
 
+    # `nix flake check` (and CI) builds the ledger, whose check phase
+    # runs the full ctest suite including SemanticBisimulation.  The
+    # oracle itself is checked upstream, in the ledger-semantics
+    # flake's own CI.
+    checks = forAllSystems (system: {
+      ledger = self.packages.${system}.ledger;
+    });
+
     devShells = forAllSystems (system: let
         pkgs = nixpkgsFor.${system};
         # Build Boost with Python support, matching exactly what the ledger
@@ -112,6 +158,9 @@
           llvmPackages_18.clang-tools # Provides clang-format (pinned to match CI)
           llvmPackages_18.clang       # Clang compiler for profiling builds
           llvmPackages_18.llvm        # Provides llvm-profdata, llvm-cov
+          ledger-semantics.packages.${system}.lean
+                                      # Lean toolchain for the oracle,
+                                      # pinned by the semantics flake
           hyperfine                   # Statistical benchmarking
           cppcheck
           doxygen                     # API documentation generator

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,51 @@ add_subdirectory(manual)
 add_subdirectory(baseline)
 add_subdirectory(regress)
 
+# Semantic bisimulation (lean/README.md, the ledger-semantics
+# submodule): every
+# positive .test journal in baseline/regress/manual is additionally
+# replayed against the Lean oracle whenever the suite runs (`make
+# check`, `make test`, `ctest`).  One batched ctest test rather than
+# per-test oracle invocations: the oracle loads once for the whole
+# corpus.  The test registers only when an oracle can exist: either
+# the lean/ submodule is checked out (development builds) or
+# LEDGER_LEAN_DIR names a prebuilt oracle tree (the Nix build).  A
+# release build from a tarball has neither, registers nothing, and
+# owes its users no Lean toolchain.  A registered test still exits 77
+# and shows as SKIPPED when the toolchain is missing at run time, or
+# when the submodule is checked out but its oracle has never been
+# built — visibly, never as a silent pass.
+if(Python_EXECUTABLE)
+  if(EXISTS "${PROJECT_SOURCE_DIR}/lean/lakefile.lean" OR
+     (DEFINED ENV{LEDGER_LEAN_DIR} AND
+      NOT "$ENV{LEDGER_LEAN_DIR}" STREQUAL ""))
+    add_test(NAME SemanticBisimulation
+      COMMAND ${Python_EXECUTABLE}
+        ${PROJECT_SOURCE_DIR}/test/semantic/check_all.py
+        --ledger $<TARGET_FILE:ledger> --source ${PROJECT_SOURCE_DIR})
+    # Bake the oracle location seen at configure time into the test,
+    # so the oracle that runs is the one whose presence registered the
+    # test, not whatever happens to be in the environment later.
+    set(_bisim_env "TZ=${Ledger_TEST_TIMEZONE}")
+    if(DEFINED ENV{LEDGER_LEAN_DIR} AND
+       NOT "$ENV{LEDGER_LEAN_DIR}" STREQUAL "")
+      list(APPEND _bisim_env "LEDGER_LEAN_DIR=$ENV{LEDGER_LEAN_DIR}")
+    endif()
+    if(DEFINED ENV{LEDGER_LEAN_REV} AND
+       NOT "$ENV{LEDGER_LEAN_REV}" STREQUAL "")
+      list(APPEND _bisim_env "LEDGER_LEAN_REV=$ENV{LEDGER_LEAN_REV}")
+    endif()
+    set_tests_properties(SemanticBisimulation PROPERTIES
+      ENVIRONMENT "${_bisim_env}"
+      SKIP_RETURN_CODE 77
+      TIMEOUT 3600)
+  else()
+    message(STATUS
+      "SemanticBisimulation: not registered (lean/ submodule not "
+      "initialized and LEDGER_LEAN_DIR unset)")
+  endif()
+endif()
+
 if(Python_EXECUTABLE)
   set(_class DocTests)
   file(GLOB ${_class}_TESTS ${PROJECT_SOURCE_DIR}/doc/*.texi)

--- a/test/semantic/check_all.py
+++ b/test/semantic/check_all.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Suite-wide oracle bisimulation: every positive test, on `make check`.
+
+For EVERY positive `.test` file in test/baseline, test/regress, and
+test/manual — positive meaning no test block expects a nonzero exit
+(`-> N`) or an `__ERROR__` section — the journal portion (everything
+before the first `test` block, exactly as RegressTests.py delineates
+it) is replayed through BOTH the C++ ledger (`balance --flat
+--no-total`) and the Lean oracle driver, and the normalized balance
+triples must agree. This runs as the `SemanticBisimulation` ctest, so
+`make check` / `make test` / `ctest` all include it.
+
+Classification (every file lands in exactly one bin; the artifact
+lists them all — absence of output is never silent success):
+
+  PASS            — oracle and C++ agree exactly.
+  FAIL            — divergence (unadjudicated; each one either
+                    exposes a C++ defect or a convention the oracle
+                    has not yet recorded — see the bisimulation
+                    section of lean/README.md).
+  SKIP:negative   — the test intentionally exercises errors; its
+                    journal is not claimed valid.
+  SKIP:no-journal — no journal text before the first test block.
+  SKIP:out-of-scope — the oracle parser rejected the journal, with
+                    the construct named; the goal state, reached by
+                    the current oracle, is zero entries here.
+  SKIP:cpp-parse  — plain `ledger balance` cannot parse the journal
+                    without the test's own flags (comparison tuple
+                    mismatch, e.g. --input-date-format); recorded,
+                    not compared.
+  SKIP:python     — the journal embeds a `python` block: embedded
+                    Python is a Turing-complete escape from the
+                    journal language, so the file is inherently
+                    non-comparable.
+
+Exit codes: 0 all compared files PASS and the ratchet bins are empty;
+1 any FAIL, or any entry in SKIP:out-of-scope or SKIP:cpp-parse (both
+reached zero against the full suite and are held there — an entry
+reappearing means one side stopped reading a journal it used to read,
+which is a regression, not a skip); 77 the Lean toolchain or a built
+oracle is unavailable (ctest SKIP_RETURN_CODE — skipped, visibly);
+2 the harness itself cannot run (missing binary, missing fixtures,
+oracle invocation failure).
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import sweep  # normalization + C++ balance parsing
+
+TEST_RE = re.compile(r"^test\s+(.*?)(?:\s*->\s*([0-9]+))?\s*$")
+
+
+def classify_test_file(path):
+    """-> (journal_text or None, skip_reason or None, cpp_flags, dc)"""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+    except UnicodeDecodeError:
+        return None, "out-of-scope: non-utf8", [], False
+    journal_lines = []
+    in_journal = True
+    negative = False
+    cpp_flags = []
+    dc = False
+    for line in text.splitlines():
+        line = line.rstrip("\r")
+        if line.startswith("test "):
+            in_journal = False
+            m = TEST_RE.match(line)
+            if m and m.group(2) and m.group(2) != "0":
+                negative = True
+            # input-affecting flags of the test's own command become
+            # part of the comparison tuple for this file
+            toks = line.split()
+            for i, tk in enumerate(toks):
+                if tk == "--now" and i + 1 < len(toks):
+                    pair = [tk, toks[i + 1].strip("'\"")]
+                    if pair[0] not in cpp_flags:
+                        cpp_flags.extend(pair)
+                elif tk.startswith("--now="):
+                    if "--now" not in cpp_flags:
+                        cpp_flags.extend(["--now", tk.split("=", 1)[1].strip("'\"")])
+                elif tk == "--recursive-aliases":
+                    if tk not in cpp_flags:
+                        cpp_flags.append(tk)
+                elif tk == "--input-date-format" and i + 1 < len(toks):
+                    pair = [tk, toks[i + 1].strip("'\"")]
+                    if pair[0] not in cpp_flags:
+                        cpp_flags.extend(pair)
+                elif tk.startswith("--input-date-format="):
+                    if "--input-date-format" not in cpp_flags:
+                        cpp_flags.extend(["--input-date-format",
+                                          tk.split("=", 1)[1].strip("'\"")])
+                elif tk == "--decimal-comma":
+                    dc = True
+                    if tk not in cpp_flags:
+                        cpp_flags.append(tk)
+
+        elif in_journal:
+            journal_lines.append(line)
+        elif line.startswith("__ERROR__"):
+            negative = True
+    if negative:
+        return None, "negative", [], False
+    if not any(l.strip() and not l.lstrip().startswith(";")
+               for l in journal_lines):
+        return None, "no-journal", [], False
+    if "--now" not in cpp_flags:
+        # Deterministic "current time", passed identically to BOTH
+        # sides: dangling timeclock check-ins auto-close at --now
+        # (timelog.cc close()), so an unpinned clock would make the
+        # comparison depend on the day it runs.  The value itself is
+        # arbitrary; any fixed date later than every journal date in
+        # the corpus behaves the same, and this one is kept only
+        # because the zero-divergence baseline was measured with it.
+        cpp_flags.extend(["--now", "2026/08/26"])
+    return "\n".join(journal_lines) + "\n", None, cpp_flags, dc
+
+
+INCLUDE_RE = re.compile(r"^\s*!?include\s+(.+?)\s*$", re.M)
+
+
+def copy_includes(journal, src_dir, dst_dir, depth=4):
+    """Copy files referenced by include lines (globs included) next to
+    the extracted journal so both sides resolve them identically."""
+    if depth == 0:
+        return
+    import glob as _glob
+    # A relative include may step above the journal's own directory
+    # (test/regress does this), which lands the copy in the shared
+    # session directory one level up.  That is allowed; escaping the
+    # session directory itself is not.
+    session_root = os.path.dirname(os.path.abspath(dst_dir))
+    for m in INCLUDE_RE.finditer(journal):
+        name = m.group(1).strip("'\"").replace("\\", "")
+        for src in sorted(_glob.glob(os.path.join(src_dir, name))):
+            rel = os.path.relpath(src, src_dir)
+            dst = os.path.join(dst_dir, rel)
+            if not os.path.abspath(dst).startswith(session_root + os.sep):
+                continue
+            if os.path.isfile(src) and not os.path.exists(dst):
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                with open(src, "rb") as fi, open(dst, "wb") as fo:
+                    fo.write(fi.read())
+                with open(src, encoding="utf-8", errors="replace") as fh:
+                    copy_includes(fh.read(), src_dir, dst_dir, depth - 1)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ledger", default=None)
+    ap.add_argument("--source", default=None)
+    ap.add_argument("dirs", nargs="*")
+    args = ap.parse_args()
+
+    repo = os.path.abspath(args.source) if args.source else sweep.REPO
+    ledger = args.ledger or os.path.join(repo, "build", "ledger")
+    env = {**os.environ, "TZ": os.environ.get("TZ", "America/Chicago")}
+    dirs = args.dirs or [os.path.join(repo, "test", d)
+                         for d in ("baseline", "regress", "manual")]
+
+    lean_dir = os.environ.get("LEDGER_LEAN_DIR", os.path.join(repo, "lean"))
+    if not os.path.isfile(os.path.join(lean_dir, "lakefile.lean")):
+        print("SKIP: Lean oracle tree not present (submodule not"
+              " initialized and LEDGER_LEAN_DIR unset)"); sys.exit(77)
+    # Probe the toolchain exactly once, up front.  The Nix build sets
+    # LEDGER_LEAN_DIR to the semantics flake's oracle output and puts
+    # the matching lake on PATH; development runs use the pinned dev
+    # shell of the lean/ submodule.  Past this point a
+    # failing oracle exits 2: substring-matching error text to decide
+    # between SKIP and FAIL would let a real divergence read as green.
+    direct_lake = "LEDGER_LEAN_DIR" in os.environ
+    if direct_lake and not shutil.which("lake"):
+        print("SKIP: LEDGER_LEAN_DIR set but lake not on PATH")
+        sys.exit(77)
+    if not direct_lake and not shutil.which("nix"):
+        print("SKIP: nix unavailable for the lean/ dev shell")
+        sys.exit(77)
+    if not direct_lake and not os.path.isdir(os.path.join(lean_dir, ".lake")):
+        # The submodule is checked out but the oracle has never been
+        # built here; running now would make lake fetch and build the
+        # full Mathlib dependency tree as a side effect of `ctest`.
+        # That is a decision for the developer, not the test.
+        print("SKIP: oracle not built in " + lean_dir + " — run\n"
+              "  nix develop ./lean --command bash -c"
+              " 'lake exe cache get && lake build'\n"
+              "once (or set LEDGER_LEAN_DIR to a built oracle tree)")
+        sys.exit(77)
+
+    if not os.path.isfile(ledger):
+        print(f"cannot compare: ledger binary not found at {ledger}",
+              file=sys.stderr)
+        sys.exit(2)
+
+    tests = []
+    for d in dirs:
+        for root, _, files in os.walk(d):
+            for f in sorted(files):
+                if f.endswith(".test"):
+                    tests.append(os.path.join(root, f))
+
+    bins = {"PASS": [], "FAIL": [], "SKIP:negative": [],
+            "SKIP:no-journal": [], "SKIP:python": [],
+            "SKIP:out-of-scope": [], "SKIP:cpp-parse": []}
+    details = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        candidates = []  # (test_path, dat_path, cpp_flags, dc)
+        for i, tpath in enumerate(tests):
+            journal, skip, cpp_flags, dc = classify_test_file(tpath)
+            if journal is not None and any(
+                    ln == "python" or ln.startswith("python ")
+                    for ln in (l.strip() for l in journal.splitlines())):
+                # a python block anywhere in the journal makes the
+                # file non-comparable, whatever its name
+                journal, skip = None, "python"
+            rel = os.path.relpath(tpath, repo)
+            if skip == "negative":
+                bins["SKIP:negative"].append(rel)
+            elif skip == "no-journal":
+                bins["SKIP:no-journal"].append(rel)
+            elif skip == "python":
+                bins["SKIP:python"].append(rel)
+            elif skip and skip.startswith("out-of-scope"):
+                bins["SKIP:out-of-scope"].append(rel)
+                details.append({"file": rel, "status": "SKIP:out-of-scope",
+                                "why": skip})
+            else:
+                assert journal is not None
+                fdir = os.path.join(tmp, f"{i:05d}")
+                os.makedirs(fdir, exist_ok=True)
+                dat = os.path.join(fdir, os.path.basename(tpath))
+                with open(dat, "w", encoding="utf-8") as fh:
+                    fh.write(journal)
+                copy_includes(journal, os.path.dirname(tpath), fdir)
+                candidates.append((tpath, dat, cpp_flags, dc))
+
+        # Detector fixtures ride the same batch: a planted one-sided
+        # defect must FAIL, and the pristine control must PASS, on
+        # every run — a comparator that has never been observed to
+        # fail provides no evidence when it passes.  Perturbing the
+        # shared journal would move both live sides identically, so
+        # the defect is planted on the C++ side only.  The fixture
+        # is mandatory: without it the run is unproved, so its
+        # absence is a harness error, not a quiet omission.
+        demo_src = os.path.join(repo, "test", "semantic", "demo.dat")
+        if not os.path.isfile(demo_src):
+            print(f"detector fixture missing: {demo_src}",
+                  file=sys.stderr)
+            sys.exit(2)
+        with open(demo_src, encoding="utf-8") as fh:
+            j = fh.read()
+        p1 = os.path.join(tmp, "selftest.dat")
+        with open(p1, "w") as fh:
+            fh.write(j)
+        p2 = os.path.join(tmp, "selftest-perturbed.dat")
+        with open(p2, "w") as fh:
+            fh.write(j.replace("$150.00", "$151.00"))
+        candidates.append(("__selftest__", p1, [], False))
+        selftest = (p1, p2)
+
+        # Batched oracle runs (chunked argv).
+        oracle = {}  # dat_path -> set(rows) | ("ERROR", msg)
+        styles = {}  # dat_path -> set of decimal-comma commodities
+        CHUNK = 800
+        for lo in range(0, len(candidates), CHUNK):
+            chunk = candidates[lo:lo + CHUNK]
+            argv = []
+            for _, d, fl, dc in chunk:
+                if dc:
+                    argv.append("--decimal-comma")
+                if "--now" in fl:
+                    argv.extend(["--now", fl[fl.index("--now") + 1]])
+                if "--recursive-aliases" in fl:
+                    argv.append("--recursive-aliases")
+                if "--input-date-format" in fl:
+                    argv.extend(["--input-date-format",
+                                 fl[fl.index("--input-date-format") + 1]])
+                argv.append(d)
+            # Oracle invocation.  When LEDGER_LEAN_DIR is set (the Nix
+            # build points it at the semantics flake's oracle output and
+            # puts the matching lake on PATH), run lake directly in that
+            # tree; otherwise run inside the pinned dev shell of the
+            # lean/ submodule (`nix develop` with that tree as cwd), so
+            # a stray lake on PATH never bypasses the pinned toolchain.
+            # Toolchain absence was probed once above and is the ONLY
+            # skip: any failure past this point is a red result, never
+            # a SKIPPED one.
+            if direct_lake:  # noqa: simple dispatch, probed above
+                cmd = ["lake", "env", "lean",
+                       "--run", "Ledger/Driver.lean", *argv]
+            else:
+                cmd = ["nix", "develop", "--command", "lake", "env", "lean",
+                       "--run", "Ledger/Driver.lean", *argv]
+            oracle_env = {**env, "GIT_CONFIG_COUNT": "1",
+                          "GIT_CONFIG_KEY_0": "safe.directory",
+                          "GIT_CONFIG_VALUE_0": "*"}
+            drv = subprocess.run(
+                cmd, cwd=lean_dir, capture_output=True,
+                text=True, timeout=3600, env=oracle_env)
+            if drv.returncode != 0:
+                msg = (drv.stderr or drv.stdout)[-500:]
+                print("oracle driver invocation failed:\n" + msg,
+                      file=sys.stderr)
+                sys.exit(2)
+            cur = None
+            for line in drv.stdout.splitlines():
+                if line.startswith("== "):
+                    cur = line[3:].strip()
+                    oracle[cur] = set()
+                    styles[cur] = set()
+                elif line.startswith("!! ERROR") and cur:
+                    oracle[cur] = ("ERROR", line[len("!! ERROR "):])
+                elif line.startswith("%% dc ") and cur:
+                    c = line[len("%% dc "):]
+                    styles[cur].add("" if c == "*" else c)
+                elif cur and line.strip():
+                    if isinstance(oracle[cur], set):
+                        oracle[cur].add(line.strip())
+
+        for tpath, dat, cpp_flags, dc in candidates:
+            if tpath == "__selftest__":
+                continue
+            rel = os.path.relpath(tpath, repo)
+            res = oracle.get(dat)
+            if res is None:
+                bins["FAIL"].append(rel)
+                details.append({"file": rel, "status": "FAIL",
+                                "why": "no oracle output for journal"})
+                continue
+            if isinstance(res, tuple):
+                bins["SKIP:out-of-scope"].append(rel)
+                details.append({"file": rel, "status": "SKIP:out-of-scope",
+                                "why": res[1]})
+                continue
+            dc_comms = frozenset(styles.get(dat, set()))
+            # --permissive quiets balance-assertion failures on the
+            # C++ side.  This is deliberate: the extracted journals
+            # lose the per-test command lines whose flags sometimes
+            # relax those assertions, the suite's own expectations
+            # already test assertion behavior, and what is compared
+            # here is the computed balances, which --permissive does
+            # not alter.
+            cpp = subprocess.run(
+                [ledger, *cpp_flags, "--permissive", "-f", dat,
+                 "balance", "--flat", "--no-total"],
+                capture_output=True, text=True, env=env)
+            if cpp.returncode != 0:
+                bins["SKIP:cpp-parse"].append(rel)
+                details.append({"file": rel, "status": "SKIP:cpp-parse",
+                                "why": cpp.stderr.strip()[-200:]})
+                continue
+            try:
+                cpp_rows = sweep.parse_cpp_balance(
+                    cpp.stdout, decimal_comma=dc, dc_comms=dc_comms)
+            except ValueError as e:
+                bins["FAIL"].append(rel)
+                details.append({"file": rel, "status": "FAIL",
+                                "why": f"unparseable C++ output: {e}"})
+                continue
+            if cpp_rows == res:
+                bins["PASS"].append(rel)
+            else:
+                bins["FAIL"].append(rel)
+                details.append({
+                    "file": rel, "status": "FAIL",
+                    "only_oracle": sorted(res - cpp_rows)[:8],
+                    "only_cpp": sorted(cpp_rows - res)[:8]})
+
+        if selftest:
+            p1, p2 = selftest
+            res = oracle.get(p1)
+            def cpp_rows_of(path):
+                out = subprocess.run(
+                    [ledger, "-f", path, "balance", "--flat", "--no-total"],
+                    capture_output=True, text=True, env=env)
+                return sweep.parse_cpp_balance(out.stdout)
+            control_ok = isinstance(res, set) and cpp_rows_of(p1) == res
+            fired = (not isinstance(res, set)) or cpp_rows_of(p2) != res
+            if control_ok and fired:
+                print("selftest: both detector fixtures green")
+            else:
+                bins["FAIL"].append("<selftest>")
+                details.append({
+                    "file": "<selftest>", "status": "FAIL",
+                    "why": f"detector fixtures: control_ok={control_ok} "
+                           f"fired_on_planted_defect={fired}"})
+
+    def run_line(cmd, **kw):
+        try:
+            out = subprocess.run(cmd, capture_output=True, text=True,
+                                 **kw).stdout
+            return (out.splitlines() or ["unknown"])[0].strip() or "unknown"
+        except OSError:
+            return "unknown"
+
+    ledger_version = run_line([ledger, "--version"], env=env)
+    git_rev = run_line(["git", "rev-parse", "HEAD"], cwd=repo)
+    # In the Nix build the oracle is a store path with no repository;
+    # the flake passes the semantics revision in LEDGER_LEAN_REV.
+    oracle_rev = (os.environ.get("LEDGER_LEAN_REV")
+                  or run_line(["git", "-C", lean_dir, "rev-parse", "HEAD"]))
+    artifact = {
+        "tuple": {
+            "oracle_rev": oracle_rev,
+            "utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "git_rev": git_rev, "ledger_version": ledger_version,
+            "tz": env["TZ"], "capture": "test/semantic/check_all.py",
+            "cpp_flags_common": ["--permissive", "balance", "--flat",
+                                 "--no-total"],
+            "cpp_flags_note": ("per-file flags (--now, --decimal-comma,"
+                               " --recursive-aliases,"
+                               " --input-date-format) are derived from"
+                               " each test's own command lines")},
+        "counts": {k: len(v) for k, v in bins.items()},
+        "details": details,
+        "bins": {k: v for k, v in bins.items() if k != "PASS"},
+    }
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y%m%dT%H%M%SZ")
+    try:
+        os.makedirs(os.path.join(HERE, "artifacts"), exist_ok=True)
+        apath = os.path.join(HERE, "artifacts", f"check-all-{stamp}.json")
+        with open(apath, "w") as fh:
+            json.dump(artifact, fh, indent=2)
+    except OSError:
+        # Read-only source tree (e.g. a Nix sandbox): keep the record.
+        apath = os.path.join(tempfile.gettempdir(),
+                             f"check-all-{stamp}.json")
+        with open(apath, "w") as fh:
+            json.dump(artifact, fh, indent=2)
+
+    total = sum(len(v) for v in bins.values())
+    print(f"semantic bisimulation over {total} .test files:")
+    for k in ("PASS", "FAIL", "SKIP:out-of-scope", "SKIP:cpp-parse",
+              "SKIP:negative", "SKIP:no-journal", "SKIP:python"):
+        print(f"  {k:<18} {len(bins[k])}")
+    for d in details:
+        if d["status"] == "FAIL":
+            print(f"  FAIL {d['file']}")
+            for k in ("why", "only_oracle", "only_cpp"):
+                if k in d:
+                    print(f"       {k}: {d[k]}")
+    print(f"artifact: {os.path.relpath(apath, repo)}")
+    # Ratchet: both bins below reached zero against the full suite,
+    # and gates only tighten.  An entry here means one side stopped
+    # reading a journal it used to read — an oracle that rejects
+    # what it once parsed, or a C++ ledger that errors where it once
+    # balanced — and letting that bin as a skip would turn either
+    # regression green.
+    ratchet = bins["SKIP:out-of-scope"] or bins["SKIP:cpp-parse"]
+    if ratchet and not bins["FAIL"]:
+        print("ratchet: SKIP:out-of-scope and SKIP:cpp-parse must stay"
+              " empty; a comparable journal is no longer compared")
+    sys.exit(1 if (bins["FAIL"] or ratchet) else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/semantic/demo.dat
+++ b/test/semantic/demo.dat
@@ -1,0 +1,21 @@
+; Semantic bisimulation demo journal.
+; Mirrors lean/Ledger/Oracle.lean (namespace Ledger.Demo): three atomic
+; generators — salary, rent, groceries — whose tensor is "january".
+;
+; The Lean oracle's golden balances (kernel-checked in Oracle.lean):
+;   Assets:Checking   $2850.00
+;   Expenses:Food      $150.00
+;   Expenses:Rent     $2000.00
+;   Income:Salary    $-5000.00
+
+2026/01/05 Employer
+    Assets:Checking      $5000.00
+    Income:Salary
+
+2026/01/10 Landlord
+    Expenses:Rent        $2000.00
+    Assets:Checking
+
+2026/01/15 Grocer
+    Expenses:Food         $150.00
+    Assets:Checking

--- a/test/semantic/sweep.py
+++ b/test/semantic/sweep.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Differential corpus sweep over a hand-kept manifest.
+
+Runs the C++ ledger (`balance --flat --no-total`) and the Lean oracle
+driver on every manifest file, normalizes both sides to canonical
+`(commodity, amount, account)` triples, and diffs.  check_all.py, the
+ctest entry point, imports this module for the normalization and
+C++-balance parsing; running this file directly is a developer tool
+for sweeping the manifest (and any generated journals) by hand.
+
+Discipline (see the bisimulation section of lean/README.md):
+  - every run writes an artifact (absence of output is never silent
+    success) into test/semantic/artifacts/, embedding the comparison
+    tuple: git revision, ledger --version, file digest, TZ;
+  - files marked out of scope are *checked to be rejected* by the
+    driver — a parser that silently accepts an out-of-scope construct
+    is itself a defect;
+  - divergences are recorded raw as `unadjudicated-divergence`:
+    deciding which side is wrong is adjudication, and the instrument
+    does not adjudicate.
+
+Usage: [LEDGER=path] python3 test/semantic/sweep.py
+Exit 0 iff every in-scope file PASSes and every out-of-scope file is
+rejected by the driver.
+"""
+
+import datetime
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+
+# (repo-relative path, scope, note)
+MANIFEST = [
+    ("test/semantic/demo.dat", "in", "golden demo journal"),
+    ("test/input/parsing.dat", "in", "tabs, -$ prefix, no trailing newline"),
+    ("test/input/transfer.dat", "in", "suffix commodity 'bytes'"),
+    ("test/input/demo.ledger", "in", "plain 13-xact journal"),
+    ("test/input/standard.dat", "in", "precision-tolerant balancing, virtuals"),
+    ("test/input/sample.dat", "in", "auto-xacts, periodic, costs, unicode"),
+    ("test/input/drewr.dat", "in", "auto-xacts, periodic"),
+    ("test/input/drewr3.dat", "in", "auto-xacts"),
+    ("test/input/wow.dat", "in", "C/D directives ignored as display-only — empirical check"),
+    ("test/input/divzero.dat", "in",
+     "expression amounts; the historical divide-by-zero is fixed in this build"),
+]
+
+
+def norm_number(num: str, decimal_comma: bool = False) -> str:
+    num = num.replace("'", "")
+    if decimal_comma:
+        num = num.replace(".", "\x00").replace(",", ".").replace("\x00", ",")
+    if "," in num:
+        groups = num.split(".")[0].split(",")
+        if not (1 <= len(groups[0]) <= 3) or any(len(g) != 3 for g in groups[1:]) \
+                or "," in (num.split(".", 1) + [""])[1]:
+            raise ValueError(f"ambiguous comma grouping: {num!r}")
+    num = num.replace(",", "")
+    if "." in num:
+        ip, fp = num.split(".", 1)
+        fp = fp.rstrip("0")
+        ip = str(int(ip)) if ip else "0"
+        return ip + ("." + fp if fp else "")
+    return str(int(num))
+
+
+NUM = r"[\d.,']+"
+
+
+def norm_amount(s: str, decimal_comma: bool = False, dc_comms=frozenset()):
+    """'$ -1,000.00' / '-$30' / '59820 bytes' / '"a b" 1' -> (comm, canon)."""
+    s = s.strip()
+    neg = False
+    if s.startswith("-"):
+        neg, s = True, s[1:].strip()
+    comm = num = None
+    m = re.match(r'^"([^"]+)"\s*(-?)\s*(' + NUM + r')$', s)
+    if m:
+        comm, num = m.group(1), m.group(3)
+        if m.group(2) == "-":
+            neg = not neg
+    if comm is None:
+        m = re.match(r'^(-?)\s*(' + NUM + r')\s*"([^"]+)"$', s)
+        if m:
+            comm, num = m.group(3), m.group(2)
+            if m.group(1) == "-":
+                neg = not neg
+    if comm is None:
+        m = re.match(r"^([^\d-][^\d]*?)\s*(-?)\s*(" + NUM + r")$", s)
+        if m:
+            comm, num = m.group(1), m.group(3)
+            if m.group(2) == "-":
+                neg = not neg
+    if comm is None:
+        m = re.match(r"^(-?)\s*(" + NUM + r")\s*(.*)$", s)
+        if not m:
+            raise ValueError(f"unparseable amount: {s!r}")
+        if m.group(1) == "-":
+            neg = not neg
+        num, comm = m.group(2), m.group(3).strip()
+    if len(comm) >= 2 and comm.startswith('"') and comm.endswith('"'):
+        comm = comm[1:-1]  # C++ re-quotes commodities needing quotes
+    dc = decimal_comma or comm in dc_comms
+    canon = norm_number(num, dc)
+    if canon in ("0", "0.0"):
+        neg = False
+    return comm, ("-" if neg else "") + canon
+
+
+def parse_cpp_balance(out: str, decimal_comma: bool = False, dc_comms=frozenset()):
+    """balance --flat --no-total output -> set of 'comm|amount|account'.
+    Multi-commodity accounts print stacked amount-only lines; the
+    account name arrives on the last line of the stack."""
+    rows, pending = [], []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        m = re.match(r"^\s*(\S.*?)\s\s+(\S.*)$", line)
+        if m and re.search(r"\d", m.group(1)):
+            for p in pending:
+                rows.append((p, m.group(2).strip()))
+            pending = []
+            rows.append((m.group(1), m.group(2).strip()))
+        else:
+            pending.append(line.strip())
+    if pending:
+        raise ValueError(f"dangling amount lines without account: {pending!r}")
+    out_rows = set()
+    for amt, acct in rows:
+        comm, canon = norm_amount(amt, decimal_comma, dc_comms)
+        out_rows.add(f"{comm}|{canon}|{acct}")
+    return out_rows
+
+
+def manifest():
+    """Static manifest plus any generated journals present."""
+    entries = list(MANIFEST)
+    gendir = os.path.join(HERE, "generated")
+    if os.path.isdir(gendir):
+        for f in sorted(os.listdir(gendir)):
+            if f.endswith(".dat"):
+                entries.append(
+                    (os.path.relpath(os.path.join(gendir, f), REPO), "in",
+                     "generated (seed in file header)"))
+    return entries
+
+
+def main():
+    ledger = os.environ.get("LEDGER", os.path.join(REPO, "build", "ledger"))
+    env = {**os.environ, "TZ": "America/Chicago"}
+
+    ledger_version = subprocess.run(
+        [ledger, "--version"], capture_output=True, text=True, env=env
+    ).stdout.splitlines()[0]
+    git_rev = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, cwd=REPO
+    ).stdout.strip()
+
+    # One batched driver invocation: single olean load for all files.
+    entries = manifest()
+    abs_paths = [os.path.join(REPO, p) for p, _, _ in entries]
+    lean_dir = os.environ.get("LEDGER_LEAN_DIR", os.path.join(REPO, "lean"))
+    if not os.path.isfile(os.path.join(lean_dir, "lakefile.lean")):
+        print("SKIP: Lean oracle tree not present"); sys.exit(77)
+    direct_lake = "LEDGER_LEAN_DIR" in os.environ
+    if direct_lake and not shutil.which("lake"):
+        print("SKIP: LEDGER_LEAN_DIR set but lake not on PATH"); sys.exit(77)
+    if not direct_lake and not shutil.which("nix"):
+        print("SKIP: nix unavailable for the lean/ dev shell"); sys.exit(77)
+    if direct_lake:
+        cmd = ["lake", "env", "lean", "--run", "Ledger/Driver.lean"]
+    else:
+        cmd = ["nix", "develop", "--command", "lake", "env", "lean",
+               "--run", "Ledger/Driver.lean"]
+    oracle_env = {**env, "GIT_CONFIG_COUNT": "1",
+                  "GIT_CONFIG_KEY_0": "safe.directory",
+                  "GIT_CONFIG_VALUE_0": "*"}
+    drv = subprocess.run(
+        [*cmd, *abs_paths],
+        cwd=lean_dir, capture_output=True, text=True,
+        timeout=1800, env=oracle_env,
+    )
+    if drv.returncode != 0:
+        print("driver invocation failed:", file=sys.stderr)
+        print(drv.stdout[-2000:], file=sys.stderr)
+        print(drv.stderr[-2000:], file=sys.stderr)
+        sys.exit(2)
+
+    # Split driver output into per-file blocks.
+    blocks = {}
+    current = None
+    for line in drv.stdout.splitlines():
+        if line.startswith("== "):
+            current = os.path.relpath(line[3:].strip(), REPO)
+            blocks[current] = []
+        elif current is not None:
+            blocks[current].append(line)
+
+    results = []
+    failures = 0
+    for path, scope, note in entries:
+        entry: dict = {
+            "path": path,
+            "scope": scope,
+            "note": note,
+            "digest": hashlib.sha256(
+                open(os.path.join(REPO, path), "rb").read()
+            ).hexdigest()[:16],
+        }
+        block = blocks.get(path, [])
+        drv_error = next((l for l in block if l.startswith("!! ERROR")), None)
+
+        if scope == "cpp-rejects":
+            cpp = subprocess.run(
+                [ledger, "-f", os.path.join(REPO, path),
+                 "balance", "--flat", "--no-total"],
+                capture_output=True, text=True, env=env)
+            if cpp.returncode != 0:
+                entry["status"] = "CPP-REJECTS (as documented)"
+                entry["cpp_stderr"] = cpp.stderr.strip()[-160:]
+            else:
+                entry["status"] = "FAIL: C++ unexpectedly accepted"
+                failures += 1
+        elif scope == "out":
+            # Fail-closed check: the driver MUST reject the file.
+            if drv_error:
+                entry["status"] = "OUT-OF-SCOPE (rejected as expected)"
+                entry["driver_error"] = drv_error
+            else:
+                entry["status"] = "FAIL: out-of-scope file ACCEPTED by driver"
+                failures += 1
+        else:
+            if drv_error:
+                entry["status"] = "FAIL: driver rejected in-scope file"
+                entry["driver_error"] = drv_error
+                failures += 1
+            else:
+                oracle_rows = set(l for l in block if l.strip())
+                cpp = subprocess.run(
+                    [ledger, "-f", os.path.join(REPO, path),
+                     "balance", "--flat", "--no-total"],
+                    capture_output=True, text=True, env=env,
+                )
+                if cpp.returncode != 0:
+                    entry["status"] = "FAIL: C++ ledger errored"
+                    entry["cpp_stderr"] = cpp.stderr[-500:]
+                    failures += 1
+                else:
+                  try:
+                    cpp_rows = parse_cpp_balance(cpp.stdout)
+                    if cpp_rows == oracle_rows:
+                        entry["status"] = "PASS"
+                        entry["rows"] = len(cpp_rows)
+                    else:
+                        entry["status"] = "unadjudicated-divergence"
+                        entry["only_oracle"] = sorted(oracle_rows - cpp_rows)
+                        entry["only_cpp"] = sorted(cpp_rows - oracle_rows)
+                        failures += 1
+                  except ValueError as e:
+                    entry["status"] = "FAIL: unparseable C++ output"
+                    entry["why"] = str(e)[:200]
+                    failures += 1
+        results.append(entry)
+
+    artifact = {
+        "tuple": {
+            "utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "git_rev": git_rev,
+            "ledger_version": ledger_version,
+            "tz": "America/Chicago",
+            "capture": "test/semantic/sweep.py",
+        },
+        "results": results,
+    }
+    os.makedirs(os.path.join(HERE, "artifacts"), exist_ok=True)
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    apath = os.path.join(HERE, "artifacts", f"sweep-{stamp}.json")
+    with open(apath, "w") as f:
+        json.dump(artifact, f, indent=2)
+
+    for e in results:
+        print(f"{e['status']:<45} {e['path']}")
+        for k in ("only_oracle", "only_cpp"):
+            for row in e.get(k, [])[:6]:
+                print(f"    {k}: {row}")
+    print(f"\nartifact: {os.path.relpath(apath, REPO)}")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request gives the test suite a second, independent notion of correctness. Every positive journal in baseline, regress, and manual is replayed through a machine-checked semantics of double-entry accounting, and the balances must agree exactly, file by file.

The semantics lives in its own repository, [ledger/ledger-semantics](https://github.com/ledger/ledger-semantics): the journal formalized in Lean 4 against Mathlib as a symmetric monoidal category with proved theorems (the Pacioli invariant among them), and an executable oracle derived from the same definitions. This repository consumes it in two deliberately separate ways. The `lean/` git submodule serves development builds, and the `ledger-semantics` flake input serves `nix build` and CI; the two pins move together.

What the comparison currently shows on this branch: of the suite's 4364 test files, 3796 are compared with zero divergence. The remainder sit in named, visible bins rather than being dropped: 489 tests that expect errors, 77 files with no journal content, and 2 journals that embed Python. Two further bins exist for journals one side fails to read, both empty on this branch and held there by a ratchet: an entry in either fails the test, because a comparable journal silently leaving the comparison would let a regression on either side go green. Every run also replays a planted-defect fixture and fails unless the detector fires, so a green result is evidence rather than habit, and each result artifact records the source revisions of both sides, the binary, and the flags it compared.

Costs land where they belong. A release build from a tarball has no submodule, registers no new test, and needs no Lean toolchain; CMake states the non-registration in its output. A development build with the submodule but no toolchain, or with an oracle checkout that has never been built, reports the test as SKIPPED through exit code 77 with instructions, never as a silent pass — `ctest` will not start a multi-gigabyte Mathlib fetch on its own. A `nix build` runs the comparison unconditionally and is the enforcing gate: the oracle and its pinned toolchain come from the semantics flake, whose multi-gigabyte Mathlib dependency tree is held as a fixed-output derivation and cached in CI, so no machine ever compiles Mathlib.

The comparison covers balances. Register rows, market valuation, and lot matching are specified in the theory and not yet compared, and the harness says so rather than implying more. Reaching zero divergence required teaching the oracle, rule by witnessed rule, the observed conventions of this implementation; four behaviors that no suite test covers were found along the way and are filed separately for adjudication as #3258, #3259, #3260, and #3261.

Verification performed at this branch's tip: a fresh configure and build with the submodule initialized, the SemanticBisimulation ctest green over the full corpus (its artifact records this branch's revision and the oracle revision it compared, 3796 passed and 0 failed), a ctest run against an unbuilt oracle checkout reporting SKIPPED with instructions, and a complete `nix build` for both aarch64-darwin and x86_64-linux whose sandboxed check phases show `SemanticBisimulation ... Passed` among a fully green ctest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ve4zBthCqjFu16W3BmPkkm
